### PR TITLE
fix(salience): priority 0 must not filter recentlyFailed (V5.2 quirk)

### DIFF
--- a/knes-agent/src/main/kotlin/knes/agent/explorer/SalienceStrategy.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/explorer/SalienceStrategy.kt
@@ -43,9 +43,15 @@ class SalienceStrategy(
         // because BFS routes around warp tiles toward viewport TOWN/CASTLE candidates
         // (priority 2) that may be unreachable. Targeting warps directly turns the
         // explorer from lucky discovery into purposeful coverage.
+        //
+        // Deliberately bypasses the global recentlyFailed window: post-loadState the
+        // emulator drops a few input frames (V5.2 "input not responding" quirk), which
+        // poisons every warp the moment we try it. Filtering by recentlyFailed there
+        // permanently disqualifies known-good warps for 10 minutes across runs. The
+        // per-run enteredWarpsThisRun set is the right gate — once we've actually
+        // entered a warp, we don't re-target it for the rest of the run.
         warpMemory?.all()
             ?.filter { it !in enteredWarpsThisRun }
-            ?.filter { asKey(it) !in recentlyFailed }
             ?.minByOrNull { manhattan(currentXY, it) }
             ?.let { return it }
 

--- a/knes-agent/src/test/kotlin/knes/agent/explorer/SalienceStrategyTest.kt
+++ b/knes-agent/src/test/kotlin/knes/agent/explorer/SalienceStrategyTest.kt
@@ -241,6 +241,30 @@ class SalienceStrategyTest : FunSpec({
         target shouldBe (200 to 200)
     }
 
+    test("priority 0: warp in recentlyFailed is still retried — only enteredWarpsThisRun gates it") {
+        // Post-loadState the emulator drops a few input frames (V5.2 "input not
+        // responding"). On run 1 the very first attempt at the closest warp fails
+        // and the warp lands in recentlyFailed (10-minute global window). If we
+        // filtered priority 0 by recentlyFailed, every subsequent run for the next
+        // 10 minutes would skip the real Coneria warp and idle out. enteredWarps-
+        // ThisRun is the correct gate.
+        val warps = OverworldWarpMemory(file = tmp("w"))
+        warps.record(worldX = 145, worldY = 152, mapId = 8)
+        val blockages = BlockageMemory(file = tmp("b"))
+        blockages.record(runId = "prev", from = 146 to 158, attemptedTo = "145,152",
+            result = "input not responding")
+        val strategy = SalienceStrategy(
+            terrainMemory = OverworldTerrainMemory(file = tmp("t")),
+            landmarkMemory = LandmarkMemory(file = tmp("l")),
+            blockageMemory = blockages,
+            fog = FogOfWar(),
+            warpMemory = warps,
+        )
+        val target = strategy.pickOverworldTarget(currentXY = 146 to 158,
+            viewport = viewportAllGrass(146 to 158))
+        target shouldBe (145 to 152)
+    }
+
     test("priority 0: closest of multiple warps wins") {
         val warps = OverworldWarpMemory(file = tmp("w"))
         warps.record(worldX = 145, worldY = 152) // distance 7


### PR DESCRIPTION
Follow-up to #107. Live verification surfaced a poisoning interaction with the V5.2 "input not responding" loadState quirk.

## Problem
Live overworld run with #107 merged plateaued at **3 runs / 0 entries**. Trace:
\`\`\`
"input not responding: 3 consecutive non-moving steps from (146,158) toward (147,154).
 Likely cause: fixture loadState quirk (V5.2) or party physically boxed in by terrain."
\`\`\`
The very first warp attempt fails because the emulator drops a few input frames after \`loadState\`. The warp lands in \`BlockageMemory\`'s \`recentlyFailed\` (10-minute global window). For the next 10 minutes, every run skips the real warp tile and idles out.

## Fix
Priority 0's purpose is *deliberate retry of known-good warps*. The right gate is per-run \`enteredWarpsThisRun\` (only set after a successful entry), not the global blockage window. Once we've actually entered a warp this run, we don't re-target it. Until then we keep trying — by run 2 the loadState quirk has cleared and the warp succeeds.

Other priorities still respect \`recentlyFailed\` (their targets are heuristic / viewport candidates that genuinely shouldn't be retried).

## Test plan
- [x] 1 new unit test: warp in \`recentlyFailed\` is still picked by priority 0 when absent from \`enteredWarpsThisRun\`.
- [x] Full suite: **213 pass / 2 pre-existing fail / 7 skipped** (Coneria8VisualDiffTest + ConeriaTownEmpiricalDiscoveryTest unchanged from master baseline).
- [ ] Live: re-run \`runExplorer\` on \`ff1-post-boot\`; expect run 1 or 2 to enter (147,154) or (145,152) and tag \`mapIdInterior\` with the live RAM mapId (closing the live verification of #106's Fix A).