### PR TITLE
fix(explorer): live mapId tag + skip Haiku on wipe / overworld

### DIFF
--- a/knes-agent/src/main/kotlin/knes/agent/explorer/SingleRun.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/explorer/SingleRun.kt
@@ -23,6 +23,8 @@ sealed interface Trigger {
     object BattleEntered : Trigger
 }
 
+data class ClassifyDecision(val mapIdToUse: Int)
+
 class SingleRun(
     private val runId: String,
     private val toolset: EmulatorToolset,
@@ -78,7 +80,8 @@ class SingleRun(
             when (trigger) {
                 is Trigger.NewInteriorEntered -> {
                     novelMapIdsThisRun += trigger.mapId
-                    handleNewInterior(trigger)
+                    val effective = handleNewInterior(trigger)
+                    if (effective != null) novelMapIdsThisRun += effective
                 }
                 Trigger.DialogBoxVisible -> handleDialog()
                 Trigger.BattleEntered -> handleBattle()
@@ -113,27 +116,41 @@ class SingleRun(
         return false
     }
 
-    private suspend fun handleNewInterior(t: Trigger.NewInteriorEntered) {
+    /** Returns the effective mapId actually classified, which may differ from
+     *  the trigger mapId if the engine completed a multi-stage warp transition
+     *  between trigger fire and snapshot, or null if classification was skipped
+     *  (party wiped or returned to overworld during the 80-step explore). */
+    private suspend fun handleNewInterior(t: Trigger.NewInteriorEntered): Int? {
         val ram = observer.ramSnapshot()
-        // Pre-record the entry as a TOWN/CASTLE/DUNGEON_ENTRY landmark (visited=true).
+        // Use RAM-stable mapId rather than trigger mapId for the entry landmark.
+        // FF1 warp transitions briefly expose a transient currentMapId during the
+        // engine handoff (e.g. (145,152) Coneria warp shows mapId=8 outer overlay
+        // before settling on mapId=24 inner). By the time we read RAM here the
+        // value has stabilised. Fall back to trigger.mapId if RAM is unreadable.
         val cx = ram["worldX"] ?: 0; val cy = ram["worldY"] ?: 0
+        val entryMapId = ram["currentMapId"]?.takeIf { it >= 0 } ?: t.mapId
         landmarkMemory.recordIfNew(Landmark(
-            id = "interior_entry_${t.mapId}_${cx}_${cy}",
-            kind = guessEntryKind(t.mapId),
+            id = "interior_entry_${entryMapId}_${cx}_${cy}",
+            kind = guessEntryKind(entryMapId),
             worldX = cx, worldY = cy,
-            mapIdInterior = t.mapId,
+            mapIdInterior = entryMapId,
             visited = true,
             discoveredRunId = runId,
         ))
-        // Run the deterministic interior explorer.
         skillRegistry.exploreInteriorFrontier(maxSteps = 80)
-        // Post-explore: ask Haiku to classify what we saw.
-        val visited = interiorMemory.visited(t.mapId)
+        // PartyWipe during exploration would cause `getScreen()` to return the
+        // game-over / title-screen frame, and a sub-map transition would leave
+        // the screenshot showing a different interior than the entry landmark.
+        // decideClassification gates both cases.
+        val ramAfter = observer.ramSnapshot()
+        val decision = decideClassification(entryMapId, ramAfter) ?: return entryMapId
+        val visited = interiorMemory.visited(decision.mapIdToUse)
         val b64 = runCatching { toolset.getScreen().base64 }.getOrNull()
         val classification = haikuConsult.classifyInterior(
-            mapId = t.mapId, visitedTileCount = visited.size, screenshotBase64 = b64, runId = runId,
+            mapId = decision.mapIdToUse, visitedTileCount = visited.size, screenshotBase64 = b64, runId = runId,
         )
         haikuCostUsd += applyInteriorClassification(landmarkMemory, classification)
+        return decision.mapIdToUse
     }
 
     private suspend fun handleDialog() {
@@ -247,6 +264,25 @@ class SingleRun(
         ): Double {
             classification.landmarks.forEach { landmarkMemory.recordIfNew(it) }
             return classification.costUsd
+        }
+
+        /** Decides whether the post-explore Haiku call should run, and which
+         *  mapId to tag its landmarks with. Returns null to skip — either the
+         *  party died (HP=0, screenshot would be game-over) or the engine left
+         *  the interior (mapflags=0, screenshot would be the overworld). When
+         *  RAM still reports an interior, prefers the live mapId over the
+         *  trigger mapId so multi-stage warps are tagged with the inner map. */
+        fun decideClassification(
+            triggerMapId: Int,
+            ramAfterExplore: Map<String, Int>,
+        ): ClassifyDecision? {
+            val mapflags = (ramAfterExplore["mapflags"] ?: 0) and 0x01
+            val hpSum = (1..4).sumOf { ramAfterExplore["char${it}_hpLow"] ?: 0 }
+            if (hpSum == 0) return null
+            if (mapflags != 1) return null
+            val ramMapId = ramAfterExplore["currentMapId"] ?: -1
+            val effective = if (ramMapId >= 0) ramMapId else triggerMapId
+            return ClassifyDecision(mapIdToUse = effective)
         }
 
         fun checkRestart(

--- a/knes-agent/src/test/kotlin/knes/agent/explorer/SingleRunHandleNewInteriorTest.kt
+++ b/knes-agent/src/test/kotlin/knes/agent/explorer/SingleRunHandleNewInteriorTest.kt
@@ -33,4 +33,48 @@ class SingleRunHandleNewInteriorTest : FunSpec({
         landmarks.findByKind(LandmarkKind.NPC_KING) shouldHaveSize 1
         landmarks.findByKind(LandmarkKind.NPC_KING).first().visited shouldBe true
     }
+
+    test("decideClassification skips when party HP is zero (game over)") {
+        // PartyWipe during exploreInteriorFrontier returns the player to the
+        // title screen; getScreen() then captures a frame Haiku misreads as
+        // interior content (e.g. "person sprite next to NEW GAME text").
+        val ram = mapOf(
+            "mapflags" to 1, "currentMapId" to 8,
+            "char1_hpLow" to 0, "char2_hpLow" to 0,
+            "char3_hpLow" to 0, "char4_hpLow" to 0,
+        )
+        SingleRun.decideClassification(triggerMapId = 8, ramAfterExplore = ram) shouldBe null
+    }
+
+    test("decideClassification skips when mapflags=0 (engine returned to overworld)") {
+        val ram = mapOf(
+            "mapflags" to 0, "currentMapId" to 8,
+            "char1_hpLow" to 35, "char2_hpLow" to 30,
+            "char3_hpLow" to 28, "char4_hpLow" to 25,
+        )
+        SingleRun.decideClassification(triggerMapId = 8, ramAfterExplore = ram) shouldBe null
+    }
+
+    test("decideClassification uses live RAM mapId when engine completed multi-stage warp") {
+        // (145,152) Coneria warp: trigger fires at transient mapId=8 outer
+        // overlay; RAM stabilises to inner mapId=24 by the time we reach the
+        // post-explore snapshot. Haiku must tag with 24, not 8.
+        val ram = mapOf(
+            "mapflags" to 1, "currentMapId" to 24,
+            "char1_hpLow" to 35, "char2_hpLow" to 30,
+            "char3_hpLow" to 28, "char4_hpLow" to 25,
+        )
+        SingleRun.decideClassification(triggerMapId = 8, ramAfterExplore = ram) shouldBe
+            ClassifyDecision(mapIdToUse = 24)
+    }
+
+    test("decideClassification falls back to trigger mapId when RAM unreadable") {
+        val ram = mapOf(
+            "mapflags" to 1,
+            "char1_hpLow" to 35, "char2_hpLow" to 30,
+            "char3_hpLow" to 28, "char4_hpLow" to 25,
+        )
+        SingleRun.decideClassification(triggerMapId = 8, ramAfterExplore = ram) shouldBe
+            ClassifyDecision(mapIdToUse = 8)
+    }
 })


### PR DESCRIPTION
Phase 3 fix for the mapId mismatch surfaced by Phase 1.5 — supersedes the diagnostic-only #105 (which can be closed unmerged; root cause confirmed live, no need to keep printlns).

## Two bugs in `handleNewInterior`

### A. Stale `t.mapId` tag
`trigger.mapId` is captured at the instant `phase` becomes `Indoors`, but FF1 multi-stage warps (e.g. (145,152) Coneria warp → `mapId=8` outer overlay → `mapId=24` inner — see `OverworldWarpMemory.kt:13`) briefly expose a transient `currentMapId` before settling. By the first `ramSnapshot()` inside `handleNewInterior` the value has stabilised. The entry landmark and the Haiku call now both use the live RAM `currentMapId`, falling back to `t.mapId` only if RAM is unreadable.

### B. PartyWipe / overworld-return corrupts the Haiku call
A wipe inside the 80-step `exploreInteriorFrontier` returns the player to the title screen; the post-explore `getScreen()` captures that frame and Haiku misclassifies UI text as interior content. **Live evidence (run-1 of diagnostic campaign, mapId=8 fixture):** `NPC_GENERIC` recorded with note _"Small figure sprite to the left of 'NEW GAME' text"_, tagged `mapId=8`. New `decideClassification` companion-helper gates the Haiku call on `mapflags=1 && hpSum > 0`.

`handleNewInterior` now returns the effective mapId so the caller adds **both** `trigger.mapId` and the stabilised mapId to `novelMapIdsThisRun` — otherwise a completed-during-explore warp would re-fire the trigger next iteration.

## Live evidence (driving the diagnosis)
With diagnostic printlns from #105:

| Run (fixture savestate) | trigger.mapId | post-explore mapId | stop | Haiku |
|--|--|--|--|--|
| 1 | 8 | 8 | **PartyWiped** | "Person sprite next to NEW GAME text" — title-screen artifact |
| 2 | 8 | 8 | Idle | 3× NPC_GENERIC + STAIRS_DOWN — proper Coneria Town interior |

Run-2 confirms `mapId=8` is genuinely Coneria Town (no throne). Morning's "throne room" classification at world (145, 152) was therefore not a mapId=8 interior — it was the (145,152) → mapId=24 multi-stage warp inner map mis-tagged as 8.

## Test plan
- [x] 4 new unit tests for `decideClassification`: HP=0, mapflags=0, multi-stage warp, RAM-unreadable.
- [x] Full suite: **209 pass / 2 pre-existing fail / 7 skipped** (Coneria8VisualDiffTest + ConeriaTownEmpiricalDiscoveryTest unchanged from master baseline).
- [ ] Live re-run with cleared `~/.knes/` (already archived to `archive-2026-05-05-pre-mapid-fix/`) to confirm landmarks are tagged with the inner mapId and PartyWipe runs leave no Haiku artifacts.