### PR TITLE
fix(explorer): skip handleNewInterior when ram mapId=0 (UnknownMapTrap)

### DIFF
--- a/knes-agent/src/main/kotlin/knes/agent/explorer/SingleRun.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/explorer/SingleRun.kt
@@ -122,17 +122,28 @@ class SingleRun(
     /** Returns the effective mapId actually classified, which may differ from
      *  the trigger mapId if the engine completed a multi-stage warp transition
      *  between trigger fire and snapshot, or null if classification was skipped
-     *  (party wiped or returned to overworld during the 80-step explore). */
+     *  (party wiped, returned to overworld, or void state mapId=0). */
     private suspend fun handleNewInterior(t: Trigger.NewInteriorEntered): Int? {
         val ram = observer.ramSnapshot()
+        val cx = ram["worldX"] ?: 0; val cy = ram["worldY"] ?: 0
+        enteredWarpsThisRun += (cx to cy)
+        // mapId=0 + mapflags=1 is UnknownMapTrap (engine void state, e.g. the
+        // transition pseudo-map reached after stepping on (147,154) bogus warp).
+        // The screen renders an outer-overlay frame Haiku misreads as a throne
+        // room with a king (verified live: 4 false NPC_KING/STAIRS landmarks
+        // produced from the INN sign + party sprite). Don't record an entry,
+        // don't call Haiku — just return early.
+        val ramMapId = ram["currentMapId"] ?: -1
+        if (ramMapId == 0) {
+            System.err.println("[explorer] handleNewInterior skipped: ram mapId=0 (UnknownMapTrap), world=($cx,$cy)")
+            return null
+        }
         // Use RAM-stable mapId rather than trigger mapId for the entry landmark.
         // FF1 warp transitions briefly expose a transient currentMapId during the
         // engine handoff (e.g. (145,152) Coneria warp shows mapId=8 outer overlay
         // before settling on mapId=24 inner). By the time we read RAM here the
         // value has stabilised. Fall back to trigger.mapId if RAM is unreadable.
-        val cx = ram["worldX"] ?: 0; val cy = ram["worldY"] ?: 0
-        enteredWarpsThisRun += (cx to cy)
-        val entryMapId = ram["currentMapId"]?.takeIf { it >= 0 } ?: t.mapId
+        val entryMapId = if (ramMapId > 0) ramMapId else t.mapId
         landmarkMemory.recordIfNew(Landmark(
             id = "interior_entry_${entryMapId}_${cx}_${cy}",
             kind = guessEntryKind(entryMapId),
@@ -274,11 +285,13 @@ class SingleRun(
         }
 
         /** Decides whether the post-explore Haiku call should run, and which
-         *  mapId to tag its landmarks with. Returns null to skip — either the
-         *  party died (HP=0, screenshot would be game-over) or the engine left
-         *  the interior (mapflags=0, screenshot would be the overworld). When
-         *  RAM still reports an interior, prefers the live mapId over the
-         *  trigger mapId so multi-stage warps are tagged with the inner map. */
+         *  mapId to tag its landmarks with. Returns null to skip — party died
+         *  (HP=0, screenshot would be game-over), engine left the interior
+         *  (mapflags=0, screenshot would be the overworld), or void state
+         *  (mapId=0 + mapflags=1, screenshot is a town-overlay pseudo-frame
+         *  that Haiku misreads as throne room with king). When RAM reports a
+         *  real interior, prefers the live mapId over the trigger mapId so
+         *  multi-stage warps are tagged with the inner map. */
         fun decideClassification(
             triggerMapId: Int,
             ramAfterExplore: Map<String, Int>,
@@ -288,7 +301,8 @@ class SingleRun(
             if (hpSum == 0) return null
             if (mapflags != 1) return null
             val ramMapId = ramAfterExplore["currentMapId"] ?: -1
-            val effective = if (ramMapId >= 0) ramMapId else triggerMapId
+            if (ramMapId == 0) return null
+            val effective = if (ramMapId > 0) ramMapId else triggerMapId
             return ClassifyDecision(mapIdToUse = effective)
         }
 

--- a/knes-agent/src/test/kotlin/knes/agent/explorer/SingleRunHandleNewInteriorTest.kt
+++ b/knes-agent/src/test/kotlin/knes/agent/explorer/SingleRunHandleNewInteriorTest.kt
@@ -68,6 +68,19 @@ class SingleRunHandleNewInteriorTest : FunSpec({
             ClassifyDecision(mapIdToUse = 24)
     }
 
+    test("decideClassification skips when ram mapId=0 (UnknownMapTrap void state)") {
+        // mapflags=1 + currentMapId=0 = engine void after stepping on a bogus warp
+        // tile (e.g. (147,154)). Screen renders a town-overlay pseudo-frame that
+        // Haiku misreads as a throne room with king + 2 stairs (verified live).
+        // Skip the Haiku call — would only produce 4 false landmarks.
+        val ram = mapOf(
+            "mapflags" to 1, "currentMapId" to 0,
+            "char1_hpLow" to 35, "char2_hpLow" to 30,
+            "char3_hpLow" to 28, "char4_hpLow" to 25,
+        )
+        SingleRun.decideClassification(triggerMapId = 8, ramAfterExplore = ram) shouldBe null
+    }
+
     test("decideClassification falls back to trigger mapId when RAM unreadable") {
         val ram = mapOf(
             "mapflags" to 1,


### PR DESCRIPTION
Complement to #110. While #110 prevented `AgentSession`'s auto-detect from recording mapId=0 transitions as warps, the **explorer's own** `handleNewInterior` would still:
1. Record an `interior_entry_0_X_Y` landmark with `mapIdInterior=0`.
2. Call Haiku on the void-state screen.

## Why this matters
Verified live with the same screenshot the agent captured at `(144,153)` mapId=0:

**Claude Haiku 4.5** classifies it as:
\`\`\`json
[
  {"kind": "NPC_KING", "note": "Crowned figure on throne in large royal room (top left area)"},
  {"kind": "NPC_GENERIC", "note": "Person sprite in center-right area of main room"},
  {"kind": "STAIRS_DOWN", "note": "Descending staircase visible in upper portion of the room"},
  {"kind": "STAIRS_DOWN", "note": "Additional descending staircase in upper-right area"}
]
\`\`\`
4 false landmarks. INN sign read as throne, party sprite as NPC, stone-path tiles as stairs. This is exactly the morning campaign's "throne tagged with mapId=8" bug, in a slightly different shape — agent enters void, Haiku hallucinates.

**Gemini 2.5 Pro** on the same screen returns `{"landmarks": []}` (after 652 thinking tokens). Vision backend swap is a separate consideration; this PR is the defensive guard regardless.

## Fix
Two skip points in \`SingleRun\`:
1. Top of \`handleNewInterior\` — return null immediately when `ram["currentMapId"] == 0`. No entry landmark, no Haiku call.
2. \`decideClassification\` — extra guard for when entry mapId was non-zero but during the 80-step explore the agent walked into a mapId=0 sub-map (return null).

## Test plan
- [x] 1 new unit test (`decideClassification` returns null when ram mapId=0).
- [x] Full suite: **220 pass / 2 pre-existing fail / 7 skipped**.

## Follow-up considerations (not this PR)
- **Gemini Pro as vision backend**: Pro correctly rejected the void state where Haiku hallucinated. ~5x more expensive per call (\$0.007 vs \$0.001) but handles edge cases better. Worth A/B testing on a real campaign.
- **Recovery from void state**: agent currently still ends `stop=UnknownMapTrap` after 3 idle frames. With this PR no garbage is recorded but the run still wastes most of its iterations. A dedicated escape skill (emulator reset + savestate reload, or `pressStartUntilOverworld` allowed for mapId=0) would let runs continue.