### PR TITLE
diag: log mapId at trigger and post-explore in handleNewInterior

### DIFF
--- a/knes-agent/src/main/kotlin/knes/agent/explorer/SingleRun.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/explorer/SingleRun.kt
@@ -117,6 +117,9 @@ class SingleRun(
         val ram = observer.ramSnapshot()
         // Pre-record the entry as a TOWN/CASTLE/DUNGEON_ENTRY landmark (visited=true).
         val cx = ram["worldX"] ?: 0; val cy = ram["worldY"] ?: 0
+        val mapIdAtTrigger = ram["currentMapId"] ?: -1
+        val mapflagsAtTrigger = ram["mapflags"] ?: -1
+        System.err.println("[mapid-diag] $runId enter: trigger.mapId=${t.mapId} ramMapId=$mapIdAtTrigger mapflags=$mapflagsAtTrigger world=($cx,$cy)")
         landmarkMemory.recordIfNew(Landmark(
             id = "interior_entry_${t.mapId}_${cx}_${cy}",
             kind = guessEntryKind(t.mapId),
@@ -128,6 +131,14 @@ class SingleRun(
         // Run the deterministic interior explorer.
         skillRegistry.exploreInteriorFrontier(maxSteps = 80)
         // Post-explore: ask Haiku to classify what we saw.
+        val ramAfter = observer.ramSnapshot()
+        val mapIdAfter = ramAfter["currentMapId"] ?: -1
+        val mapflagsAfter = ramAfter["mapflags"] ?: -1
+        val pxAfter = ramAfter["smPlayerX"] ?: -1; val pyAfter = ramAfter["smPlayerY"] ?: -1
+        System.err.println("[mapid-diag] $runId post-explore: ramMapId=$mapIdAfter mapflags=$mapflagsAfter party=($pxAfter,$pyAfter)")
+        if (mapIdAfter != t.mapId) {
+            System.err.println("[mapid-diag] $runId MISMATCH: trigger.mapId=${t.mapId} != ramMapId=$mapIdAfter — Haiku screenshot is from $mapIdAfter but classification will tag mapId=${t.mapId}")
+        }
         val visited = interiorMemory.visited(t.mapId)
         val b64 = runCatching { toolset.getScreen().base64 }.getOrNull()
         val classification = haikuConsult.classifyInterior(


### PR DESCRIPTION
## Summary
- Phase 1 of debugging the Phase 1.5 mapId mismatch (Haiku described a throne room while the landmark recorded `mapIdInterior=8` Coneria Town).
- Emits stderr `[mapid-diag]` lines bracketing the 80-step `exploreInteriorFrontier` window so we can see whether the agent transitions between maps mid-explore (e.g. via stairs at mapId=8 (12,18) → mapId=24).
- No behaviour change — pure `System.err.println`.

## Why this code, why now
Three competing root-cause hypotheses identified during investigation:
1. Phase classifier returns wrong mapId at trigger time (transient RAM).
2. Agent walks down stairs during 80-step explore → screenshot is from a deeper map than `t.mapId`.
3. Coneria warp memory annotation is wrong / stale (note says "mapId=8 outer overlay → mapId=24 inner"; `OverworldWarpMemory.kt:13` claims (145,152) → mapId=24 directly).

Existing data is insufficient to distinguish — `ExplorerSession` does not write `trace.jsonl`, and the prior live campaign's stderr was not captured.

## Test plan
- [x] Compiles.
- [x] Full suite: 205 pass / 2 pre-existing fail (`Coneria8VisualDiffTest`, `ConeriaTownEmpiricalDiscoveryTest`) / 7 skipped — same as master baseline.
- [ ] Live: run `./gradlew :knes-agent:runExplorer 2> /tmp/mapid-diag.log` with a cleared `~/.knes/ff1-landmarks.json`, inspect `[mapid-diag]` lines + correlate with Haiku classifications.