### PR TITLE
fix(agent): filter mapId=0 in auto-detected warps

### DIFF
--- a/knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt
@@ -73,9 +73,7 @@ class AgentSession(
         // here and inject into both advisor and executor observations so neither suggests
         // routing back through a known warp.
         val failedWarpTiles: MutableSet<Pair<Int, Int>> = mutableSetOf()
-        // Match toolCallLog format: "entered interior after N steps; world=(X,Y) ... targeted=false"
-        // (set by WalkOverworldTo.kt when an UNEXPECTED interior was entered mid-route).
-        val failedRegex = Regex("""world=\((\d+),(\d+)\)[^|]*targeted=false""")
+        val failedRegex = FAILED_WARP_REGEX
         // V5.25: pre-seed from persistent memory so the very first walk in
         // this run already knows about warps detected in earlier sessions.
         // Both the LLM hint (text injection) and the deterministic fog block
@@ -193,6 +191,13 @@ class AgentSession(
                 drainedCalls.forEach { call ->
                     failedRegex.findAll(call).forEach { m ->
                         val tile = m.groupValues[1].toInt() to m.groupValues[2].toInt()
+                        val transitionMapId = m.groupValues[3].toInt()
+                        // mapId=0 + mapflags=1 is UnknownMapTrap (engine void), not a real
+                        // interior. Recording it as a warp would dead-end priority-0 targeting.
+                        if (transitionMapId == 0) {
+                            println("[session-memory] skip warp record at $tile (mapId=0 trap, not real interior)")
+                            return@forEach
+                        }
                         if (failedWarpTiles.add(tile)) {
                             println("[session-memory] +failedWarpTile=$tile (total=${failedWarpTiles.size})")
                             // V5.28: 1x1 block. Was 3x3 in V5.24 on the assumption
@@ -207,6 +212,7 @@ class AgentSession(
                             // V5.25: persist for future sessions. Save immediately
                             // so a crash mid-run doesn't lose the discovery.
                             warpMemory.record(tile.first, tile.second,
+                                mapId = transitionMapId,
                                 note = "auto-detected ${java.time.Instant.now()}")
                             warpMemory.save()
                         }
@@ -239,5 +245,16 @@ class AgentSession(
         } finally {
             trace.close()
         }
+    }
+
+    companion object {
+        /** Matches `WalkOverworldTo`'s `aborted` toolCallLog entry:
+         *  `"entered interior after N steps; world=(X,Y) mapId=M party=(...) targeted=false"`.
+         *  Capture groups: 1=worldX, 2=worldY, 3=mapId.
+         *
+         *  The mapId capture lets the auto-detect filter out UnknownMapTrap (mapId=0)
+         *  transitions — they don't lead to a real interior, just engine void state, and
+         *  recording them as warps would dead-end priority-0 warp targeting next campaign. */
+        val FAILED_WARP_REGEX = Regex("""world=\((\d+),(\d+)\) mapId=(-?\d+)[^|]*targeted=false""")
     }
 }

--- a/knes-agent/src/test/kotlin/knes/agent/runtime/AgentSessionFailedWarpRegexTest.kt
+++ b/knes-agent/src/test/kotlin/knes/agent/runtime/AgentSessionFailedWarpRegexTest.kt
@@ -1,0 +1,48 @@
+package knes.agent.runtime
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/** Tests the regex used by AgentSession to extract UNEXPECTED interior entries
+ *  from toolCallLog entries written by WalkOverworldTo.aborted (targeted=false).
+ *  Critical that the mapId capture works correctly — mapId=0 indicates an
+ *  UnknownMapTrap, which should NOT be recorded as a warp. */
+class AgentSessionFailedWarpRegexTest : FunSpec({
+    test("captures world coords AND mapId from a real WalkOverworldTo abort message") {
+        val msg = "walkOverworldTo.aborted=entered interior after 6 steps; " +
+            "world=(147,155) mapId=0 party=(16,23) targeted=false"
+        val m = AgentSession.FAILED_WARP_REGEX.find(msg)!!
+        m.groupValues[1] shouldBe "147"
+        m.groupValues[2] shouldBe "155"
+        m.groupValues[3] shouldBe "0"
+    }
+
+    test("captures non-zero mapId — real warp transitions like Coneria mapId=8") {
+        val msg = "walkOverworldTo.aborted=entered interior after 4 steps; " +
+            "world=(145,152) mapId=8 party=(11,32) targeted=false"
+        val m = AgentSession.FAILED_WARP_REGEX.find(msg)!!
+        m.groupValues[1] shouldBe "145"
+        m.groupValues[2] shouldBe "152"
+        m.groupValues[3] shouldBe "8"
+    }
+
+    test("does not match targeted=true (successful entry, not auto-detect candidate)") {
+        val msg = "walkOverworldTo.aborted=entered interior after 4 steps; " +
+            "world=(145,152) mapId=8 party=(11,32) targeted=true"
+        AgentSession.FAILED_WARP_REGEX.find(msg) shouldBe null
+    }
+
+    test("captures mapId across the world→targeted span containing party=(...)") {
+        // Make sure the [^|]* between mapId and targeted doesn't break on the
+        // party= field's parentheses.
+        val msg = "world=(99,88) mapId=42 party=(7,7) extra=garbage targeted=false"
+        val m = AgentSession.FAILED_WARP_REGEX.find(msg)!!
+        m.groupValues[3] shouldBe "42"
+    }
+
+    test("handles negative mapId (-1 sentinel from RamObserver fallback)") {
+        val msg = "world=(10,20) mapId=-1 party=(0,0) targeted=false"
+        val m = AgentSession.FAILED_WARP_REGEX.find(msg)!!
+        m.groupValues[3] shouldBe "-1"
+    }
+})


### PR DESCRIPTION
Closes Priority A from prior HANDOFF: UnknownMapTrap (mapId=0 + mapflags=1) transitions were being auto-detected as warps in \`OverworldWarpMemory\`, then priority-0 targeting next campaign would dead-end every run there.

## What was wrong
\`AgentSession\`'s \`failedRegex\` matched \`world=(X,Y)...targeted=false\` from \`WalkOverworldTo.aborted\` log entries but ignored the \`mapId=N\` field in the same message. Every "UNEXPECTED interior entry", real or trap, got recorded as a warp.

Tonight's live verification surfaced this: \`(147,154)\` was auto-detected as a warp from a prior campaign, but transitions there land at \`mapId=0 party=(16,23)\` — engine void, not a real interior. Priority-0 targeted (147,154) every overworld run, hit UnknownMapTrap, never made progress.

## Fix
- Extend regex to capture \`mapId\` (3rd group).
- Skip recording when \`mapId == 0\`; log instead.
- Pass captured \`mapId\` to \`warpMemory.record(...)\` so future entries have the actual interior mapId (was defaulting to 0 because the call didn't pass one).
- Extract regex to \`AgentSession.FAILED_WARP_REGEX\` companion for testing.

## Test plan
- [x] 5 new regex tests: real abort message format / non-zero mapId capture / \`targeted=true\` exclusion / negative-mapId fallback / capture across \`party=\` field.
- [x] Full suite: **218 pass / 2 pre-existing fail / 7 skipped**.

## Out of scope
Existing entries in \`~/.knes/ff1-overworld-warps.json\` with default \`mapId=0\` are NOT removed on load — they're ambiguous (real warp recorded pre-PR vs UnknownMapTrap recorded pre-PR). Manual cleanup if needed; future records will have correct mapId.