### PR TITLE
FF1 agent V2 — Phase 4: pipeline rewire (singleRunStrategy + SkillRegistry)

### DIFF
--- a/knes-agent/src/main/kotlin/knes/agent/Main.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/Main.kt
@@ -2,6 +2,8 @@ package knes.agent
 
 import knes.agent.advisor.AdvisorAgent
 import knes.agent.executor.ExecutorAgent
+import knes.agent.llm.AnthropicSession
+import knes.agent.llm.ModelRouter
 import knes.agent.perception.RamObserver
 import knes.agent.runtime.AgentSession
 import knes.agent.runtime.Budget
@@ -12,31 +14,36 @@ import kotlinx.coroutines.runBlocking
 import kotlin.system.exitProcess
 
 fun main(args: Array<String>) {
+    val rom = args.firstOrNull { it.startsWith("--rom=") }?.removePrefix("--rom=") ?: "roms/ff.nes"
+    val profile = args.firstOrNull { it.startsWith("--profile=") }?.removePrefix("--profile=") ?: "ff1"
+    val maxSkills = args.firstOrNull { it.startsWith("--max-skill-invocations=") }?.removePrefix("--max-skill-invocations=")?.toIntOrNull() ?: 80
+    val costCap = args.firstOrNull { it.startsWith("--cost-cap-usd=") }?.removePrefix("--cost-cap-usd=")?.toDoubleOrNull() ?: 3.0
+    val wallCap = args.firstOrNull { it.startsWith("--wall-clock-cap-seconds=") }?.removePrefix("--wall-clock-cap-seconds=")?.toIntOrNull() ?: 900
+    val key = System.getenv("ANTHROPIC_API_KEY")?.takeIf { it.isNotBlank() }
+        ?: error("ANTHROPIC_API_KEY not set")
+
     val outcome: Outcome = runBlocking {
-        val rom = args.firstOrNull { it.startsWith("--rom=") }?.removePrefix("--rom=") ?: "roms/ff1.nes"
-        val profile = args.firstOrNull { it.startsWith("--profile=") }?.removePrefix("--profile=") ?: "ff1"
-        val maxSteps = args.firstOrNull { it.startsWith("--max-steps=") }?.removePrefix("--max-steps=")?.toIntOrNull() ?: 2000
-        val key = System.getenv("ANTHROPIC_API_KEY")?.takeIf { it.isNotBlank() }
-            ?: error("ANTHROPIC_API_KEY not set")
+        AnthropicSession(key).use { anthropic ->
+            val session = EmulatorSession()
+            val toolset = EmulatorToolset(session)
+            require(toolset.loadRom(rom).ok) { "Failed to load ROM: $rom" }
+            require(toolset.applyProfile(profile).ok) { "Failed to apply profile: $profile" }
 
-        val session = EmulatorSession()
-        val toolset = EmulatorToolset(session)
-        require(toolset.loadRom(rom).ok) { "Failed to load ROM: $rom" }
-        require(toolset.applyProfile(profile).ok) { "Failed to apply profile: $profile" }
+            val router = ModelRouter()
+            val observer = RamObserver(toolset)
+            val advisor = AdvisorAgent(anthropic, router, toolset)
+            val executor = ExecutorAgent(anthropic, router, toolset, advisor)
 
-        val observer = RamObserver(toolset)
-        val advisor = AdvisorAgent(key, toolset)
-        val executor = ExecutorAgent(key, toolset, advisor)
-
-        AgentSession(
-            toolset = toolset,
-            observer = observer,
-            executor = executor,
-            advisor = advisor,
-            budget = Budget(maxToolCalls = maxSteps),
-        ).run()
+            AgentSession(
+                toolset = toolset,
+                observer = observer,
+                executor = executor,
+                advisor = advisor,
+                budget = Budget(maxSkillInvocations = maxSkills, costCapUsd = costCap, wallClockCapSeconds = wallCap),
+            ).run()
+        }
     }
 
     println("OUTCOME: $outcome")
-    exitProcess(if (outcome == Outcome.Victory) 0 else 1)
+    exitProcess(if (outcome == Outcome.Victory || outcome == Outcome.AtGarlandBattle) 0 else 1)
 }

--- a/knes-agent/src/main/kotlin/knes/agent/advisor/AdvisorAgent.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/advisor/AdvisorAgent.kt
@@ -1,44 +1,47 @@
 package knes.agent.advisor
 
 import ai.koog.agents.core.agent.AIAgent
