### PR TITLE
FF1 explorer — overworld traversal unblocked, Phase 1.5 validated end-to-end

### DIFF
--- a/knes-agent/src/main/kotlin/knes/agent/explorer/SalienceStrategy.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/explorer/SalienceStrategy.kt
@@ -80,16 +80,24 @@ class SalienceStrategy(
         // Priority 4: diversify
         val recent = blockageMemory.pathTriedRecentDirections(k = 3).toSet()
         val cardinals = listOf("N" to (0 to -1), "E" to (1 to 0), "S" to (0 to 1), "W" to (-1 to 0))
-        cardinals.firstOrNull { it.first !in recent }?.let { (_, delta) ->
+        cardinals.firstOrNull { (dirName, delta) ->
+            val candidate = currentXY.first + delta.first * 8 to currentXY.second + delta.second * 8
+            dirName !in recent && asKey(candidate) !in recentlyFailed
+        }?.let { (_, delta) ->
             return currentXY.first + delta.first * 8 to currentXY.second + delta.second * 8
         }
 
-        // Priority 5: wander — first walkable tile in viewport
+        // Priority 5: wander — first walkable tile in viewport that hasn't recently failed.
+        // Without the recentlyFailed filter this row-major scan deterministically returns
+        // the same isPassable()-but-pathfinder-impassable tile every iteration (e.g. world
+        // (146,150) for spawn (146,158)) → infinite re-target loop until idle cap fires.
         for (ly in 0 until viewport.height) {
             for (lx in 0 until viewport.width) {
-                if (viewport.tiles[ly][lx].isPassable()) {
-                    return viewport.localToWorld(lx, ly)
-                }
+                if (!viewport.tiles[ly][lx].isPassable()) continue
+                val world = viewport.localToWorld(lx, ly)
+                if (asKey(world) in recentlyFailed) continue
+                if (world == currentXY) continue
+                return world
             }
         }
         return currentXY  // truly degenerate

--- a/knes-agent/src/main/kotlin/knes/agent/explorer/SingleRun.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/explorer/SingleRun.kt
@@ -189,6 +189,16 @@ class SingleRun(
                     blockageMemory.record(runId, from = cx to cy,
                         attemptedTo = "${target.first},${target.second}",
                         result = res.message)
+                    // Pathfinder rejected the target as impassable / no-path. Salience
+                    // priority 2 records ANY TOWN/CASTLE-typed viewport tile as a Landmark,
+                    // but the OverworldTileClassifier conflates entry tiles with wall
+                    // decoration. When BFS confirms the tile isn't actually walkable, drop
+                    // the bogus tile-tagged landmark so the next salience pick doesn't
+                    // re-target the same dead end. Confirmed entries (mapIdInterior != null)
+                    // are preserved.
+                    if (looksUnreachable(res.message)) {
+                        landmarkMemory.removeTileTaggedAt(target.first, target.second)
+                    }
                 }
             }
             is FfPhase.Indoors -> skillRegistry.exploreInteriorFrontier()
@@ -207,6 +217,12 @@ class SingleRun(
     }
 
     companion object {
+        /** Pathfinder messages indicating the target is unreachable from current position.
+         *  Used to purge bogus tile-tagged landmarks that the OverworldTileClassifier
+         *  misidentified as TOWN/CASTLE entries. Visible-for-test. */
+        fun looksUnreachable(message: String): Boolean =
+            "impassable terrain" in message || "no path within viewport" in message
+
         /** Per-run novelty trigger detector. Pure function — no side effects.
          *  Caller adds the mapId to its `novelMapIdsThisRun` set after firing.
          *  Replaces the previous `interiorMemory.hasMapBeenSeen` gating which

--- a/knes-agent/src/main/kotlin/knes/agent/perception/LandmarkMemory.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/perception/LandmarkMemory.kt
@@ -108,6 +108,21 @@ class LandmarkMemory(
     fun atLocation(worldX: Int, worldY: Int): Landmark? =
         byId.values.firstOrNull { it.worldX == worldX && it.worldY == worldY }
 
+    /** Remove all tile-tagged candidates (mapIdInterior == null) at exact world coords.
+     *  Confirmed entries (mapIdInterior != null) are preserved.
+     *
+     *  Used by `SingleRun` to purge salience priority-2 misclassifications when the
+     *  pathfinder reports the target as impassable terrain or no-path-within-viewport.
+     *  Without this, every run picks the same bogus landmark again and idles out. */
+    fun removeTileTaggedAt(worldX: Int, worldY: Int): Boolean {
+        val toRemove = byId.values.filter {
+            it.worldX == worldX && it.worldY == worldY && it.mapIdInterior == null
+        }
+        if (toRemove.isEmpty()) return false
+        toRemove.forEach { byId.remove(it.id) }
+        return true
+    }
+
     fun markVisited(id: String) {
         byId[id]?.let { byId[id] = it.copy(visited = true) }
     }

--- a/knes-agent/src/test/kotlin/knes/agent/explorer/SalienceStrategyTest.kt
+++ b/knes-agent/src/test/kotlin/knes/agent/explorer/SalienceStrategyTest.kt
@@ -94,6 +94,76 @@ class SalienceStrategyTest : FunSpec({
         target shouldBe (180 to 180)
     }
 
+    test("priority 5 wander skips recently-failed tile (no infinite re-target loop)") {
+        // All grass viewport — priority 5 row-major scan would return local (0,0) =
+        // world (138,150) for spawn (146,158). Mark it recently failed; expect a
+        // different walkable tile.
+        val tiles = Array(16) { Array(16) { TileType.GRASS } }
+        val vm = ViewportMap(tiles, partyLocalXY = 8 to 8, partyWorldXY = 146 to 158)
+        val blockages = BlockageMemory(file = tmp("b"))
+        blockages.record(runId = "r", from = 146 to 158, attemptedTo = "138,150",
+            result = "stuck at (146,158): no path within viewport")
+        // Also mark the priority-4 cardinal candidates (E/N/S/W from currentXY by 8) as
+        // recently failed so we deterministically fall through to priority 5.
+        for ((d, p) in listOf("N" to (146 to 150), "E" to (154 to 158),
+                "S" to (146 to 166), "W" to (138 to 158))) {
+            blockages.record(runId = "r", from = 146 to 158,
+                attemptedTo = "${p.first},${p.second}",
+                result = "stuck: $d")
+            blockages.recordRunStartDirection("seed-$d", d)
+        }
+        val strategy = SalienceStrategy(
+            terrainMemory = OverworldTerrainMemory(file = tmp("t")),
+            landmarkMemory = LandmarkMemory(file = tmp("l")),
+            blockageMemory = blockages,
+            fog = FogOfWar(),
+        )
+        val target = strategy.pickOverworldTarget(currentXY = 146 to 158, viewport = vm)
+        // Should NOT be (138,150) (priority 5 row-major first match), since it's recently failed.
+        (target == 138 to 150) shouldBe false
+        // Should also not be currentXY (degenerate).
+        (target == 146 to 158) shouldBe false
+    }
+
+    test("priority 4 diversify skips cardinal candidate that's recently failed") {
+        val vm = viewportAllGrass(146 to 158)
+        val blockages = BlockageMemory(file = tmp("b"))
+        // Mark "N" cardinal (146,150) as recently failed.
+        blockages.record(runId = "r", from = 146 to 158, attemptedTo = "146,150",
+            result = "impassable terrain")
+        val strategy = SalienceStrategy(
+            terrainMemory = OverworldTerrainMemory(file = tmp("t")),
+            landmarkMemory = LandmarkMemory(file = tmp("l")),
+            blockageMemory = blockages,
+            fog = FogOfWar(),
+        )
+        // No landmarks, no salient tiles, no terrain frontier → fall through to priority 4.
+        // Priority 4 must skip "N" → (146,150) and pick another cardinal.
+        val target = strategy.pickOverworldTarget(currentXY = 146 to 158, viewport = vm)
+        (target == 146 to 150) shouldBe false
+    }
+
+    test("recently-failed viewport tile is NOT re-picked by priority 2") {
+        val tiles = Array(16) { Array(16) { TileType.GRASS } }
+        tiles[5][5] = TileType.CASTLE  // local (5,5) → world (143,155) for spawn (146,158)
+        val vm = ViewportMap(tiles, partyLocalXY = 8 to 8, partyWorldXY = 146 to 158)
+
+        val blockages = BlockageMemory(file = tmp("b"))
+        // Simulate prior iteration's failure on (143,155).
+        blockages.record(runId = "run-1", from = 146 to 158, attemptedTo = "143,155",
+            result = "stuck at (146,158): target (143,155) is impassable terrain")
+        val strategy = SalienceStrategy(
+            terrainMemory = OverworldTerrainMemory(file = tmp("t")),
+            landmarkMemory = LandmarkMemory(file = tmp("l")),
+            blockageMemory = blockages,
+            fog = FogOfWar(),
+        )
+        val target = strategy.pickOverworldTarget(currentXY = 146 to 158, viewport = vm)
+        // recentlyFailed includes (143,155) → priority 2 must skip it. Falls through to
+        // priority 4 (diversify) which picks a cardinal — currentXY ± 8.
+        (target == 143 to 155) shouldBe false
+    }
+
     test("priority 2: TOWN tile in viewport beats unmapped frontier when no landmark exists") {
         val tiles = Array(16) { Array(16) { TileType.GRASS } }
         tiles[5][5] = TileType.TOWN  // local (5,5)

--- a/knes-agent/src/test/kotlin/knes/agent/explorer/SingleRunDetectTriggerTest.kt
+++ b/knes-agent/src/test/kotlin/knes/agent/explorer/SingleRunDetectTriggerTest.kt
@@ -79,4 +79,22 @@ class SingleRunDetectTriggerTest : FunSpec({
         )
         trigger shouldBe null
     }
+
+    test("looksUnreachable detects 'impassable terrain' message") {
+        SingleRun.looksUnreachable(
+            "stuck at (146,158): target (146,150) is impassable terrain (closest reachable: (146, 158))"
+        ) shouldBe true
+    }
+
+    test("looksUnreachable detects 'no path within viewport' message") {
+        SingleRun.looksUnreachable(
+            "stuck at (146,158): no path within viewport (closest reachable: (146, 158))"
+        ) shouldBe true
+    }
+
+    test("looksUnreachable returns false for unrelated abort messages") {
+        SingleRun.looksUnreachable("encounter triggered after 5 steps") shouldBe false
+        SingleRun.looksUnreachable("UNEXPECTED interior entry at world=(145,152) ...") shouldBe false
+        SingleRun.looksUnreachable("did not reach (X,Y) in 32 steps") shouldBe false
+    }
 })

--- a/knes-agent/src/test/kotlin/knes/agent/perception/LandmarkMemoryTest.kt
+++ b/knes-agent/src/test/kotlin/knes/agent/perception/LandmarkMemoryTest.kt
@@ -77,6 +77,36 @@ class LandmarkMemoryTest : FunSpec({
         merged.discoveredRunId shouldBe "run-1"
     }
 
+    test("removeTileTaggedAt drops only tile-tagged candidates at coords (mapIdInterior == null)") {
+        val tmp = Files.createTempFile("landmarks", ".json").toFile().apply { deleteOnExit() }
+        val mem = LandmarkMemory(file = tmp)
+        // tile-tagged castle decoration misclassified at (146,150)
+        mem.record(Landmark(id = "tagged_146_150", kind = LandmarkKind.CASTLE_ENTRY,
+            worldX = 146, worldY = 150, visited = false))
+        // confirmed entry at SAME coords — must NOT be removed
+        mem.record(Landmark(id = "confirmed_146_150", kind = LandmarkKind.CASTLE_ENTRY,
+            worldX = 146, worldY = 150, mapIdInterior = 1, visited = true))
+        // tile-tagged at different coords — must NOT be removed
+        mem.record(Landmark(id = "tagged_147_154", kind = LandmarkKind.TOWN_ENTRY,
+            worldX = 147, worldY = 154, visited = false))
+
+        mem.removeTileTaggedAt(146, 150) shouldBe true
+        // confirmed remains; tagged elsewhere remains
+        mem.findByKind(LandmarkKind.CASTLE_ENTRY) shouldHaveSize 1
+        mem.findByKind(LandmarkKind.CASTLE_ENTRY).first().mapIdInterior shouldBe 1
+        mem.findByKind(LandmarkKind.TOWN_ENTRY) shouldHaveSize 1
+    }
+
+    test("removeTileTaggedAt returns false when nothing matches") {
+        val tmp = Files.createTempFile("landmarks", ".json").toFile().apply { deleteOnExit() }
+        val mem = LandmarkMemory(file = tmp)
+        mem.record(Landmark(id = "t", kind = LandmarkKind.TOWN_ENTRY,
+            worldX = 100, worldY = 100, mapIdInterior = 8))
+        mem.removeTileTaggedAt(100, 100) shouldBe false  // confirmed, not tile-tagged
+        mem.removeTileTaggedAt(0, 0) shouldBe false       // nothing at coords
+        mem.findByKind(LandmarkKind.TOWN_ENTRY) shouldHaveSize 1
+    }
+
     test("recordIfNew upgrade is monotonic — never weakens visited or unsets mapIdInterior") {
         val tmp = Files.createTempFile("landmarks", ".json").toFile().apply { deleteOnExit() }
         val mem = LandmarkMemory(file = tmp)


### PR DESCRIPTION
## Summary

Two correlated fixes that close the loop on Phase 1.5 end-to-end validation: agent now actually enters interiors and Haiku 4.5 classifies NPCs.

### Commit 1: `f2d899c` — purge tile-tagged landmark on impassable / no-path

Live evidence after PR #103 (per-run novelty fix): 228× \"stuck at (146,158): no path within viewport\" + 20× \"target (146,150) is impassable terrain\" — agent never reached `FfPhase.Indoors`.

Root cause: `SalienceStrategy` priority 2 records every TOWN/CASTLE-typed viewport tile as a candidate Landmark, but `OverworldTileClassifier` conflates entry tiles with wall decoration (the same misclassification documented in pre-existing `Coneria8VisualDiffTest`). Priority 1B then picks the bogus landmark, BFS rejects it, blockage logged, same landmark re-picked next iteration.

Fix: when pathfinder reports impassable / no-path, drop the tile-tagged landmark at the target coord. Confirmed entries (`mapIdInterior != null`) preserved.

### Commit 2: `257d3c6` — priorities 4 + 5 must filter recentlyFailed too

Even with the purge, live still showed (146,150) re-targeted 10× in one run. Trace: salience priority 5 (wander) does a row-major viewport scan and returns first `isPassable()` tile — deterministically the same impassable-per-BFS tile every iteration. Priority 4 (diversify) had a parallel gap.

Fix: add `asKey(candidate) !in recentlyFailed` to both priorities.

## End-to-end validation

```
[campaign] FINAL: CampaignResult(
  outcome=Plateau, runsExecuted=7,
  coverage=CoverageStats(terrainTilesKnown=65502, warpsKnown=4,
    landmarksKnown=13, landmarksVisited=1, interiorMapsExplored=3),
  totalCostUsd=8.98E-4)
```

- ✓ Confirmed entry: `interior_entry_8_145_152` with `mapIdInterior=8, visited=true`
- ✓ Haiku called, cost \$0.000898 (Haiku 4.5 pricing × ~700 input + ~30 output tokens)
- ✓ NPC classifications written:
  - `NPC_KING` — \"Crowned figure on throne in upper chamber\"
  - `NPC_GENERIC` — \"Guard or attendant on left side of throne room\"
  - `STAIRS_DOWN` — \"Descending staircase in center of lower chamber\"

## Test plan

- [x] `./gradlew :knes-agent:test` — 205 pass / 2 pre-existing fails / 7 skipped (+8 new tests vs. master)
- [x] Live `runExplorer` with cleared `~/.knes/ff1-landmarks.json` — Phase 1.5 + 2 validated end-to-end (NPC entries written, cost > 0)