### PR TITLE
FF1 explorer — per-run novelty unblocks Haiku trigger

### DIFF
--- a/knes-agent/src/main/kotlin/knes/agent/explorer/SingleRun.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/explorer/SingleRun.kt
@@ -46,6 +46,11 @@ class SingleRun(
     private var haikuCostUsd = 0.0
     private val coverageDeltaWindow: ArrayDeque<Int> = ArrayDeque()
     private var firstStartDirection: String? = null
+    /** Per-run set of mapIds for which `NewInteriorEntered` has already fired this run.
+     *  Replaces persistent `interiorMemory.hasMapBeenSeen` gating — that prevented Haiku
+     *  classification ever firing on previously-seen maps across sessions. Now bounded
+     *  by ~3-5 maps per run; each run gets one classification per visited interior. */
+    private val novelMapIdsThisRun: MutableSet<Int> = mutableSetOf()
 
     suspend fun execute(): RunResult {
         var stepsTaken = 0
@@ -69,9 +74,12 @@ class SingleRun(
                 return RunResult(reason, haikuCostUsd, stepsTaken)
             }
 
-            val trigger = detectTrigger(phase, ram)
+            val trigger = detectTrigger(phase, ram, novelMapIdsThisRun, ::isDialogBoxOpen)
             when (trigger) {
-                is Trigger.NewInteriorEntered -> handleNewInterior(trigger)
+                is Trigger.NewInteriorEntered -> {
+                    novelMapIdsThisRun += trigger.mapId
+                    handleNewInterior(trigger)
+                }
                 Trigger.DialogBoxVisible -> handleDialog()
                 Trigger.BattleEntered -> handleBattle()
                 null -> deterministicStep(phase, ram)
@@ -94,14 +102,6 @@ class SingleRun(
         coverageDeltaWindow.addLast(delta)
         while (coverageDeltaWindow.size > coverageWindow) coverageDeltaWindow.removeFirst()
         if (delta > 0) idleTurns = 0
-    }
-
-    private fun detectTrigger(phase: FfPhase, ram: Map<String, Int>): Trigger? = when {
-        phase is FfPhase.Indoors && !interiorMemory.hasMapBeenSeen(phase.mapId) ->
-            Trigger.NewInteriorEntered(phase.mapId)
-        phase is FfPhase.Battle -> Trigger.BattleEntered
-        isDialogBoxOpen(ram) -> Trigger.DialogBoxVisible
-        else -> null
     }
 
     /** Heuristic: dialog typically blocks input; FF1 sets specific screen-state bits.
@@ -207,6 +207,23 @@ class SingleRun(
     }
 
     companion object {
+        /** Per-run novelty trigger detector. Pure function — no side effects.
+         *  Caller adds the mapId to its `novelMapIdsThisRun` set after firing.
+         *  Replaces the previous `interiorMemory.hasMapBeenSeen` gating which
+         *  was persistent across sessions and starved Haiku classification. */
+        fun detectTrigger(
+            phase: FfPhase,
+            ram: Map<String, Int>,
+            novelMapIdsThisRun: Set<Int>,
+            isDialogBoxOpen: (Map<String, Int>) -> Boolean = { false },
+        ): Trigger? = when {
+            phase is FfPhase.Indoors && phase.mapId !in novelMapIdsThisRun ->
+                Trigger.NewInteriorEntered(phase.mapId)
+            phase is FfPhase.Battle -> Trigger.BattleEntered
+            isDialogBoxOpen(ram) -> Trigger.DialogBoxVisible
+            else -> null
+        }
+
         /** Pure helper used by handleNewInterior; testable in isolation. */
         fun applyInteriorClassification(
             landmarkMemory: LandmarkMemory,

--- a/knes-agent/src/test/kotlin/knes/agent/explorer/SingleRunDetectTriggerTest.kt
+++ b/knes-agent/src/test/kotlin/knes/agent/explorer/SingleRunDetectTriggerTest.kt
@@ -1,0 +1,82 @@
+package knes.agent.explorer
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import knes.agent.perception.FfPhase
+
+/**
+ * Per-run novelty for `NewInteriorEntered`. The pre-fix gate was
+ * `!interiorMemory.hasMapBeenSeen(mapId)` — persistent across sessions, so
+ * once a map was entered in any run, the trigger never fired again. With 3
+ * pre-seeded maps, Haiku was never called and Phase 1.5 stayed unvalidated.
+ *
+ * Fix: gate on `mapId !in novelMapIdsThisRun`. Caller adds to the set on
+ * first fire — subsequent steps in the SAME run for the same map don't
+ * re-trigger, so we don't spam Haiku, but each run gets one classification
+ * per map.
+ */
+class SingleRunDetectTriggerTest : FunSpec({
+
+    test("first interior entry fires NewInteriorEntered") {
+        val novel = mutableSetOf<Int>()
+        val trigger = SingleRun.detectTrigger(
+            phase = FfPhase.Indoors(mapId = 1, localX = 0, localY = 0),
+            ram = emptyMap(),
+            novelMapIdsThisRun = novel,
+        )
+        trigger.shouldBeInstanceOf<Trigger.NewInteriorEntered>()
+        (trigger as Trigger.NewInteriorEntered).mapId shouldBe 1
+    }
+
+    test("re-entry to same map within run does not re-trigger") {
+        val novel = mutableSetOf(1)  // already seen this run
+        val trigger = SingleRun.detectTrigger(
+            phase = FfPhase.Indoors(mapId = 1, localX = 0, localY = 0),
+            ram = emptyMap(),
+            novelMapIdsThisRun = novel,
+        )
+        trigger shouldBe null
+    }
+
+    test("different map in same run still triggers (bounded per-map)") {
+        val novel = mutableSetOf(1)  // mapId=1 already fired
+        val trigger = SingleRun.detectTrigger(
+            phase = FfPhase.Indoors(mapId = 8, localX = 0, localY = 0),
+            ram = emptyMap(),
+            novelMapIdsThisRun = novel,
+        )
+        trigger.shouldBeInstanceOf<Trigger.NewInteriorEntered>()
+        (trigger as Trigger.NewInteriorEntered).mapId shouldBe 8
+    }
+
+    test("ignores cross-session interiorMemory — fires even for previously-seen maps") {
+        // The whole point of the fix: a map seen in any prior session must still
+        // trigger once per current run. We model that by passing an empty novel set
+        // — the function MUST NOT look at interiorMemory.hasMapBeenSeen anymore.
+        val trigger = SingleRun.detectTrigger(
+            phase = FfPhase.Indoors(mapId = 1, localX = 0, localY = 0),
+            ram = emptyMap(),
+            novelMapIdsThisRun = emptySet(),
+        )
+        trigger.shouldBeInstanceOf<Trigger.NewInteriorEntered>()
+    }
+
+    test("Battle phase always triggers BattleEntered (independent of novelty set)") {
+        val trigger = SingleRun.detectTrigger(
+            phase = FfPhase.Battle(enemyId = 0, enemyHp = 0, enemyDead = false),
+            ram = emptyMap(),
+            novelMapIdsThisRun = setOf(1, 8),
+        )
+        trigger shouldBe Trigger.BattleEntered
+    }
+
+    test("Overworld phase yields no trigger") {
+        val trigger = SingleRun.detectTrigger(
+            phase = FfPhase.Overworld(x = 146, y = 158),
+            ram = emptyMap(),
+            novelMapIdsThisRun = emptySet(),
+        )
+        trigger shouldBe null
+    }
+})


### PR DESCRIPTION
## Summary

Phase 1.5 was unvalidated end-to-end after PR #102 because `SingleRun.detectTrigger` gated `NewInteriorEntered` on `!interiorMemory.hasMapBeenSeen(mapId)` — persistent across sessions. With 3 pre-seeded maps in `~/.knes/ff1-interior-memory.json` (Coneria Castle, Coneria Town, Temple of Fiends), the trigger never fired and Haiku classification stayed at \$0 every campaign (HANDOFF \"Top priority for next session\").

This PR replaces that gate with per-run novelty: `novelMapIdsThisRun: MutableSet<Int>` tracked in `SingleRun`. Trigger fires the first time agent enters each map THIS run regardless of historic memory; subsequent steps in the same run for the same map don't re-trigger. Bounded by ~3-5 maps per run.

`detectTrigger` lifted to companion (pure function) for direct unit testing — no need to spin up the full `SingleRun` to verify gating logic.

## Test plan

- [x] `./gradlew :knes-agent:test` — 197 pass / 2 pre-existing fails / 7 skipped (+6 new tests)
- [x] Pre-existing `SingleRunHandleNewInteriorTest` still passes (uses `applyInteriorClassification` directly, unaffected by the gating change)
- [ ] Live `runExplorer` with cleared `~/.knes/ff1-landmarks.json` produces ≥1 record with `mapIdInterior != null` and `totalCostUsd > 0` (validating Phase 1.5 end-to-end)