### PR TITLE
FF1 explorer Phase 1.5 + Phase 2 — real Haiku, agent reads landmarks

### DIFF
--- a/knes-agent/src/main/kotlin/knes/agent/Main.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/Main.kt
@@ -6,6 +6,7 @@ import knes.agent.llm.AnthropicSession
 import knes.agent.llm.ModelRouter
 import knes.agent.perception.FogOfWar
 import knes.agent.perception.InteriorMapLoader
+import knes.agent.perception.LandmarkMemory
 import knes.agent.perception.MapSession
 import knes.agent.perception.OverworldMap
 import knes.agent.perception.AnthropicVisionInteriorNavigator
@@ -60,6 +61,7 @@ fun main(args: Array<String>) {
                 toolCallLog = toolCallLog,
                 budget = Budget(maxSkillInvocations = maxSkills, costCapUsd = costCap, wallClockCapSeconds = wallCap),
                 fog = fog,
+                landmarkMemory = LandmarkMemory(),
             ).run()
         }
     }

--- a/knes-agent/src/main/kotlin/knes/agent/explorer/AnthropicHaikuConsult.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/explorer/AnthropicHaikuConsult.kt
@@ -1,22 +1,213 @@
 package knes.agent.explorer
 
-import knes.agent.llm.AnthropicSession
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
+import knes.agent.perception.Landmark
+import knes.agent.perception.LandmarkKind
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
 
 /**
- * Production HaikuConsult backed by Anthropic Haiku 4.5. Phase 1 MVP stub:
- * returns no classifications and zero cost. Phase 1.5 will wire real prompts
- * + screenshot analysis. The campaign can run end-to-end with this stub —
- * terrain/warps/blockages still accumulate; only NPC landmark classification
- * is no-op until the prompt is added.
+ * Production HaikuConsult backed by Anthropic Haiku 4.5 (text + image).
+ *
+ * Two prompts:
+ *  - classifyInterior — given a screenshot of an FF1 interior, list any visible
+ *    KING / SHOPKEEPER / GENERIC NPCs, plus stairs. Mapped to [LandmarkKind].
+ *  - readDialog — given a screenshot with a dialog box, paraphrase the text
+ *    and hint at landmark kind (KING/SHOPKEEPER/null).
+ *
+ * Without a screenshot, both calls degrade gracefully to text-only (no NPC
+ * classification, but still cheap; the empty result is fine — terrain/warp/blockage
+ * memory still grows from the deterministic step loop).
+ *
+ * Cost per call extracted from `usage.input_tokens` + `usage.output_tokens` in the
+ * Anthropic response.
  */
 class AnthropicHaikuConsult(
-    private val anthropic: AnthropicSession,
-) : HaikuConsult {
-    override suspend fun classifyInterior(
-        mapId: Int, visitedTileCount: Int, screenshotPng: ByteArray?,
-    ): HaikuConsult.InteriorClassification =
-        HaikuConsult.InteriorClassification(landmarks = emptyList(), costUsd = 0.0)
+    private val apiKey: String,
+    private val model: String = "claude-haiku-4-5",
+    private val client: HttpClient = HttpClient(CIO) {
+        install(HttpTimeout) { requestTimeoutMillis = 30_000 }
+    },
+) : HaikuConsult, AutoCloseable {
 
-    override suspend fun readDialog(screenshotPng: ByteArray?): HaikuConsult.DialogReading =
-        HaikuConsult.DialogReading(summary = "", landmarkHint = null, costUsd = 0.0)
+    override suspend fun classifyInterior(
+        mapId: Int, visitedTileCount: Int, screenshotBase64: String?, runId: String,
+    ): HaikuConsult.InteriorClassification {
+        val body = buildClassifyBody(mapId, visitedTileCount, screenshotBase64)
+        val raw = postOrNull(body) ?: return HaikuConsult.InteriorClassification(emptyList(), 0.0)
+        return parseInteriorResponse(raw, mapId = mapId, runId = runId)
+    }
+
+    override suspend fun readDialog(screenshotBase64: String?): HaikuConsult.DialogReading {
+        val body = buildDialogBody(screenshotBase64)
+        val raw = postOrNull(body) ?: return HaikuConsult.DialogReading("", null, 0.0)
+        return parseDialogResponse(raw)
+    }
+
+    override fun close() { client.close() }
+
+    private suspend fun postOrNull(body: String): String? {
+        val resp = try {
+            client.post(API_URL) {
+                header("x-api-key", apiKey)
+                header("anthropic-version", "2023-06-01")
+                contentType(ContentType.Application.Json)
+                setBody(body)
+            }
+        } catch (e: Exception) {
+            System.err.println("[haiku-consult] request failed: ${e.message}")
+            return null
+        }
+        if (!resp.status.isSuccess()) {
+            System.err.println("[haiku-consult] http ${resp.status.value}: ${resp.bodyAsText().take(200)}")
+            return null
+        }
+        return resp.bodyAsText()
+    }
+
+    private fun buildClassifyBody(mapId: Int, visitedTileCount: Int, b64: String?): String {
+        val userText = "Map id: $mapId. Visited tiles in this interior: $visitedTileCount. " +
+            "Identify any NPCs visible on screen and stairs. Output JSON only:\n" +
+            """{"landmarks":[{"kind":"NPC_KING|NPC_SHOPKEEPER|NPC_GENERIC|STAIRS_UP|STAIRS_DOWN","note":"<short>"}]}"""
+        return buildBody(systemPrompt = SYSTEM_CLASSIFY, userText = userText, b64 = b64, maxTokens = 300)
+    }
+
+    private fun buildDialogBody(b64: String?): String {
+        val userText = "Read the dialog text in this FF1 NES screenshot (white text on black box). " +
+            "Output JSON only:\n" +
+            """{"summary":"<paraphrase ≤80 chars>","landmarkHint":"KING|SHOPKEEPER|null"}"""
+        return buildBody(systemPrompt = SYSTEM_DIALOG, userText = userText, b64 = b64, maxTokens = 200)
+    }
+
+    private fun buildBody(systemPrompt: String, userText: String, b64: String?, maxTokens: Int): String {
+        val obj = buildJsonObject {
+            put("model", model)
+            put("max_tokens", maxTokens)
+            put("system", systemPrompt)
+            put("messages", buildJsonArray {
+                add(buildJsonObject {
+                    put("role", "user")
+                    put("content", buildJsonArray {
+                        if (b64 != null) {
+                            add(buildJsonObject {
+                                put("type", "image")
+                                put("source", buildJsonObject {
+                                    put("type", "base64")
+                                    put("media_type", "image/png")
+                                    put("data", b64)
+                                })
+                            })
+                        }
+                        add(buildJsonObject {
+                            put("type", "text")
+                            put("text", userText)
+                        })
+                    })
+                })
+            })
+        }
+        return obj.toString()
+    }
+
+    companion object {
+        private const val API_URL = "https://api.anthropic.com/v1/messages"
+
+        // Haiku 4.5 pricing (Anthropic, late 2025): $1 / MTok input, $5 / MTok output.
+        // If pricing changes the absolute cost number drifts but the budget cap still triggers.
+        private const val INPUT_USD_PER_TOKEN = 1.0e-6
+        private const val OUTPUT_USD_PER_TOKEN = 5.0e-6
+
+        private val JSON_OBJECT = Regex("""\{[\s\S]*\}""")
+        private val json = Json { ignoreUnknownKeys = true }
+
+        private const val SYSTEM_CLASSIFY =
+            "You analyze a screenshot of a Final Fantasy 1 (NES) interior — castle, town, " +
+                "or dungeon room. Identify visible NPCs and staircases. " +
+                "NPC_KING: a crowned figure on a throne (large royal room). " +
+                "NPC_SHOPKEEPER: a counter with item icons or weapons displayed. " +
+                "NPC_GENERIC: any other person sprite. " +
+                "STAIRS_UP / STAIRS_DOWN: ascending / descending staircase tile. " +
+                "Return ONLY JSON, no prose."
+
+        private const val SYSTEM_DIALOG =
+            "You read short on-screen dialog text from a Final Fantasy 1 (NES) screenshot. " +
+                "Dialog appears as a white-bordered box near the bottom of the screen with white " +
+                "text on dark background. Paraphrase concisely. If the speaker is identified by " +
+                "context (king on throne / shopkeeper at counter), set landmarkHint to KING / " +
+                "SHOPKEEPER. Otherwise set landmarkHint to null. Return ONLY JSON, no prose."
+
+        /** Parse the Anthropic response envelope and the inner LLM-emitted JSON.
+         *  Visible for testing — pure function, no side effects. */
+        fun parseInteriorResponse(rawJson: String, mapId: Int, runId: String): HaikuConsult.InteriorClassification {
+            val (innerText, costUsd) = parseEnvelope(rawJson)
+            if (innerText == null) return HaikuConsult.InteriorClassification(emptyList(), costUsd)
+            val landmarks = try {
+                val match = JSON_OBJECT.find(innerText) ?: return HaikuConsult.InteriorClassification(emptyList(), costUsd)
+                val obj = json.parseToJsonElement(match.value).jsonObject
+                val arr = obj["landmarks"]?.jsonArray ?: return HaikuConsult.InteriorClassification(emptyList(), costUsd)
+                arr.mapNotNull { el ->
+                    val o = el.jsonObject
+                    val kindStr = o["kind"]?.jsonPrimitive?.content ?: return@mapNotNull null
+                    val kind = runCatching { LandmarkKind.valueOf(kindStr) }.getOrNull() ?: LandmarkKind.NPC_GENERIC
+                    val note = o["note"]?.jsonPrimitive?.content ?: ""
+                    Landmark(
+                        id = "haiku_${kindStr.lowercase()}_${mapId}_${note.hashCode().toString(16)}",
+                        kind = kind, mapId = mapId,
+                        note = note, visited = false, discoveredRunId = runId,
+                    )
+                }
+            } catch (e: Exception) {
+                System.err.println("[haiku-consult] parseInterior failed: ${e.message}")
+                emptyList()
+            }
+            return HaikuConsult.InteriorClassification(landmarks, costUsd)
+        }
+
+        fun parseDialogResponse(rawJson: String): HaikuConsult.DialogReading {
+            val (innerText, costUsd) = parseEnvelope(rawJson)
+            if (innerText == null) return HaikuConsult.DialogReading("", null, costUsd)
+            return try {
+                val match = JSON_OBJECT.find(innerText) ?: return HaikuConsult.DialogReading("", null, costUsd)
+                val obj = json.parseToJsonElement(match.value).jsonObject
+                val summary = obj["summary"]?.jsonPrimitive?.content ?: ""
+                val rawHint = obj["landmarkHint"]?.jsonPrimitive?.content
+                val hint = if (rawHint == null || rawHint.equals("null", ignoreCase = true) || rawHint.isBlank()) null else rawHint
+                HaikuConsult.DialogReading(summary, hint, costUsd)
+            } catch (e: Exception) {
+                System.err.println("[haiku-consult] parseDialog failed: ${e.message}")
+                HaikuConsult.DialogReading("", null, costUsd)
+            }
+        }
+
+        /** Returns (innerText, costUsd). innerText is null when the envelope is malformed. */
+        private fun parseEnvelope(rawJson: String): Pair<String?, Double> {
+            return try {
+                val root = json.parseToJsonElement(rawJson).jsonObject
+                val text = root["content"]?.jsonArray?.firstOrNull()?.jsonObject?.get("text")?.jsonPrimitive?.content
+                val usage = root["usage"]?.jsonObject
+                val inTok = usage?.get("input_tokens")?.jsonPrimitive?.content?.toIntOrNull() ?: 0
+                val outTok = usage?.get("output_tokens")?.jsonPrimitive?.content?.toIntOrNull() ?: 0
+                val cost = inTok * INPUT_USD_PER_TOKEN + outTok * OUTPUT_USD_PER_TOKEN
+                text to cost
+            } catch (e: Exception) {
+                System.err.println("[haiku-consult] envelope parse failed: ${e.message}")
+                null to 0.0
+            }
+        }
+    }
 }

