### PR TITLE
feat(explorer): GeminiVisionConsult — alt vision backend (Gemini 2.5 Pro)

### DIFF
--- a/knes-agent/src/main/kotlin/knes/agent/explorer/ExplorerMain.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/explorer/ExplorerMain.kt
@@ -53,15 +53,30 @@ fun main() {
     )
 
     val haiku: HaikuConsult = try {
-        val apiKey = System.getenv("ANTHROPIC_API_KEY")
-        if (apiKey.isNullOrBlank()) {
-            System.err.println("[explorer] no ANTHROPIC_API_KEY — using FakeHaikuConsult (zero classification)")
-            FakeHaikuConsult()
-        } else {
-            AnthropicHaikuConsult(apiKey = apiKey)
+        when (System.getenv("KNES_VISION")?.lowercase()) {
+            "gemini-pro", "gemini" -> {
+                val key = System.getenv("GEMINI_API_KEY")
+                if (key.isNullOrBlank()) {
+                    System.err.println("[explorer] KNES_VISION=gemini but GEMINI_API_KEY unset — using FakeHaikuConsult")
+                    FakeHaikuConsult()
+                } else {
+                    System.err.println("[explorer] vision backend: Gemini 2.5 Pro")
+                    GeminiVisionConsult(apiKey = key)
+                }
+            }
+            else -> {
+                val key = System.getenv("ANTHROPIC_API_KEY")
+                if (key.isNullOrBlank()) {
+                    System.err.println("[explorer] no ANTHROPIC_API_KEY — using FakeHaikuConsult (zero classification)")
+                    FakeHaikuConsult()
+                } else {
+                    System.err.println("[explorer] vision backend: Claude Haiku 4.5 (default; KNES_VISION=gemini-pro to switch)")
+                    AnthropicHaikuConsult(apiKey = key)
+                }
+            }
         }
     } catch (e: Exception) {
-        System.err.println("[explorer] Haiku init failed (${e.message}) — using FakeHaikuConsult")
+        System.err.println("[explorer] vision init failed (${e.message}) — using FakeHaikuConsult")
         FakeHaikuConsult()
     }
 

--- a/knes-agent/src/main/kotlin/knes/agent/explorer/GeminiVisionConsult.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/explorer/GeminiVisionConsult.kt
@@ -1,0 +1,213 @@
+package knes.agent.explorer
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
+import knes.agent.perception.Landmark
+import knes.agent.perception.LandmarkKind
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+/**
+ * Alternative HaikuConsult backed by Google Gemini 2.5 Pro (text + image).
+ *
+ * Empirical comparison vs Anthropic Haiku 4.5 (2026-05-06):
+ *  - On UnknownMapTrap mapId=0 void state, Pro returns `{"landmarks": []}` correctly;
+ *    Haiku hallucinates 4 landmarks (NPC_KING + 2× STAIRS_DOWN false positives).
+ *  - On real Coneria Castle throne (mapId=24), Pro identifies KING + describes the
+ *    flanking dragon emblems; Haiku also catches KING but hallucinates a STAIRS_DOWN.
+ *  - Cost: Pro ~6× more expensive per call ($0.005-0.007 vs $0.001) but the precision
+ *    gain ($0.30 vs $0.05 over a 50-run campaign with ~50% Haiku false positives)
+ *    is worth it.
+ *
+ * Selected via `KNES_VISION` env var (`gemini-pro` | `haiku`); default haiku.
+ */
+class GeminiVisionConsult(
+    private val apiKey: String,
+    private val model: String = "gemini-2.5-pro",
+    private val client: HttpClient = HttpClient(CIO) {
+        install(HttpTimeout) { requestTimeoutMillis = 60_000 }
+    },
+) : HaikuConsult, AutoCloseable {
+
+    override suspend fun classifyInterior(
+        mapId: Int, visitedTileCount: Int, screenshotBase64: String?, runId: String,
+    ): HaikuConsult.InteriorClassification {
+        val body = buildBody(SYSTEM_CLASSIFY, classifyUserText(mapId, visitedTileCount), screenshotBase64,
+            maxOutputTokens = 2000)
+        val raw = postOrNull(body) ?: return HaikuConsult.InteriorClassification(emptyList(), 0.0)
+        return parseInteriorResponse(raw, mapId = mapId, runId = runId)
+    }
+
+    override suspend fun readDialog(screenshotBase64: String?): HaikuConsult.DialogReading {
+        val body = buildBody(SYSTEM_DIALOG, DIALOG_USER_TEXT, screenshotBase64, maxOutputTokens = 800)
+        val raw = postOrNull(body) ?: return HaikuConsult.DialogReading("", null, 0.0)
+        return parseDialogResponse(raw)
+    }
+
+    override fun close() { client.close() }
+
+    private suspend fun postOrNull(body: String): String? {
+        val url = "https://generativelanguage.googleapis.com/v1beta/models/$model:generateContent?key=$apiKey"
+        val resp = try {
+            client.post(url) {
+                contentType(ContentType.Application.Json)
+                setBody(body)
+            }
+        } catch (e: Exception) {
+            System.err.println("[gemini-vision] request failed: ${e.message}")
+            return null
+        }
+        if (!resp.status.isSuccess()) {
+            System.err.println("[gemini-vision] http ${resp.status.value}: ${resp.bodyAsText().take(200)}")
+            return null
+        }
+        return resp.bodyAsText()
+    }
+
+    private fun classifyUserText(mapId: Int, visitedTileCount: Int): String =
+        "Map id: $mapId. Visited tiles in this interior: $visitedTileCount. " +
+            "Identify any NPCs visible on screen and stairs. Output JSON only:\n" +
+            """{"landmarks":[{"kind":"NPC_KING|NPC_SHOPKEEPER|NPC_GENERIC|STAIRS_UP|STAIRS_DOWN","note":"<short>"}]}"""
+
+    private fun buildBody(systemPrompt: String, userText: String, b64: String?, maxOutputTokens: Int): String {
+        val obj = buildJsonObject {
+            put("system_instruction", buildJsonObject {
+                put("parts", buildJsonArray {
+                    add(buildJsonObject { put("text", systemPrompt) })
+                })
+            })
+            put("contents", buildJsonArray {
+                add(buildJsonObject {
+                    put("role", "user")
+                    put("parts", buildJsonArray {
+                        if (b64 != null) {
+                            add(buildJsonObject {
+                                put("inline_data", buildJsonObject {
+                                    put("mime_type", "image/png")
+                                    put("data", b64)
+                                })
+                            })
+                        }
+                        add(buildJsonObject { put("text", userText) })
+                    })
+                })
+            })
+            put("generationConfig", buildJsonObject {
+                put("maxOutputTokens", maxOutputTokens)
+                put("temperature", 0)
+            })
+        }
+        return obj.toString()
+    }
+
+    companion object {
+        // Gemini 2.5 Pro pricing (Google, late 2025): $1.25 / MTok input, $10 / MTok
+        // output. thoughtsTokenCount is billed as output (reasoning tokens). Costs
+        // here are upper-bound; if pricing changes the absolute number drifts but
+        // the budget cap still triggers correctly.
+        private const val INPUT_USD_PER_TOKEN = 1.25e-6
+        private const val OUTPUT_USD_PER_TOKEN = 10.0e-6
+
+        private val JSON_OBJECT = Regex("""\{[\s\S]*\}""")
+        private val json = Json { ignoreUnknownKeys = true }
+
+        private const val SYSTEM_CLASSIFY =
+            "You analyze a screenshot of a Final Fantasy 1 (NES) interior — castle, town, " +
+                "or dungeon room. Identify visible NPCs and staircases. " +
+                "NPC_KING: a crowned figure on a throne (large royal room). " +
+                "NPC_SHOPKEEPER: a counter with item icons or weapons displayed. " +
+                "NPC_GENERIC: any other person sprite. " +
+                "STAIRS_UP / STAIRS_DOWN: ascending / descending staircase tile. " +
+                "Return ONLY JSON, no prose. If nothing matches the categories, return an empty list."
+
+        private const val SYSTEM_DIALOG =
+            "You read short on-screen dialog text from a Final Fantasy 1 (NES) screenshot. " +
+                "Dialog appears as a white-bordered box near the bottom of the screen with white " +
+                "text on dark background. Paraphrase concisely. If the speaker is identified by " +
+                "context (king on throne / shopkeeper at counter), set landmarkHint to KING / " +
+                "SHOPKEEPER. Otherwise set landmarkHint to null. Return ONLY JSON, no prose."
+
+        private const val DIALOG_USER_TEXT =
+            "Read the dialog text in this FF1 NES screenshot (white text on black box). " +
+                "Output JSON only:\n" +
+                """{"summary":"<paraphrase ≤80 chars>","landmarkHint":"KING|SHOPKEEPER|null"}"""
+
+        /** Parse the Gemini response envelope and the inner LLM-emitted JSON.
+         *  Visible for testing — pure function, no side effects. */
+        fun parseInteriorResponse(rawJson: String, mapId: Int, runId: String): HaikuConsult.InteriorClassification {
+            val (innerText, costUsd) = parseEnvelope(rawJson)
+            if (innerText == null) return HaikuConsult.InteriorClassification(emptyList(), costUsd)
+            val landmarks = try {
+                val match = JSON_OBJECT.find(innerText) ?: return HaikuConsult.InteriorClassification(emptyList(), costUsd)
+                val obj = json.parseToJsonElement(match.value).jsonObject
+                val arr = obj["landmarks"]?.jsonArray ?: return HaikuConsult.InteriorClassification(emptyList(), costUsd)
+                arr.mapNotNull { el ->
+                    val o = el.jsonObject
+                    val kindStr = o["kind"]?.jsonPrimitive?.content ?: return@mapNotNull null
+                    val kind = runCatching { LandmarkKind.valueOf(kindStr) }.getOrNull() ?: return@mapNotNull null
+                    val note = o["note"]?.jsonPrimitive?.content ?: ""
+                    Landmark(
+                        id = "gemini_${kindStr.lowercase()}_${mapId}_${note.hashCode().toString(16)}",
+                        kind = kind, mapId = mapId,
+                        note = note, visited = false, discoveredRunId = runId,
+                    )
+                }
+            } catch (e: Exception) {
+                System.err.println("[gemini-vision] parseInterior failed: ${e.message}")
+                emptyList()
+            }
+            return HaikuConsult.InteriorClassification(landmarks, costUsd)
+        }
+
+        fun parseDialogResponse(rawJson: String): HaikuConsult.DialogReading {
+            val (innerText, costUsd) = parseEnvelope(rawJson)
+            if (innerText == null) return HaikuConsult.DialogReading("", null, costUsd)
+            return try {
+                val match = JSON_OBJECT.find(innerText) ?: return HaikuConsult.DialogReading("", null, costUsd)
+                val obj = json.parseToJsonElement(match.value).jsonObject
+                val summary = obj["summary"]?.jsonPrimitive?.content ?: ""
+                val rawHint = obj["landmarkHint"]?.jsonPrimitive?.content
+                val hint = if (rawHint == null || rawHint.equals("null", ignoreCase = true) || rawHint.isBlank()) null else rawHint
+                HaikuConsult.DialogReading(summary, hint, costUsd)
+            } catch (e: Exception) {
+                System.err.println("[gemini-vision] parseDialog failed: ${e.message}")
+                HaikuConsult.DialogReading("", null, costUsd)
+            }
+        }
+
+        /** Returns (innerText, costUsd). innerText is null when the envelope is malformed.
+         *  Gemini's `usageMetadata` exposes promptTokenCount, candidatesTokenCount,
+         *  and thoughtsTokenCount. The latter is billed as output. */
+        private fun parseEnvelope(rawJson: String): Pair<String?, Double> {
+            return try {
+                val root = json.parseToJsonElement(rawJson).jsonObject
+                val candidate = root["candidates"]?.jsonArray?.firstOrNull()?.jsonObject
+                val text = candidate?.get("content")?.jsonObject?.get("parts")?.jsonArray
+                    ?.mapNotNull { it.jsonObject["text"]?.jsonPrimitive?.content }
+                    ?.joinToString("")
+                val usage = root["usageMetadata"]?.jsonObject
+                val inTok = usage?.get("promptTokenCount")?.jsonPrimitive?.content?.toIntOrNull() ?: 0
+                val outTok = usage?.get("candidatesTokenCount")?.jsonPrimitive?.content?.toIntOrNull() ?: 0
+                val thoughtTok = usage?.get("thoughtsTokenCount")?.jsonPrimitive?.content?.toIntOrNull() ?: 0
+                val cost = inTok * INPUT_USD_PER_TOKEN + (outTok + thoughtTok) * OUTPUT_USD_PER_TOKEN
+                (if (text.isNullOrBlank()) null else text) to cost
+            } catch (e: Exception) {
+                System.err.println("[gemini-vision] envelope parse failed: ${e.message}")
+                null to 0.0
+            }
+        }
+    }
+}

--- a/knes-agent/src/test/kotlin/knes/agent/explorer/GeminiVisionConsultTest.kt
+++ b/knes-agent/src/test/kotlin/knes/agent/explorer/GeminiVisionConsultTest.kt
@@ -1,0 +1,118 @@
+package knes.agent.explorer
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import knes.agent.perception.LandmarkKind
+
+class GeminiVisionConsultTest : FunSpec({
+    test("parseInteriorResponse extracts landmarks from Gemini envelope with thoughts billing") {
+        // Real Gemini 2.5 Pro response shape captured from the live A/B test on the
+        // Coneria Castle throne screenshot. Note the markdown code fence around the
+        // inner JSON — JSON_OBJECT regex extracts the first object regardless.
+        val envelope = """
+            {
+              "candidates": [{
+                "content": {
+                  "parts": [{
+                    "text": "```json\n{\n  \"landmarks\": [\n    {\n      \"kind\": \"NPC_KING\",\n      \"note\": \"A king sits on a throne in a large royal room, flanked by two golden dragon emblems.\"\n    }\n  ]\n}\n```"
+                  }]
+                }
+              }],
+              "usageMetadata": {
+                "promptTokenCount": 375,
+                "candidatesTokenCount": 14,
+                "thoughtsTokenCount": 432
+              }
+            }
+        """.trimIndent()
+        val res = GeminiVisionConsult.parseInteriorResponse(envelope, mapId = 24, runId = "test-run")
+        res.landmarks shouldHaveSize 1
+        res.landmarks[0].kind shouldBe LandmarkKind.NPC_KING
+        res.landmarks[0].mapId shouldBe 24
+        res.landmarks[0].note shouldContain "throne"
+        res.landmarks[0].discoveredRunId shouldBe "test-run"
+        res.landmarks[0].id shouldContain "gemini_npc_king_24"
+        // Cost: 375 in @ $1.25/M + (14 + 432) out/thoughts @ $10/M
+        // = 0.000469 + 0.00446 = ~$0.00493
+        (res.costUsd > 0.004 && res.costUsd < 0.006) shouldBe true
+    }
+
+    test("parseInteriorResponse returns empty list when Pro correctly rejects void state") {
+        // From the live trap-screen A/B test: Gemini 2.5 Pro returns empty landmarks
+        // on the mapId=0 UnknownMapTrap screen where Haiku 4.5 hallucinates 4 false
+        // positives. This is the explicit win for Pro on the edge case.
+        val envelope = """
+            {
+              "candidates": [{
+                "content": {"parts": [{"text": "```json\n{\n  \"landmarks\": []\n}\n```"}]}
+              }],
+              "usageMetadata": {
+                "promptTokenCount": 375, "candidatesTokenCount": 14, "thoughtsTokenCount": 652
+              }
+            }
+        """.trimIndent()
+        val res = GeminiVisionConsult.parseInteriorResponse(envelope, mapId = 0, runId = "test")
+        res.landmarks.shouldBeEmpty()
+    }
+
+    test("parseInteriorResponse drops landmarks with kind values not in LandmarkKind enum") {
+        // Gemini 2.5 Flash sometimes hallucinates outside the requested schema
+        // (e.g. "Building", "Path", "Vegetation"). Drop those to avoid polluting
+        // LandmarkMemory with unparseable kinds.
+        val envelope = """
+            {
+              "candidates": [{
+                "content": {"parts": [{"text": "{\"landmarks\":[{\"kind\":\"Building\",\"note\":\"Inn\"},{\"kind\":\"NPC_KING\",\"note\":\"throne\"}]}"}]}
+              }],
+              "usageMetadata": {"promptTokenCount":1,"candidatesTokenCount":1,"thoughtsTokenCount":0}
+            }
+        """.trimIndent()
+        val res = GeminiVisionConsult.parseInteriorResponse(envelope, mapId = 24, runId = "test")
+        // Only NPC_KING survives; "Building" is not a valid LandmarkKind.
+        res.landmarks shouldHaveSize 1
+        res.landmarks[0].kind shouldBe LandmarkKind.NPC_KING
+    }
+
+    test("parseInteriorResponse returns empty list on malformed envelope") {
+        val res = GeminiVisionConsult.parseInteriorResponse("{not valid json", mapId = 0, runId = "x")
+        res.landmarks.shouldBeEmpty()
+        res.costUsd shouldBe 0.0
+    }
+
+    test("parseInteriorResponse returns empty list when candidates array is missing (safety/blocked)") {
+        // Gemini may return a safety-blocked response without `candidates`.
+        val envelope = """{"promptFeedback":{"blockReason":"SAFETY"},"usageMetadata":{"promptTokenCount":10}}"""
+        val res = GeminiVisionConsult.parseInteriorResponse(envelope, mapId = 0, runId = "x")
+        res.landmarks.shouldBeEmpty()
+    }
+
+    test("parseDialogResponse extracts summary + landmarkHint, normalises null") {
+        val envelope = """
+            {
+              "candidates": [{
+                "content": {"parts": [{"text": "{\"summary\":\"the king asks for help\",\"landmarkHint\":\"KING\"}"}]}
+              }],
+              "usageMetadata": {"promptTokenCount":50,"candidatesTokenCount":20}
+            }
+        """.trimIndent()
+        val res = GeminiVisionConsult.parseDialogResponse(envelope)
+        res.summary shouldBe "the king asks for help"
+        res.landmarkHint shouldBe "KING"
+    }
+
+    test("parseDialogResponse normalises 'null' string to actual null") {
+        val envelope = """
+            {
+              "candidates": [{
+                "content": {"parts": [{"text": "{\"summary\":\"shopkeeper greets you\",\"landmarkHint\":\"null\"}"}]}
+              }],
+              "usageMetadata": {"promptTokenCount":40,"candidatesTokenCount":15}
+            }
+        """.trimIndent()
+        val res = GeminiVisionConsult.parseDialogResponse(envelope)
+        res.landmarkHint shouldBe null
+    }
+})


### PR DESCRIPTION
Adds a `HaikuConsult` implementation backed by Google's Gemini 2.5 Pro. Selectable at startup via `KNES_VISION=gemini-pro` (default remains Haiku, so this PR is non-breaking).

## Why
Live A/B comparison (2026-05-06) on two test screenshots:

| Screen | Haiku 4.5 | Gemini 2.5 Pro |
|--------|-----------|----------------|
| **UnknownMapTrap mapId=0 void** (INN sign + party sprite, town-overlay pseudo-frame) | `NPC_KING + NPC_GENERIC + 2× STAIRS_DOWN` — **4 false positives**, hallucinates throne from INN sign | `{"landmarks": []}` — correct rejection |
| **Real Coneria Castle throne mapId=24** | `NPC_KING ✓ + STAIRS_DOWN ✗` (false stairs from pillars) | `NPC_KING ✓` with note _"flanked by two golden dragon emblems"_ — accurate detail |

Pattern: Haiku over-generates landmarks (especially STAIRS false positives), Pro is conservatively accurate. The bigger gap: Pro CORRECTLY rejects the void state where Haiku hallucinates a throne — combined with #111 (which now skips mapId=0 entirely), this is belt-and-suspenders defence.

## Cost
~6× per call: \$0.005-0.007 (Pro, thinking tokens billed as output) vs \$0.001 (Haiku).

For a 50-run campaign:
- Haiku: \$0.05, ~50% false-positive landmarks
- Pro: \$0.30, mostly clean

\$0.25 absolute differential is small; precision gain over many campaigns matters more.

## Implementation
- Mirrors `AnthropicHaikuConsult` structure (same prompts, same JSON output schema). Only HTTP envelope and pricing differ.
- `thoughtsTokenCount` is billed as output per Google pricing (verified \~\$0.005 for trap / \~\$0.007 for castle in practice).
- "Return empty list if nothing matches" added to system prompt — Pro honours it; Haiku tends to fabricate even with this hint.
- Defensive: drops landmarks with `kind` strings that don't match `LandmarkKind` enum (Gemini Flash sometimes returns out-of-schema kinds like "Building").

Selected via:
\`\`\`
KNES_VISION=gemini-pro ./gradlew :knes-agent:runExplorer  # uses GEMINI_API_KEY
KNES_VISION=haiku      ./gradlew :knes-agent:runExplorer  # default; uses ANTHROPIC_API_KEY
\`\`\`

## Test plan
- [x] 7 new envelope-parsing tests: happy-path landmark extraction (real Pro castle response shape), correct empty-rejection, unparseable-kind drop, malformed envelope, safety-blocked response, dialog parsing.
- [x] Full suite: **226 pass / 2 pre-existing fail / 7 skipped**.
- [ ] Live A/B campaign: 20-run runs with KNES_VISION=haiku and KNES_VISION=gemini-pro, compare landmark precision/recall + total cost.