### PR TITLE
feat(salience): priority 0 — target known warp tiles deliberately

### DIFF
--- a/knes-agent/src/main/kotlin/knes/agent/explorer/ExplorerSession.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/explorer/ExplorerSession.kt
@@ -73,7 +73,7 @@ class ExplorerSession(
     private val savedState: ByteArray,
     private val budget: CampaignBudget = CampaignBudget(),
 ) {
-    private val salience = SalienceStrategy(terrainMemory, landmarkMemory, blockageMemory, fog)
+    private val salience = SalienceStrategy(terrainMemory, landmarkMemory, blockageMemory, fog, warpMemory)
 
     suspend fun run(): CampaignResult {
         var runs = 0

--- a/knes-agent/src/main/kotlin/knes/agent/explorer/SalienceStrategy.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/explorer/SalienceStrategy.kt
@@ -6,6 +6,7 @@ import knes.agent.perception.Landmark
 import knes.agent.perception.LandmarkKind
 import knes.agent.perception.LandmarkMemory
 import knes.agent.perception.OverworldTerrainMemory
+import knes.agent.perception.OverworldWarpMemory
 import knes.agent.perception.TileType
 import knes.agent.perception.ViewportMap
 import java.time.Duration
@@ -21,15 +22,32 @@ class SalienceStrategy(
     private val landmarkMemory: LandmarkMemory,
     private val blockageMemory: BlockageMemory,
     private val fog: FogOfWar,
+    private val warpMemory: OverworldWarpMemory? = null,
     private val recentFailureWindow: Duration = Duration.ofMinutes(10),
     private val frontierRadius: Int = 20,
     /** Distance ceiling for tile-tagged landmark candidates (mapIdInterior == null).
      *  Confirmed entries (mapIdInterior != null) ignore this. Default 2 × frontierRadius. */
     private val tileTaggedDistanceLimit: Int = 40,
 ) {
-    fun pickOverworldTarget(currentXY: Pair<Int, Int>, viewport: ViewportMap): Pair<Int, Int> {
+    fun pickOverworldTarget(
+        currentXY: Pair<Int, Int>,
+        viewport: ViewportMap,
+        enteredWarpsThisRun: Set<Pair<Int, Int>> = emptySet(),
+    ): Pair<Int, Int> {
         val recentlyFailed = blockageMemory.recentlyFailedTargets(recentFailureWindow)
         val asKey: (Pair<Int, Int>) -> String = { "${it.first},${it.second}" }
+
+        // Priority 0: known warp tile not yet entered this run. OverworldWarpMemory
+        // carries cross-session evidence that the tile triggers an interior — without
+        // this, the explorer's deterministic salience plateaus at 17 runs / 0 entries
+        // because BFS routes around warp tiles toward viewport TOWN/CASTLE candidates
+        // (priority 2) that may be unreachable. Targeting warps directly turns the
+        // explorer from lucky discovery into purposeful coverage.
+        warpMemory?.all()
+            ?.filter { it !in enteredWarpsThisRun }
+            ?.filter { asKey(it) !in recentlyFailed }
+            ?.minByOrNull { manhattan(currentXY, it) }
+            ?.let { return it }
 
         val unvisited = landmarkMemory.findByKind(
                 LandmarkKind.TOWN_ENTRY, LandmarkKind.CASTLE_ENTRY, LandmarkKind.DUNGEON_ENTRY,

--- a/knes-agent/src/main/kotlin/knes/agent/explorer/SingleRun.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/explorer/SingleRun.kt
@@ -53,6 +53,9 @@ class SingleRun(
      *  classification ever firing on previously-seen maps across sessions. Now bounded
      *  by ~3-5 maps per run; each run gets one classification per visited interior. */
     private val novelMapIdsThisRun: MutableSet<Int> = mutableSetOf()
+    /** Per-run set of overworld warp tiles already entered. Drives SalienceStrategy
+     *  priority 0 — once we've taken a warp this run, target the next nearest one. */
+    private val enteredWarpsThisRun: MutableSet<Pair<Int, Int>> = mutableSetOf()
 
     suspend fun execute(): RunResult {
         var stepsTaken = 0
@@ -128,6 +131,7 @@ class SingleRun(
         // before settling on mapId=24 inner). By the time we read RAM here the
         // value has stabilised. Fall back to trigger.mapId if RAM is unreadable.
         val cx = ram["worldX"] ?: 0; val cy = ram["worldY"] ?: 0
+        enteredWarpsThisRun += (cx to cy)
         val entryMapId = ram["currentMapId"]?.takeIf { it >= 0 } ?: t.mapId
         landmarkMemory.recordIfNew(Landmark(
             id = "interior_entry_${entryMapId}_${cx}_${cy}",
@@ -200,7 +204,10 @@ class SingleRun(
                     firstStartDirection = pickInitialCardinal(cx to cy, viewport)
                     blockageMemory.recordRunStartDirection(runId, firstStartDirection ?: "?")
                 }
-                val target = salience.pickOverworldTarget(currentXY = cx to cy, viewport = viewport)
+                val target = salience.pickOverworldTarget(
+                    currentXY = cx to cy, viewport = viewport,
+                    enteredWarpsThisRun = enteredWarpsThisRun,
+                )
                 val res = skillRegistry.exploreOverworldFrontier(target.first, target.second)
                 if (!res.ok) {
                     blockageMemory.record(runId, from = cx to cy,

--- a/knes-agent/src/test/kotlin/knes/agent/explorer/SalienceStrategyTest.kt
+++ b/knes-agent/src/test/kotlin/knes/agent/explorer/SalienceStrategyTest.kt
@@ -8,6 +8,7 @@ import knes.agent.perception.Landmark
 import knes.agent.perception.LandmarkKind
 import knes.agent.perception.LandmarkMemory
 import knes.agent.perception.OverworldTerrainMemory
+import knes.agent.perception.OverworldWarpMemory
 import knes.agent.perception.TileType
 import knes.agent.perception.ViewportMap
 import java.nio.file.Files
@@ -196,5 +197,64 @@ class SalienceStrategyTest : FunSpec({
         // We expect a real frontier tile. 146,158 yields itself (distance 0). That's the chosen target.
         target.first shouldBe 146
         target.second shouldBe 158
+    }
+
+    test("priority 0: known warp not yet entered this run is targeted, beating priority 1A") {
+        // Both a confirmed entry (priority 1A, distance 50) and a known warp (priority 0,
+        // distance 6) exist; priority 0 must win because OverworldWarpMemory carries
+        // cross-session evidence the warp triggers an interior, while a confirmed entry
+        // at (200,200) might still need the matching warp tile to be walked over.
+        val landmarks = LandmarkMemory(file = tmp("l"))
+        landmarks.record(Landmark(id = "far_confirmed", kind = LandmarkKind.TOWN_ENTRY,
+            worldX = 200, worldY = 200, mapIdInterior = 8, visited = false))
+        val warps = OverworldWarpMemory(file = tmp("w"))
+        warps.record(worldX = 145, worldY = 152, mapId = 8)
+        val strategy = SalienceStrategy(
+            terrainMemory = OverworldTerrainMemory(file = tmp("t")),
+            landmarkMemory = landmarks,
+            blockageMemory = BlockageMemory(file = tmp("b")),
+            fog = FogOfWar(),
+            warpMemory = warps,
+        )
+        val target = strategy.pickOverworldTarget(currentXY = 146 to 158,
+            viewport = viewportAllGrass(146 to 158))
+        target shouldBe (145 to 152)
+    }
+
+    test("priority 0: warp already entered this run is skipped — falls through to next priority") {
+        val landmarks = LandmarkMemory(file = tmp("l"))
+        landmarks.record(Landmark(id = "far_confirmed", kind = LandmarkKind.TOWN_ENTRY,
+            worldX = 200, worldY = 200, mapIdInterior = 8, visited = false))
+        val warps = OverworldWarpMemory(file = tmp("w"))
+        warps.record(worldX = 145, worldY = 152, mapId = 8)
+        val strategy = SalienceStrategy(
+            terrainMemory = OverworldTerrainMemory(file = tmp("t")),
+            landmarkMemory = landmarks,
+            blockageMemory = BlockageMemory(file = tmp("b")),
+            fog = FogOfWar(),
+            warpMemory = warps,
+        )
+        val target = strategy.pickOverworldTarget(currentXY = 146 to 158,
+            viewport = viewportAllGrass(146 to 158),
+            enteredWarpsThisRun = setOf(145 to 152))
+        // (145,152) is excluded; falls through to priority 1A (confirmed entry at 200,200).
+        target shouldBe (200 to 200)
+    }
+
+    test("priority 0: closest of multiple warps wins") {
+        val warps = OverworldWarpMemory(file = tmp("w"))
+        warps.record(worldX = 145, worldY = 152) // distance 7
+        warps.record(worldX = 100, worldY = 100) // distance 104
+        warps.record(worldX = 150, worldY = 160) // distance 6
+        val strategy = SalienceStrategy(
+            terrainMemory = OverworldTerrainMemory(file = tmp("t")),
+            landmarkMemory = LandmarkMemory(file = tmp("l")),
+            blockageMemory = BlockageMemory(file = tmp("b")),
+            fog = FogOfWar(),
+            warpMemory = warps,
+        )
+        val target = strategy.pickOverworldTarget(currentXY = 146 to 158,
+            viewport = viewportAllGrass(146 to 158))
+        target shouldBe (150 to 160)
     }
 })


### PR DESCRIPTION
## Why

ExplorerSession's deterministic salience plateaus at **17 runs / 0 entries** on the overworld savestate. The agent walks toward viewport TOWN/CASTLE candidates (priority 2), BFS routes around the actual warp tiles, and the idle threshold fires before any interior is entered. Without entries, every campaign costs \$0 and produces no Haiku data — and #106's Fix A (live mapId tag for multi-stage warps) cannot be verified live.

`OverworldWarpMemory` already persists cross-session evidence that specific tiles trigger interiors (`~/.knes/ff1-overworld-warps.json`, e.g. (145,152) Coneria warp). Targeting them deliberately turns the explorer from _lucky discovery_ (relying on BFS routing through a warp tile incidentally) into _purposeful coverage_.

## What

- `SalienceStrategy` gains `warpMemory: OverworldWarpMemory?` (nullable — tests that don't care leave it null).
- `pickOverworldTarget` gains `enteredWarpsThisRun: Set<Pair<Int,Int>>` (default empty).
- New **priority 0**: closest known warp tile not yet entered this run, filtered against `recentlyFailed`. Beats priority 1A.
- `SingleRun` tracks `enteredWarpsThisRun` and adds `(cx, cy)` at the start of `handleNewInterior`. Threaded through.

## Test plan
- [x] 3 new unit tests: priority 0 picks closest / skips already-entered / closest-of-multiple wins.
- [x] Full suite: **212 pass / 2 pre-existing fail / 7 skipped** (Coneria8VisualDiffTest + ConeriaTownEmpiricalDiscoveryTest unchanged from master baseline).
- [ ] Live: re-run `runExplorer` on `ff1-post-boot` overworld savestate; expect run-1 to enter (145,152) and confirm Fix A tagging now produces `mapIdInterior=24` (not 8) per the warp's documented inner mapId.