--- a/knes-agent/src/main/kotlin/knes/agent/explorer/ExplorerMain.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/explorer/ExplorerMain.kt
@@ -1,7 +1,6 @@
 package knes.agent.explorer
 
 import kotlinx.coroutines.runBlocking
-import knes.agent.llm.AnthropicSession
 import knes.agent.perception.BlockageMemory
 import knes.agent.perception.FogOfWar
 import knes.agent.perception.InteriorMapLoader
@@ -54,18 +53,15 @@ fun main() {
     )
 
     val haiku: HaikuConsult = try {
-        // ANTHROPIC_API_KEY env var required by AnthropicSession.
-        // If absent, fall back to no-op fake so the campaign still runs and
-        // accumulates terrain/warp/blockage memory without NPC classification.
         val apiKey = System.getenv("ANTHROPIC_API_KEY")
         if (apiKey.isNullOrBlank()) {
             System.err.println("[explorer] no ANTHROPIC_API_KEY — using FakeHaikuConsult (zero classification)")
             FakeHaikuConsult()
         } else {
-            AnthropicHaikuConsult(AnthropicSession(apiKey = apiKey))
+            AnthropicHaikuConsult(apiKey = apiKey)
         }
     } catch (e: Exception) {
-        System.err.println("[explorer] AnthropicSession init failed (${e.message}) — using FakeHaikuConsult")
+        System.err.println("[explorer] Haiku init failed (${e.message}) — using FakeHaikuConsult")
         FakeHaikuConsult()
     }
 