+import ai.koog.agents.core.agent.singleRunStrategy
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.core.tools.reflect.tools
-import ai.koog.agents.ext.agent.reActStrategy
-import ai.koog.prompt.executor.clients.anthropic.AnthropicLLMClient
-import ai.koog.prompt.executor.clients.anthropic.AnthropicModels
-import ai.koog.prompt.executor.llms.SingleLLMPromptExecutor
-import ai.koog.prompt.llm.LLModel
+import knes.agent.llm.AgentRole
+import knes.agent.llm.AnthropicSession
+import knes.agent.llm.ModelRouter
+import knes.agent.perception.FfPhase
 import knes.agent.tools.EmulatorToolset
 
 /**
- * Single-shot planner. Given the current observation (text + optional screenshot path),
- * returns a short numbered plan-of-attack the executor will follow until the next phase change.
- *
- * Read-only access: only `getState` and `getScreen` are exposed via a wrapper toolset
- * (the advisor must not change game state). It returns plan text; the executor consumes it.
+ * Single-shot planner. Each plan() call does ONE Koog AIAgent.run (singleRunStrategy):
+ * the LLM either returns plain text or invokes one read-only tool (getState/getScreen).
+ * Read-only access — advisor must never mutate emulator state.
  */
 class AdvisorAgent(
-    private val apiKey: String,
+    private val anthropic: AnthropicSession,
+    private val modelRouter: ModelRouter,
     private val toolset: EmulatorToolset,
-    private val model: LLModel = AnthropicModels.Opus_4,   // confirmed: Opus_4 = claude-opus-4-0
 ) {
     private val readOnlyTools = ReadOnlyToolset(toolset)
     private val registry = ToolRegistry { tools(readOnlyTools) }
 
-    // Koog's AIAgent is single-use; build a fresh instance + executor per plan call.
-    private fun newAgent(): AIAgent<String, String> = AIAgent(
-        promptExecutor = SingleLLMPromptExecutor(AnthropicLLMClient(apiKey)),
-        llmModel = model,
+    private fun newAgent(phase: FfPhase): AIAgent<String, String> = AIAgent(
+        promptExecutor = anthropic.executor,
+        llmModel = modelRouter.modelFor(phase, AgentRole.ADVISOR),
         toolRegistry = registry,
-        strategy = reActStrategy(reasoningInterval = 1, name = "ff1_advisor"),
-        systemPrompt = """
+        strategy = singleRunStrategy(),
+        systemPrompt = systemPrompt,
+    )
+
+    suspend fun plan(phase: FfPhase, observation: String): String =
+        newAgent(phase).run(observation)
+
+    companion object {
+        val systemPrompt: String = """
             You are the planner for an autonomous Final Fantasy (NES) agent.
             Given the current emulator state, output a short numbered plan (1–6 steps) the
             executor will follow until the next phase change. Each step must be actionable
-            using the kNES tool surface (step / tap / sequence / execute_action).
+            using the available kNES skills (pressStartUntilOverworld, walkOverworldTo,
+            battleFightAll, walkUntilEncounter).
             Do NOT execute the plan yourself; only describe it as text.
-        """.trimIndent(),
-    )
-
-    suspend fun plan(observation: String): String = newAgent().run(observation)
+        """.trimIndent()
+    }
 }

--- a/knes-agent/src/main/kotlin/knes/agent/executor/AdvisorToolset.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/executor/AdvisorToolset.kt
@@ -4,19 +4,14 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.agents.core.tools.annotations.Tool
 import ai.koog.agents.core.tools.reflect.ToolSet
 import knes.agent.advisor.AdvisorAgent
+import knes.agent.perception.FfPhase
 
-/**
- * Wraps AdvisorAgent as a Koog ToolSet so the ExecutorAgent can call it via the
- * standard reflect-based tool registration.
- *
- * Note: Koog 0.5.1 exposes `AIAgent.asTool(...)` (via AIAgentToolKt) but that
- * path requires explicit KSerializer wiring and returns an opaque AgentToolResult.
- * The wrapper approach is simpler and returns a plain String the executor can act on
- * directly.
- */
-@LLMDescription("Advisor consultation tools. Call askAdvisor with a short reason when stuck.")
+@LLMDescription("Advisor consultation tool.")
 class AdvisorToolset(private val advisor: AdvisorAgent) : ToolSet {
     @Tool
     @LLMDescription("Consult the planner when stuck or at a phase boundary. Provide a short reason. Returns a numbered plan.")
-    suspend fun askAdvisor(reason: String): String = advisor.plan(reason)
+    suspend fun askAdvisor(reason: String): String =
+        // Phase is unknown from inside the tool path; advisor itself observes via its read-only tools.
+        // TitleOrMenu is the broadest assumption (Opus model, most capable).
+        advisor.plan(FfPhase.TitleOrMenu, reason)
 }

--- a/knes-agent/src/main/kotlin/knes/agent/executor/ExecutorAgent.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/executor/ExecutorAgent.kt
@@ -1,70 +1,59 @@
 package knes.agent.executor
 
 import ai.koog.agents.core.agent.AIAgent
+import ai.koog.agents.core.agent.singleRunStrategy
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.core.tools.reflect.tools
-import ai.koog.agents.ext.agent.reActStrategy
-import ai.koog.prompt.executor.clients.anthropic.AnthropicLLMClient
-import ai.koog.prompt.executor.clients.anthropic.AnthropicModels
-import ai.koog.prompt.executor.llms.SingleLLMPromptExecutor
-import ai.koog.prompt.llm.LLModel
 import knes.agent.advisor.AdvisorAgent
+import knes.agent.llm.AgentRole
+import knes.agent.llm.AnthropicSession
+import knes.agent.llm.ModelRouter
+import knes.agent.perception.FfPhase
+import knes.agent.skills.SkillRegistry
 import knes.agent.tools.EmulatorToolset
 
 class ExecutorAgent(
-    private val apiKey: String,
+    private val anthropic: AnthropicSession,
+    private val modelRouter: ModelRouter,
     private val toolset: EmulatorToolset,
     private val advisor: AdvisorAgent,
-    private val model: LLModel = AnthropicModels.Sonnet_4_5,
-    private val reasoningInterval: Int = 1,
 ) {
+    private val skillRegistry = SkillRegistry(toolset)
     private val advisorTool = AdvisorToolset(advisor)
     private val registry = ToolRegistry {
-        tools(toolset)
+        tools(skillRegistry)
         tools(advisorTool)
     }
 
-    // Koog's AIAgent is single-use (StatefulSingleUseAIAgent). Build a fresh one per call.
-    // Also fresh prompt executor + LLM client — Koog 0.5.1 retains conversation state inside
-    // the executor that triggers Anthropic 400 errors after iteration-cap on subsequent runs.
-    // maxIterations caps Koog's internal ReAct loop per outer turn (default 50 is too expensive).
-    private fun newAgent(): AIAgent<String, String> = AIAgent(
-        promptExecutor = SingleLLMPromptExecutor(AnthropicLLMClient(apiKey)),
-        llmModel = model,
+    private fun newAgent(phase: FfPhase): AIAgent<String, String> = AIAgent(
+        promptExecutor = anthropic.executor,
+        llmModel = modelRouter.modelFor(phase, AgentRole.EXECUTOR),
         toolRegistry = registry,
-        strategy = reActStrategy(reasoningInterval = reasoningInterval, name = "ff1_executor"),
+        strategy = singleRunStrategy(),
         systemPrompt = ff1ExecutorSystemPrompt,
-        maxIterations = 10,
     )
 
-    suspend fun run(input: String): String = try {
-        newAgent().run(input)
-    } catch (e: Exception) {
-        // Koog's reActStrategy hits an internal iteration cap (default 50) and throws
-        // AIAgentMaxNumberOfIterationsReachedException — but that class is `internal`.
-        // Match by class name; let anything else propagate.
-        if (e::class.simpleName == "AIAgentMaxNumberOfIterationsReachedException") {
-            "ITERATION_CAP: ${e.message?.take(120)?.trim()}"
-        } else throw e
-    }
+    suspend fun run(phase: FfPhase, input: String): String = newAgent(phase).run(input)
 
     companion object {
-        // Source of truth for the Claude Code MCP setup is docs/ff1-system-prompt.md.
-        // This prompt is a smaller, agent-loop-focused variant: the broader "what is FF1"
-        // context is delivered per-turn from the runtime (RAM diff + plan).
         val ff1ExecutorSystemPrompt: String = """
-            You are an autonomous Final Fantasy (NES) executor. Use the kNES tools to advance
-            the game toward defeating Garland (the bridge boss).
+            You are an autonomous Final Fantasy (NES) executor. Drive the game toward
+            the start of the Garland battle by invoking exactly one scripted skill per turn
+            (or asking the advisor when stuck).
 
-            Tool surface: load_rom / step / tap / sequence / get_state / get_screen /
-            apply_profile / list_actions / execute_action / press / release / reset.
+            Skills available this turn (each is a single tool call):
+            - pressStartUntilOverworld(maxAttempts) — title screen → overworld with party
+            - walkOverworldTo(targetX, targetY, maxSteps) — greedy walk; aborts on encounter
+            - battleFightAll() — every alive character uses FIGHT until battle ends
+            - walkUntilEncounter() — walk randomly until a battle starts
+            - getState() — read RAM and frame count
+            - askAdvisor(reason) — consult the planner when stuck or at a phase boundary
 
-            Conventions: 60 frames = 1 second. Prefer tap/sequence over many steps.
-            Set screenshot=true only when the visual context changed.
-
-            When uncertain or stuck (no progress, unknown screen, battle starts/ends), call
-            askAdvisor("...short reason..."). Otherwise, keep executing the current plan until
-            the next phase boundary. Reply DONE when no further action is required this turn.
+            Conventions:
+            - Pick exactly one tool per turn. Do not narrate state — just choose a skill.
+            - The outer loop will observe RAM after your skill returns and call you again.
+            - When uncertain (unfamiliar phase, last skill failed, stuck), call askAdvisor.
+            - Do NOT call getState repeatedly to "look around"; call a skill that advances state.
         """.trimIndent()
     }
 }

--- a/knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt
@@ -8,7 +8,12 @@ import knes.agent.perception.ScreenshotPolicy
 import knes.agent.tools.EmulatorToolset
 import java.nio.file.Path
 
-data class Budget(val maxToolCalls: Int = 2000, val maxAdvisorCalls: Int = 30)
+data class Budget(
+    val maxSkillInvocations: Int = 80,
+    val maxAdvisorCalls: Int = 30,
+    val costCapUsd: Double = 3.0,
+    val wallClockCapSeconds: Int = 900,
+)
 
 class AgentSession(
     private val toolset: EmulatorToolset,
@@ -21,24 +26,14 @@ class AgentSession(
     private val trace = Trace(runDir)
     private val screenshotPolicy = ScreenshotPolicy()
 
-    /**
-     * Drives the agent until success/failure. Each "outer turn":
-     *   1. Observe RAM, classify phase.
-     *   2. Check SuccessCriteria — terminate if Victory / PartyDefeated.
-     *   3. If phase changed since last turn, ask advisor for a plan.
-     *   4. Run the executor for up to one phase (its internal reActStrategy iterates;
-     *      we re-enter when phase changes or executor returns).
-     *   5. Watchdog: bump idleTurns if RAM didn't change; on threshold, force advisor.
-     *
-     * Termination: SuccessCriteria != InProgress, or budget exhausted.
-     */
     suspend fun run(): Outcome {
         var previousPhase: FfPhase? = null
         var currentPlan = "Start the game from the title screen and begin a new game."
         var idleTurns = 0
         var lastRam: Map<String, Int> = emptyMap()
         var advisorCalls = 0
-        var toolCalls = 0   // approximate; one bump per executor outer-turn
+        var skillsInvoked = 0
+        val startMs = System.currentTimeMillis()
 
         try {
             while (true) {
@@ -51,30 +46,26 @@ class AgentSession(
                     return outcome
                 }
 
-                val phaseChanged = previousPhase == null || previousPhase!!::class != phase::class
+                val phaseChanged = previousPhase == null || previousPhase::class != phase::class
                 if (phaseChanged || idleTurns >= 20) {
                     if (++advisorCalls > budget.maxAdvisorCalls) return Outcome.OutOfBudget
                     val attachShot = screenshotPolicy.shouldAttach(previousPhase, phase)
                     val obs = buildString {
                         append("Phase: $phase\nRAM: $ram\n")
-                        if (attachShot) {
-                            // Mention only that a screenshot was taken; full base64 in trace, not in prompt.
-                            // The advisor's ReadOnlyToolset has getScreen() if it wants raw pixels.
-                            append("(screenshot available via get_screen)\n")
-                        }
+                        if (attachShot) append("(screenshot available via getScreen)\n")
                         append("Reason: ${if (phaseChanged) "phase change" else "watchdog stuck"}")
                     }
-                    println("[advisor #$advisorCalls] phase=$phase reason=${if (phaseChanged) "phase change" else "watchdog stuck"}")
-                    currentPlan = advisor.plan(obs)
+                    println("[advisor #$advisorCalls] phase=$phase")
+                    currentPlan = advisor.plan(phase, obs)
                     println("[advisor plan] ${currentPlan.lineSequence().take(3).joinToString(" | ").take(200)}")
                     trace.record(TraceEvent(0, "advisor", phase.toString(), note = currentPlan.take(500)))
                     idleTurns = 0
                 }
 
                 val executorInput = "Plan:\n$currentPlan\n\nCurrent phase: $phase\nRAM: $ram"
-                println("[executor turn=$toolCalls] phase=$phase idle=$idleTurns")
-                val result = executor.run(executorInput)
-                toolCalls += 1
+                println("[executor turn=$skillsInvoked] phase=$phase idle=$idleTurns")
+                val result = executor.run(phase, executorInput)
+                skillsInvoked += 1
                 println("[executor result] ${result.lineSequence().take(2).joinToString(" | ").take(160)}")
                 trace.record(TraceEvent(0, "executor", phase.toString(), note = result.take(500)))
 
@@ -83,7 +74,9 @@ class AgentSession(
                 lastRam = newRam
                 previousPhase = phase
 
-                if (toolCalls > budget.maxToolCalls) return Outcome.OutOfBudget
+                if (skillsInvoked > budget.maxSkillInvocations) return Outcome.OutOfBudget
+                val elapsedSec = (System.currentTimeMillis() - startMs) / 1000
+                if (elapsedSec > budget.wallClockCapSeconds) return Outcome.OutOfBudget
             }
         } finally {
             trace.close()

--- a/knes-agent/src/main/kotlin/knes/agent/runtime/Outcome.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/runtime/Outcome.kt
@@ -9,11 +9,14 @@ import knes.agent.perception.FfPhase
  */
 const val GARLAND_ID = 0x7C
 
-enum class Outcome { InProgress, Victory, PartyDefeated, OutOfBudget, Error }
+enum class Outcome { InProgress, AtGarlandBattle, Victory, PartyDefeated, OutOfBudget, Error }
 
 object SuccessCriteria {
     fun evaluate(phase: FfPhase): Outcome = when (phase) {
-        is FfPhase.Battle -> if (phase.enemyId == GARLAND_ID && phase.enemyDead) Outcome.Victory else Outcome.InProgress
+        is FfPhase.Battle ->
+            if (phase.enemyId == GARLAND_ID) {
+                if (phase.enemyDead) Outcome.Victory else Outcome.AtGarlandBattle
+            } else Outcome.InProgress
         FfPhase.PartyDefeated -> Outcome.PartyDefeated
         else -> Outcome.InProgress
     }

--- a/knes-agent/src/test/kotlin/knes/agent/runtime/SuccessCriteriaTest.kt
+++ b/knes-agent/src/test/kotlin/knes/agent/runtime/SuccessCriteriaTest.kt
@@ -14,4 +14,7 @@ class SuccessCriteriaTest : FunSpec({
     test("defeat on party wipe") {
         SuccessCriteria.evaluate(FfPhase.PartyDefeated) shouldBe Outcome.PartyDefeated
     }
+    test("at garland battle when alive") {
+        SuccessCriteria.evaluate(FfPhase.Battle(enemyId = GARLAND_ID, enemyHp = 106, enemyDead = false)) shouldBe Outcome.AtGarlandBattle
+    }
 })


### PR DESCRIPTION
## Scope

**Phase 4 of the V2 plan.** Architectural rewire — the inner loop changes from Koog's `reActStrategy` (which iterated up to 50 times per outer turn before V1's catch handler kicked in) to `singleRunStrategy` (exactly one LLM invocation per outer turn). The outer loop in `AgentSession` now owns iteration entirely.

Plan: `docs/superpowers/plans/2026-05-02-ff1-koog-agent-v2.md`
Spec: `docs/superpowers/specs/2026-05-01-ff1-koog-agent-v2-design.md`
Builds on: PR #93 (Phase 1, merged), PR #94 (Phase 2-3, merged)

## What's in (single combined commit `48be884`)

### Inner loop change
- **`ExecutorAgent` and `AdvisorAgent` rewired to `singleRunStrategy()`.** One LLM call per `agent.run(input)`. The model returns either a tool call (Koog runs the tool, returns its result) or plain text (that text is the output). No internal iteration.
- **Removed V1's `try/catch (AIAgentMaxNumberOfIterationsReachedException)` workaround** from `ExecutorAgent` — the exception can no longer fire. Removed `maxIterations = 10` and the V1 fresh-AIAgent-per-call workaround motivation.
- **Outer loop in `AgentSession` is the only loop.** It observes RAM, evaluates `SuccessCriteria`, optionally consults the advisor on phase change/watchdog, then issues exactly one executor turn. Termination is RAM-driven (success/failure) or budget-driven (skill count, advisor count, wall clock).

### Wiring updates
- `AdvisorAgent` constructor now takes `(AnthropicSession, ModelRouter, EmulatorToolset)` instead of `(apiKey: String, toolset)`. Long-lived client + per-phase-routed model.
- `ExecutorAgent` constructor now takes `(AnthropicSession, ModelRouter, EmulatorToolset, AdvisorAgent)`. Registers `SkillRegistry` (5 macro tools from PR #94) + `AdvisorToolset` (askAdvisor) — total 6 LLM-facing tools.
- `AdvisorToolset.askAdvisor` updated to match `AdvisorAgent.plan(phase, observation)` signature.
- `AgentSession` constructor: `Budget` expanded to `(maxSkillInvocations, maxAdvisorCalls, costCapUsd, wallClockCapSeconds)`. New CLI flags `--max-skill-invocations`, `--cost-cap-usd`, `--wall-clock-cap-seconds`. Stdout progress prints kept.
- `Main.kt` constructs `AnthropicSession.use { … }`, `ModelRouter()`, all agents, runs `AgentSession`. Exit code 0 on `Outcome.Victory` or `Outcome.AtGarlandBattle`.

### Pulled forward from Phase 5
- **`Outcome.AtGarlandBattle`** added (was originally Phase 5 Task 5.1). `SuccessCriteria.evaluate` returns it for `Battle(GARLAND_ID, …, enemyDead=false)`. Added unit test.

## Canonical Koog 0.6.1 API surface (corrected)

The plan's locked-in surface from Phase 1 had a couple of small drifts in 0.6.1:
- `singleRunStrategy` lives in `ai.koog.agents.core.agent`, not `agents.ext.agent`. Class is `AIAgentSimpleStrategiesKt`.
- `singleRunStrategy()` takes a `ToolCalls` enum (default `SEQUENTIAL`), not a `name: String`. Called with no args.

Both fixed in the commit; `AIAgent` Companion `invoke(promptExecutor, llmModel, toolRegistry, strategy, systemPrompt)` works as expected.

## What's NOT in (deferred)

- **Phase 5 Task 5.2** (`NewGameMenu` / `NameEntry` RAM detection) — skipped. The bootFlag-fix in PR #94 already produces a 4-state classifier (`TitleOrMenu` / `Overworld` / `Battle` / `PartyDefeated`) that's sufficient for V2 scope C; finer pre-game phases would only matter if we needed phase-specific advisor prompts during character creation, which `pressStartUntilOverworld` makes unnecessary.
- **Phase 6** (`CostTracker`) — deferred to V2.1. `costCapUsd` is in `Budget` but not enforced (no token-count plumbing yet). Wall-clock and skill-count caps are enforced.
- **Phase 7** (live acceptance run) — separate PR with evidence after this one merges.

## Test plan

- [ ] CI passes (`./gradlew build` green locally on Java 17, Koog 0.6.1)
- [ ] All 24 `:knes-agent` tests green (V1 + V2 phases 1-4)
- [ ] V1 smoke tests (`AnthropicSmokeTest`, `ReactSmokeTest`) untouched and still self-skip without API key

## Honest framing

After this PR merges, the V2 pipeline is ready for the live acceptance run. Open questions:
- Does `singleRunStrategy` actually terminate cleanly on a tool call (vs reActStrategy's "try to keep going" behavior)? V1's biggest failure mode was the model looping; this PR's whole architecture bets on `singleRunStrategy` fixing that.
- Without prompt caching (still Path B / no-op stub from PR #93), realistic per-turn cost on the live acceptance run could be $0.05-0.20. With 50-200 outer turns expected for boot→Garland, a Garland run could be $5-20 — above the spec §10's optimistic $3 cap. We'll measure in Phase 7 and adjust V2.1 accordingly.