--- a/knes-agent/src/main/kotlin/knes/agent/explorer/HaikuConsult.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/explorer/HaikuConsult.kt
@@ -27,13 +27,14 @@ interface HaikuConsult {
     suspend fun classifyInterior(
         mapId: Int,
         visitedTileCount: Int,
-        screenshotPng: ByteArray?,
+        screenshotBase64: String?,
+        runId: String = "",
     ): InteriorClassification
 
     /** Called when a dialog box is open. Implementation should read the dialog text
      *  (may press A across pages) and return a summary plus optional landmark hint. */
     suspend fun readDialog(
-        screenshotPng: ByteArray?,
+        screenshotBase64: String?,
     ): DialogReading
 }
 
@@ -46,7 +47,7 @@ class FakeHaikuConsult(
     var dialogCalls: Int = 0; private set
 
     override suspend fun classifyInterior(
-        mapId: Int, visitedTileCount: Int, screenshotPng: ByteArray?,
+        mapId: Int, visitedTileCount: Int, screenshotBase64: String?, runId: String,
     ): HaikuConsult.InteriorClassification {
         val res = interiorClassifications.getOrNull(interiorCalls)
             ?: HaikuConsult.InteriorClassification(emptyList(), 0.0)
@@ -54,7 +55,7 @@ class FakeHaikuConsult(
         return res
     }
 
-    override suspend fun readDialog(screenshotPng: ByteArray?): HaikuConsult.DialogReading {
+    override suspend fun readDialog(screenshotBase64: String?): HaikuConsult.DialogReading {
         val res = dialogReadings.getOrNull(dialogCalls)
             ?: HaikuConsult.DialogReading("", null, 0.0)
         dialogCalls++

--- a/knes-agent/src/main/kotlin/knes/agent/explorer/SalienceStrategy.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/explorer/SalienceStrategy.kt
@@ -23,16 +23,35 @@ class SalienceStrategy(
     private val fog: FogOfWar,
     private val recentFailureWindow: Duration = Duration.ofMinutes(10),
     private val frontierRadius: Int = 20,
+    /** Distance ceiling for tile-tagged landmark candidates (mapIdInterior == null).
+     *  Confirmed entries (mapIdInterior != null) ignore this. Default 2 × frontierRadius. */
+    private val tileTaggedDistanceLimit: Int = 40,
 ) {
     fun pickOverworldTarget(currentXY: Pair<Int, Int>, viewport: ViewportMap): Pair<Int, Int> {
         val recentlyFailed = blockageMemory.recentlyFailedTargets(recentFailureWindow)
         val asKey: (Pair<Int, Int>) -> String = { "${it.first},${it.second}" }
 
-        // Priority 1: unvisited landmarks
-        landmarkMemory.findByKind(LandmarkKind.TOWN_ENTRY, LandmarkKind.CASTLE_ENTRY, LandmarkKind.DUNGEON_ENTRY)
+        val unvisited = landmarkMemory.findByKind(
+                LandmarkKind.TOWN_ENTRY, LandmarkKind.CASTLE_ENTRY, LandmarkKind.DUNGEON_ENTRY,
+            )
             .filter { !it.visited }
             .filter { it.worldX != null && it.worldY != null }
             .filter { (it.worldX!! to it.worldY!!).let { p -> asKey(p) !in recentlyFailed } }
+
+        // Priority 1A: confirmed entries — Landmark.mapIdInterior set by handleNewInterior
+        // on a prior run, proving the tile actually leads to an interior. No distance limit.
+        unvisited
+            .filter { it.mapIdInterior != null }
+            .minByOrNull { manhattan(currentXY, it.worldX!! to it.worldY!!) }
+            ?.let { return it.worldX!! to it.worldY!! }
+
+        // Priority 1B: tile-tagged candidates — auto-recorded by priority 2 in some prior
+        // run; never actually entered. Many may be unreachable from the current zone (other
+        // continent, water-locked, etc.). Limit to manhattan ≤ tileTaggedDistanceLimit so
+        // stale records on the far side of the world don't starve local exploration.
+        unvisited
+            .filter { it.mapIdInterior == null }
+            .filter { manhattan(currentXY, it.worldX!! to it.worldY!!) <= tileTaggedDistanceLimit }
             .minByOrNull { manhattan(currentXY, it.worldX!! to it.worldY!!) }
             ?.let { return it.worldX!! to it.worldY!! }
 

--- a/knes-agent/src/main/kotlin/knes/agent/explorer/SingleRun.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/explorer/SingleRun.kt
@@ -129,13 +129,9 @@ class SingleRun(
         skillRegistry.exploreInteriorFrontier(maxSteps = 80)
         // Post-explore: ask Haiku to classify what we saw.
         val visited = interiorMemory.visited(t.mapId)
-        val screenshot: ByteArray? = runCatching {
-            // Implementation note: real screenshot acquisition is via toolset.getState() or a
-            // dedicated call. Pass null if not yet wired — the explorer handles cost=0.0.
-            null
-        }.getOrNull()
+        val b64 = runCatching { toolset.getScreen().base64 }.getOrNull()
         val classification = haikuConsult.classifyInterior(
-            mapId = t.mapId, visitedTileCount = visited.size, screenshotPng = screenshot,
+            mapId = t.mapId, visitedTileCount = visited.size, screenshotBase64 = b64, runId = runId,
         )
         haikuCostUsd += applyInteriorClassification(landmarkMemory, classification)
     }
@@ -143,7 +139,8 @@ class SingleRun(
     private suspend fun handleDialog() {
         // Press A once to advance, take screenshot, ask Haiku to read.
         toolset.tap(button = "A", count = 1, pressFrames = 5, gapFrames = 30)
-        val reading = haikuConsult.readDialog(screenshotPng = null)
+        val b64 = runCatching { toolset.getScreen().base64 }.getOrNull()
+        val reading = haikuConsult.readDialog(screenshotBase64 = b64)
         haikuCostUsd += reading.costUsd
         if (reading.landmarkHint != null) {
             val ram = observer.ramSnapshot()

--- a/knes-agent/src/main/kotlin/knes/agent/perception/LandmarkMemory.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/perception/LandmarkMemory.kt
@@ -62,7 +62,16 @@ class LandmarkMemory(
     fun record(l: Landmark) { byId[l.id] = l }
 
     /** Records iff no existing landmark matches on (kind + world coords) for overworld
-     *  or (kind + mapId + local coords) for interior. Returns true if added. */
+     *  or (kind + mapId + local coords) for interior. Returns true if added.
+     *
+     *  When a duplicate exists, fields on the existing record are upgraded
+     *  monotonically with stronger info from the new record: visited flag
+     *  becomes true if either is true; mapIdInterior fills in if previously
+     *  null; note + discoveredRunId fill in if previously blank. This prevents
+     *  the case where SalienceStrategy auto-records a tile-tagged candidate
+     *  (visited=false, mapIdInterior=null), then later handleNewInterior
+     *  records the confirmed entry (visited=true, mapIdInterior=N) and the
+     *  stronger record was discarded. */
     fun recordIfNew(l: Landmark): Boolean {
         val isOverworld = l.worldX != null && l.worldY != null
         val isInterior = l.mapId != null && l.localX != null && l.localY != null
@@ -78,7 +87,17 @@ class LandmarkMemory(
                 else -> false  // coord-less landmarks are never deduped
             }
         }
-        if (dup != null) return false
+        if (dup != null) {
+            val upgraded = dup.copy(
+                visited = dup.visited || l.visited,
+                mapIdInterior = dup.mapIdInterior ?: l.mapIdInterior,
+                note = if (dup.note.isBlank() && l.note.isNotBlank()) l.note else dup.note,
+                discoveredRunId = if (dup.discoveredRunId.isBlank() && l.discoveredRunId.isNotBlank())
+                    l.discoveredRunId else dup.discoveredRunId,
+            )
+            if (upgraded != dup) byId[dup.id] = upgraded
+            return false
+        }
         byId[l.id] = l
         return true
     }

--- a/knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt
@@ -4,6 +4,7 @@ import knes.agent.advisor.AdvisorAgent
 import knes.agent.executor.ExecutorAgent
 import knes.agent.perception.FfPhase
 import knes.agent.perception.FogOfWar
+import knes.agent.perception.LandmarkMemory
 import knes.agent.perception.OverworldWarpMemory
 import knes.agent.perception.RamObserver
 import knes.agent.perception.ScreenshotPolicy
@@ -36,6 +37,13 @@ class AgentSession(
      * to keep the host filesystem clean.
      */
     private val warpMemory: OverworldWarpMemory = OverworldWarpMemory(),
+    /**
+     * Phase 2: persistent landmark catalog populated by the explorer phase
+     * (towns, castles, dungeons, NPCs). Injected into both advisor and
+     * executor observations so the planner can route to known points of
+     * interest without rediscovery. Default loads from ~/.knes/ff1-landmarks.json.
+     */
+    private val landmarkMemory: LandmarkMemory = LandmarkMemory(),
     runDir: Path = Trace.newRunDir(),
     /**
      * Optional per-turn hook fired after each executor turn. Receives current
@@ -87,6 +95,11 @@ class AgentSession(
             }
         }
 
+        val landmarkContext: String? = LandmarkContext.render(landmarkMemory)
+        if (landmarkContext != null) {
+            println("[landmark-memory] preloaded ${landmarkMemory.all().size} landmarks (advisor + executor injection)")
+        }
+
         try {
             while (true) {
                 val phase = observer.observeWithVision()
@@ -136,6 +149,10 @@ class AgentSession(
                             append(failedWarpTiles.joinToString(", ") { "(${it.first},${it.second})" })
                             append('\n')
                         }
+                        if (landmarkContext != null) {
+                            append(landmarkContext)
+                            append('\n')
+                        }
                         append("Reason: $reason")
                     }
                     println("[advisor #$advisorCalls] phase=$phase")
@@ -157,6 +174,10 @@ class AgentSession(
                         append("\nSession memory — known FF1 warp tiles to avoid as targets " +
                             "or route-throughs: ")
                         append(failedWarpTiles.joinToString(", ") { "(${it.first},${it.second})" })
+                    }
+                    if (landmarkContext != null) {
+                        append('\n')
+                        append(landmarkContext)
                     }
                 }
                 println("[executor turn=$skillsInvoked] phase=$phase idle=$idleTurns")

--- a/knes-agent/src/main/kotlin/knes/agent/runtime/LandmarkContext.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/runtime/LandmarkContext.kt
@@ -1,0 +1,66 @@
+package knes.agent.runtime
+
+import knes.agent.perception.Landmark
+import knes.agent.perception.LandmarkKind
+import knes.agent.perception.LandmarkMemory
+
+/**
+ * Phase 2 — Agent uses explorer memory.
+ *
+ * Renders the persistent `LandmarkMemory` (populated by the explorer phase) as a
+ * compact text block injected into both advisor and executor observations. Lets
+ * the planner LLM reference towns, castles, dungeons, and known NPCs without
+ * having to rediscover them each run.
+ *
+ * Returns `null` when memory is empty so the caller can skip the section header.
+ */
+object LandmarkContext {
+    fun render(memory: LandmarkMemory): String? {
+        val all = memory.all()
+        if (all.isEmpty()) return null
+
+        val grouped = all.groupBy { it.kind }
+        val ordering = listOf(
+            LandmarkKind.TOWN_ENTRY,
+            LandmarkKind.CASTLE_ENTRY,
+            LandmarkKind.DUNGEON_ENTRY,
+            LandmarkKind.NPC_KING,
+            LandmarkKind.NPC_SHOPKEEPER,
+            LandmarkKind.NPC_GENERIC,
+            LandmarkKind.STAIRS_UP,
+            LandmarkKind.STAIRS_DOWN,
+            LandmarkKind.EXIT_TILE,
+            LandmarkKind.UNKNOWN,
+        )
+
+        val lines = buildList {
+            for (kind in ordering) {
+                val entries = grouped[kind] ?: continue
+                for (l in entries.sortedBy { it.id }) {
+                    add("- ${formatLine(l)}")
+                }
+            }
+        }
+
+        return buildString {
+            append("Known landmarks (from prior exploration runs):\n")
+            append(lines.joinToString("\n"))
+        }
+    }
+
+    private fun formatLine(l: Landmark): String = buildString {
+        append(l.kind.name)
+        when {
+            l.worldX != null && l.worldY != null -> {
+                append(" at world(${l.worldX},${l.worldY})")
+                if (l.mapIdInterior != null) append(" → mapId=${l.mapIdInterior}")
+            }
+            l.mapId != null -> {
+                append(" in mapId=${l.mapId}")
+                if (l.localX != null && l.localY != null) append(" local(${l.localX},${l.localY})")
+            }
+        }
+        if (l.visited) append(" [visited]")
+        if (l.note.isNotBlank()) append(" — \"${l.note.take(60)}\"")
+    }
+}

--- a/knes-agent/src/test/kotlin/knes/agent/explorer/AnthropicHaikuConsultLiveTest.kt
+++ b/knes-agent/src/test/kotlin/knes/agent/explorer/AnthropicHaikuConsultLiveTest.kt
@@ -1,0 +1,50 @@
+package knes.agent.explorer
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Live HTTP smoke test for AnthropicHaikuConsult — round-trips against the real
+ * Anthropic API with a text-only prompt (no screenshot). Skips silently when
+ * ANTHROPIC_API_KEY is unset so CI doesn't break.
+ *
+ * Asserts the round-trip succeeds and the cost calc reports a non-zero value
+ * (proves usage parsing is wired). The model's actual JSON output isn't fixed
+ * — without a screenshot Haiku will return an empty landmarks array, but the
+ * envelope parsing is still exercised end-to-end.
+ */
+class AnthropicHaikuConsultLiveTest : FunSpec({
+    test("classifyInterior round-trips against real API (text only)") {
+        val key = System.getenv("ANTHROPIC_API_KEY")?.takeIf { it.isNotBlank() }
+        if (key == null) { println("ANTHROPIC_API_KEY not set; skipping live test"); return@test }
+
+        val consult = AnthropicHaikuConsult(apiKey = key)
+        try {
+            val res = runBlocking {
+                consult.classifyInterior(mapId = 1, visitedTileCount = 0, screenshotBase64 = null, runId = "live-test")
+            }
+            // Without a screenshot the model has nothing to classify — landmarks
+            // should be empty or contain only hallucinated entries. Either way
+            // the cost must reflect that the HTTP call actually happened.
+            (res.costUsd > 0.0) shouldBe true
+            println("[live] classifyInterior: landmarks=${res.landmarks.size} cost=$${"%.6f".format(res.costUsd)}")
+        } finally {
+            consult.close()
+        }
+    }
+
+    test("readDialog round-trips against real API (text only)") {
+        val key = System.getenv("ANTHROPIC_API_KEY")?.takeIf { it.isNotBlank() }
+        if (key == null) { println("ANTHROPIC_API_KEY not set; skipping live test"); return@test }
+
+        val consult = AnthropicHaikuConsult(apiKey = key)
+        try {
+            val res = runBlocking { consult.readDialog(screenshotBase64 = null) }
+            (res.costUsd > 0.0) shouldBe true
+            println("[live] readDialog: hint=${res.landmarkHint} cost=$${"%.6f".format(res.costUsd)}")
+        } finally {
+            consult.close()
+        }
+    }
+})

--- a/knes-agent/src/test/kotlin/knes/agent/explorer/AnthropicHaikuConsultTest.kt
+++ b/knes-agent/src/test/kotlin/knes/agent/explorer/AnthropicHaikuConsultTest.kt
@@ -1,0 +1,77 @@
+package knes.agent.explorer
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.shouldBe
+import knes.agent.perception.LandmarkKind
+
+/**
+ * Pure-unit tests on the response parser. The HTTP boundary is exercised live
+ * (manual / opt-in) — these only validate the JSON envelope + inner-text parsing.
+ */
+class AnthropicHaikuConsultTest : FunSpec({
+    test("parseInteriorResponse extracts NPC_KING landmark with correct cost") {
+        val raw = """
+            {
+              "content": [{"type":"text","text":"{\"landmarks\":[{\"kind\":\"NPC_KING\",\"note\":\"crowned NPC on throne\"}]}"}],
+              "usage": {"input_tokens": 1500, "output_tokens": 30}
+            }
+        """.trimIndent()
+        val res = AnthropicHaikuConsult.parseInteriorResponse(raw, mapId = 1, runId = "run-1")
+        res.landmarks shouldHaveSize 1
+        res.landmarks[0].kind shouldBe LandmarkKind.NPC_KING
+        res.landmarks[0].mapId shouldBe 1
+        res.landmarks[0].note shouldBe "crowned NPC on throne"
+        res.landmarks[0].discoveredRunId shouldBe "run-1"
+        // 1500 * $1e-6 + 30 * $5e-6 = 0.0015 + 0.00015
+        res.costUsd shouldBe (0.001650).plusOrMinus(1e-9)
+    }
+
+    test("parseInteriorResponse falls back to NPC_GENERIC for unknown kind") {
+        val raw = """
+            {"content":[{"type":"text","text":"{\"landmarks\":[{\"kind\":\"WIZARD\",\"note\":\"robed figure\"}]}"}],"usage":{"input_tokens":100,"output_tokens":10}}
+        """.trimIndent()
+        val res = AnthropicHaikuConsult.parseInteriorResponse(raw, mapId = 8, runId = "")
+        res.landmarks shouldHaveSize 1
+        res.landmarks[0].kind shouldBe LandmarkKind.NPC_GENERIC
+    }
+
+    test("parseInteriorResponse handles malformed inner text gracefully") {
+        val raw = """{"content":[{"type":"text","text":"not json"}],"usage":{"input_tokens":100,"output_tokens":10}}"""
+        val res = AnthropicHaikuConsult.parseInteriorResponse(raw, mapId = 8, runId = "")
+        res.landmarks.shouldBeEmpty()
+        res.costUsd shouldBe (100 * 1e-6 + 10 * 5e-6).plusOrMinus(1e-9)
+    }
+
+    test("parseInteriorResponse handles missing usage field") {
+        val raw = """{"content":[{"type":"text","text":"{\"landmarks\":[]}"}]}"""
+        val res = AnthropicHaikuConsult.parseInteriorResponse(raw, mapId = 1, runId = "")
+        res.landmarks.shouldBeEmpty()
+        res.costUsd shouldBe 0.0
+    }
+
+    test("parseDialogResponse extracts summary and KING hint") {
+        val raw = """
+            {"content":[{"type":"text","text":"{\"summary\":\"King asks for bridge\",\"landmarkHint\":\"KING\"}"}],"usage":{"input_tokens":800,"output_tokens":20}}
+        """.trimIndent()
+        val res = AnthropicHaikuConsult.parseDialogResponse(raw)
+        res.summary shouldBe "King asks for bridge"
+        res.landmarkHint shouldBe "KING"
+        res.costUsd shouldBe (800 * 1e-6 + 20 * 5e-6).plusOrMinus(1e-9)
+    }
+
+    test("parseDialogResponse normalizes literal 'null' hint to kotlin null") {
+        val raw = """{"content":[{"type":"text","text":"{\"summary\":\"x\",\"landmarkHint\":\"null\"}"}],"usage":{"input_tokens":50,"output_tokens":10}}"""
+        val res = AnthropicHaikuConsult.parseDialogResponse(raw)
+        res.landmarkHint shouldBe null
+    }
+
+    test("parseDialogResponse extracts JSON even when wrapped in prose") {
+        val raw = """{"content":[{"type":"text","text":"Here is the result: {\"summary\":\"hi\",\"landmarkHint\":null}"}],"usage":{"input_tokens":40,"output_tokens":5}}"""
+        val res = AnthropicHaikuConsult.parseDialogResponse(raw)
+        res.summary shouldBe "hi"
+        res.landmarkHint shouldBe null
+    }
+})

--- a/knes-agent/src/test/kotlin/knes/agent/explorer/SalienceStrategyTest.kt
+++ b/knes-agent/src/test/kotlin/knes/agent/explorer/SalienceStrategyTest.kt
@@ -21,10 +21,11 @@ class SalienceStrategyTest : FunSpec({
             partyWorldXY = centerWorld)
     }
 
-    test("priority 1: unvisited landmark is chosen even when far") {
+    test("priority 1A: confirmed entry (mapIdInterior set) is chosen even when far") {
         val landmarks = LandmarkMemory(file = tmp("l"))
+        // mapIdInterior=8 means handleNewInterior recorded an actual entry → confirmed.
         landmarks.record(Landmark(id = "town", kind = LandmarkKind.TOWN_ENTRY,
-            worldX = 200, worldY = 200, visited = false))
+            worldX = 200, worldY = 200, mapIdInterior = 8, visited = false))
         val strategy = SalienceStrategy(
             terrainMemory = OverworldTerrainMemory(file = tmp("t")),
             landmarkMemory = landmarks,
@@ -34,6 +35,63 @@ class SalienceStrategyTest : FunSpec({
         val target = strategy.pickOverworldTarget(currentXY = 146 to 158,
             viewport = viewportAllGrass(146 to 158))
         target shouldBe (200 to 200)
+    }
+
+    test("priority 1B: tile-tagged candidate beyond distance limit is ignored, falls through") {
+        val landmarks = LandmarkMemory(file = tmp("l"))
+        // Same far coords (200,200) but no mapIdInterior — auto-recorded, never entered.
+        landmarks.record(Landmark(id = "stale", kind = LandmarkKind.CASTLE_ENTRY,
+            worldX = 200, worldY = 200, visited = false))
+        val terrain = OverworldTerrainMemory(file = tmp("t"))
+        // Provide a frontier so priority 3 has something to return.
+        terrain.record(146, 158, TileType.GRASS)
+        terrain.record(147, 158, TileType.GRASS)
+        val strategy = SalienceStrategy(
+            terrainMemory = terrain,
+            landmarkMemory = landmarks,
+            blockageMemory = BlockageMemory(file = tmp("b")),
+            fog = FogOfWar(),
+        )
+        val target = strategy.pickOverworldTarget(currentXY = 146 to 158,
+            viewport = viewportAllGrass(146 to 158))
+        // Should NOT pick (200,200) — distance 96 exceeds tileTaggedDistanceLimit=40.
+        // Falls through to priority 3 (frontier) — accepts any local tile, not (200,200).
+        (target == 200 to 200) shouldBe false
+    }
+
+    test("priority 1B: tile-tagged candidate WITHIN distance limit is still chosen") {
+        val landmarks = LandmarkMemory(file = tmp("l"))
+        // (160,170) is manhattan distance 14+12=26 from (146,158) — within default limit 40.
+        landmarks.record(Landmark(id = "near", kind = LandmarkKind.TOWN_ENTRY,
+            worldX = 160, worldY = 170, visited = false))
+        val strategy = SalienceStrategy(
+            terrainMemory = OverworldTerrainMemory(file = tmp("t")),
+            landmarkMemory = landmarks,
+            blockageMemory = BlockageMemory(file = tmp("b")),
+            fog = FogOfWar(),
+        )
+        val target = strategy.pickOverworldTarget(currentXY = 146 to 158,
+            viewport = viewportAllGrass(146 to 158))
+        target shouldBe (160 to 170)
+    }
+
+    test("priority 1A confirmed entry beats priority 1B local candidate when both exist") {
+        val landmarks = LandmarkMemory(file = tmp("l"))
+        // Local tile-tag at (150,160) — distance 6, would normally win on distance.
+        landmarks.record(Landmark(id = "tagged", kind = LandmarkKind.TOWN_ENTRY,
+            worldX = 150, worldY = 160, visited = false))
+        // Far confirmed entry at (180,180) — distance 56, but has mapIdInterior.
+        landmarks.record(Landmark(id = "confirmed", kind = LandmarkKind.CASTLE_ENTRY,
+            worldX = 180, worldY = 180, mapIdInterior = 1, visited = false))
+        val strategy = SalienceStrategy(
+            terrainMemory = OverworldTerrainMemory(file = tmp("t")),
+            landmarkMemory = landmarks,
+            blockageMemory = BlockageMemory(file = tmp("b")),
+            fog = FogOfWar(),
+        )
+        val target = strategy.pickOverworldTarget(currentXY = 146 to 158,
+            viewport = viewportAllGrass(146 to 158))
+        target shouldBe (180 to 180)
     }
 
     test("priority 2: TOWN tile in viewport beats unmapped frontier when no landmark exists") {

--- a/knes-agent/src/test/kotlin/knes/agent/explorer/SingleRunHandleNewInteriorTest.kt
+++ b/knes-agent/src/test/kotlin/knes/agent/explorer/SingleRunHandleNewInteriorTest.kt
@@ -26,7 +26,7 @@ class SingleRunHandleNewInteriorTest : FunSpec({
 
         // Direct call into the helper without spinning up full SingleRun.
         val classification = runBlocking {
-            fake.classifyInterior(mapId = 1, visitedTileCount = 30, screenshotPng = null)
+            fake.classifyInterior(mapId = 1, visitedTileCount = 30, screenshotBase64 = null)
         }
         val cost = SingleRun.applyInteriorClassification(landmarks, classification)
         cost shouldBe 0.012

--- a/knes-agent/src/test/kotlin/knes/agent/perception/LandmarkMemoryTest.kt
+++ b/knes-agent/src/test/kotlin/knes/agent/perception/LandmarkMemoryTest.kt
@@ -57,4 +57,36 @@ class LandmarkMemoryTest : FunSpec({
         mem.recordIfNew(Landmark(id = "g2", kind = LandmarkKind.NPC_GENERIC)) shouldBe true
         mem.findByKind(LandmarkKind.NPC_GENERIC) shouldHaveSize 2
     }
+
+    test("recordIfNew upgrades existing record with stronger info on duplicate (visited + mapIdInterior)") {
+        val tmp = Files.createTempFile("landmarks", ".json").toFile().apply { deleteOnExit() }
+        val mem = LandmarkMemory(file = tmp)
+        // First: SalienceStrategy auto-records a tile-tagged candidate (no entry yet).
+        mem.recordIfNew(Landmark(id = "tagged_147_154", kind = LandmarkKind.TOWN_ENTRY,
+            worldX = 147, worldY = 154, visited = false)) shouldBe true
+        // Then: handleNewInterior records the confirmed entry at the same coords.
+        mem.recordIfNew(Landmark(id = "interior_entry_8_147_154", kind = LandmarkKind.TOWN_ENTRY,
+            worldX = 147, worldY = 154, mapIdInterior = 8, visited = true,
+            note = "first entry", discoveredRunId = "run-1")) shouldBe false  // dedup'd
+        // The existing record must now reflect visited=true, mapIdInterior=8, note + runId filled.
+        mem.findByKind(LandmarkKind.TOWN_ENTRY) shouldHaveSize 1
+        val merged = mem.findByKind(LandmarkKind.TOWN_ENTRY).first()
+        merged.visited shouldBe true
+        merged.mapIdInterior shouldBe 8
+        merged.note shouldBe "first entry"
+        merged.discoveredRunId shouldBe "run-1"
+    }
+
+    test("recordIfNew upgrade is monotonic — never weakens visited or unsets mapIdInterior") {
+        val tmp = Files.createTempFile("landmarks", ".json").toFile().apply { deleteOnExit() }
+        val mem = LandmarkMemory(file = tmp)
+        mem.recordIfNew(Landmark(id = "strong", kind = LandmarkKind.CASTLE_ENTRY,
+            worldX = 152, worldY = 151, mapIdInterior = 1, visited = true, note = "throne"))
+        mem.recordIfNew(Landmark(id = "weaker", kind = LandmarkKind.CASTLE_ENTRY,
+            worldX = 152, worldY = 151, mapIdInterior = null, visited = false, note = ""))
+        val res = mem.findByKind(LandmarkKind.CASTLE_ENTRY).first()
+        res.visited shouldBe true
+        res.mapIdInterior shouldBe 1
+        res.note shouldBe "throne"
+    }
 })

--- a/knes-agent/src/test/kotlin/knes/agent/runtime/LandmarkContextTest.kt
+++ b/knes-agent/src/test/kotlin/knes/agent/runtime/LandmarkContextTest.kt
@@ -1,0 +1,77 @@
+package knes.agent.runtime
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import knes.agent.perception.Landmark
+import knes.agent.perception.LandmarkKind
+import knes.agent.perception.LandmarkMemory
+import java.nio.file.Files
+
+class LandmarkContextTest : FunSpec({
+    fun emptyMem(): LandmarkMemory =
+        LandmarkMemory(file = Files.createTempFile("lm", ".json").toFile().apply { deleteOnExit() })
+
+    test("render returns null when memory is empty") {
+        LandmarkContext.render(emptyMem()) shouldBe null
+    }
+
+    test("render groups entries by kind in canonical order") {
+        val mem = emptyMem().apply {
+            record(Landmark(id = "npc_generic_1", kind = LandmarkKind.NPC_GENERIC,
+                mapId = 8, localX = 5, localY = 6))
+            record(Landmark(id = "town_147", kind = LandmarkKind.TOWN_ENTRY,
+                worldX = 147, worldY = 154, mapIdInterior = 8, visited = true))
+            record(Landmark(id = "castle_152", kind = LandmarkKind.CASTLE_ENTRY,
+                worldX = 152, worldY = 151, mapIdInterior = 1))
+            record(Landmark(id = "king_1", kind = LandmarkKind.NPC_KING,
+                mapId = 1, note = "asks for bridge"))
+        }
+        val text = LandmarkContext.render(mem)!!
+        text shouldContain "Known landmarks"
+        // ordering: TOWN before CASTLE before NPC_KING before NPC_GENERIC
+        val tIdx = text.indexOf("TOWN_ENTRY")
+        val cIdx = text.indexOf("CASTLE_ENTRY")
+        val kIdx = text.indexOf("NPC_KING")
+        val gIdx = text.indexOf("NPC_GENERIC")
+        (tIdx in 0 until cIdx) shouldBe true
+        (cIdx in 0 until kIdx) shouldBe true
+        (kIdx in 0 until gIdx) shouldBe true
+    }
+
+    test("render formats overworld landmark with world coords + mapId destination") {
+        val mem = emptyMem().apply {
+            record(Landmark(id = "town", kind = LandmarkKind.TOWN_ENTRY,
+                worldX = 147, worldY = 154, mapIdInterior = 8, visited = true,
+                note = "south Coneria edge"))
+        }
+        val text = LandmarkContext.render(mem)!!
+        text shouldContain "TOWN_ENTRY at world(147,154)"
+        text shouldContain "→ mapId=8"
+        text shouldContain "[visited]"
+        text shouldContain "south Coneria edge"
+    }
+
+    test("render formats interior NPC landmark with mapId only") {
+        val mem = emptyMem().apply {
+            record(Landmark(id = "k", kind = LandmarkKind.NPC_KING,
+                mapId = 1, note = "throne"))
+        }
+        val text = LandmarkContext.render(mem)!!
+        text shouldContain "NPC_KING in mapId=1"
+        text shouldContain "throne"
+        text shouldNotContain "world("
+    }
+
+    test("render truncates long notes to 60 chars") {
+        val long = "x".repeat(120)
+        val mem = emptyMem().apply {
+            record(Landmark(id = "g", kind = LandmarkKind.NPC_GENERIC, mapId = 8, note = long))
+        }
+        val text = LandmarkContext.render(mem)!!
+        text shouldContain "x".repeat(60)
+        // 61 'x' would mean the truncation didn't fire
+        text shouldNotContain "x".repeat(61)
+    }
+})


### PR DESCRIPTION
## Summary

Builds on cross-run explorer Phase 1 (merged in #101). Three commits, rebased onto current master.

- **Phase 1.5** — `AnthropicHaikuConsult` stub → real Haiku 4.5 calls. Direct HTTP to Anthropic Messages API (mirrors `VisionOverworldNavigator`), parses `usage` for cost calc ($1/MT in, $5/MT out). Interface param renamed `screenshotPng:ByteArray?` → `screenshotBase64:String?` (eliminates round-trip; `toolset.getScreen()` returns base64 natively). `SingleRun` wires the screenshot for both interior classification and dialog reading.
- **Phase 2** — `AgentSession` consumes `~/.knes/ff1-landmarks.json` populated by the explorer. New `LandmarkContext.render(memory)` formats landmarks grouped by kind (TOWN → CASTLE → DUNGEON → NPCs → stairs) and the result is injected into both advisor and executor observations. Agent can now reference towns/castles/known NPCs without rediscovery.
- **Live test** — Round-trip smoke test against real Anthropic API for both `classifyInterior` and `readDialog`. Skips silently without `ANTHROPIC_API_KEY` (matches `AnthropicSmokeTest`). Verified locally 2/2 PASS.

Tests: 14 new (7 parsing + 5 LandmarkContext + 2 live). Total agent suite **186 / 2 pre-existing fails / 7 skipped**. Zero regressions.

## Test plan

- [x] `./gradlew :knes-agent:test` — 184 unit tests pass, 2 pre-existing failures unchanged
- [x] Live `AnthropicHaikuConsultLiveTest` — 2/2 PASS with key (~2.5s)
- [ ] Live `runExplorer` with real Haiku populates `ff1-landmarks.json` with NPC entries
- [ ] Live `runAgent` reads landmarks and includes them in advisor/executor prompts