### PR TITLE
fix(explorer): bail immediately on mapId=0 + mapflags=1 (UnknownMapTrap)

### DIFF
--- a/knes-agent/src/main/kotlin/knes/agent/explorer/SingleRun.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/explorer/SingleRun.kt
@@ -320,6 +320,12 @@ class SingleRun(
             val partyHpSum = (1..4).sumOf { ram["char${it}_hpLow"] ?: 0 }
             return when {
                 partyHpSum == 0 && mapflags == 1 -> StopReason.PartyWiped
+                // mapId=0 + mapflags=1 = UnknownMapTrap engine void state. Bail
+                // immediately without waiting for 3 idle turns — there's no
+                // useful exploration to do in void state, and the savestate
+                // reload at the start of the next run is cheaper than burning
+                // ~80 frames of fruitless exploreInteriorFrontier here.
+                mapflags == 1 && mapId == 0 -> StopReason.UnknownMapTrap
                 mapflags == 1 && mapId !in knownMapIds && consecutiveIdleInTrap >= 3 -> StopReason.UnknownMapTrap
                 idleTurns >= 10 -> StopReason.Idle
                 coverageDeltaInWindow == 0 && stepsTaken > coverageWindow -> StopReason.LocalPlateau

--- a/knes-agent/src/test/kotlin/knes/agent/explorer/SingleRunRestartTriggersTest.kt
+++ b/knes-agent/src/test/kotlin/knes/agent/explorer/SingleRunRestartTriggersTest.kt
@@ -18,12 +18,39 @@ class SingleRunRestartTriggersTest : FunSpec({
     test("unknown mapId trap after 3 idle turns triggers UnknownMapTrap") {
         val ram = mapOf(
             "mapflags" to 0x01,
-            "currentMapId" to 0,  // not in KNOWN_MAP_IDS
+            "currentMapId" to 99,  // not in KNOWN_MAP_IDS, not zero either
             "char1_hpLow" to 30, "char2_hpLow" to 0, "char3_hpLow" to 0, "char4_hpLow" to 0,
         )
         SingleRun.checkRestart(ram, knownMapIds = setOf(1, 8),
             consecutiveIdleInTrap = 3, idleTurns = 0,
             stepsTaken = 0, coverageWindow = 10, coverageDeltaInWindow = 1) shouldBe StopReason.UnknownMapTrap
+    }
+
+    test("mapId=0 + mapflags=1 (engine void) bails immediately without waiting for idle") {
+        // Bogus warps like (147,154) transition to mapId=0+mapflags=1 — no real
+        // interior, just engine void state. Don't wait 3 idle turns; bail now
+        // and let the next run reload savestate.
+        val ram = mapOf(
+            "mapflags" to 0x01,
+            "currentMapId" to 0,
+            "char1_hpLow" to 30, "char2_hpLow" to 30, "char3_hpLow" to 30, "char4_hpLow" to 30,
+        )
+        SingleRun.checkRestart(ram, knownMapIds = setOf(1, 8),
+            consecutiveIdleInTrap = 0, idleTurns = 0,
+            stepsTaken = 0, coverageWindow = 10, coverageDeltaInWindow = 1) shouldBe StopReason.UnknownMapTrap
+    }
+
+    test("mapId=0 + mapflags=0 (overworld coords reset) is NOT trap — we're on overworld") {
+        // After party wipe / game reset the RAM may show mapflags=0 and mapId=0
+        // simultaneously — that's the overworld at spawn coords being reloaded,
+        // not a trap. Don't fire UnknownMapTrap.
+        val ram = mapOf(
+            "mapflags" to 0x00, "currentMapId" to 0,
+            "char1_hpLow" to 30, "char2_hpLow" to 30, "char3_hpLow" to 30, "char4_hpLow" to 30,
+        )
+        SingleRun.checkRestart(ram, knownMapIds = setOf(1, 8),
+            consecutiveIdleInTrap = 0, idleTurns = 2,
+            stepsTaken = 5, coverageWindow = 10, coverageDeltaInWindow = 2) shouldBe null
     }
 
     test("idle 10 turns triggers Idle") {


### PR DESCRIPTION
Closes Priority C from prior HANDOFF: every explorer run that walks into a bogus warp burns most of its budget waiting for the legacy 3-idle-turns trap detection to fire.

## Problem
After #111 (skip mapId=0 in handleNewInterior), the explorer no longer records garbage landmarks when it lands in the engine void state. But the run itself doesn't END early — it continues for ~10 outer iterations + ~80 frames of fruitless `exploreInteriorFrontier` before `checkRestart` finally bails on `consecutiveIdleInTrap >= 3`. With Priority 0 warp targeting (#107), every run that picks a bogus warp wastes most of its budget here.

## Fix
Add an immediate-bail rule to `checkRestart`:
\`\`\`kotlin
mapflags == 1 && mapId == 0 -> StopReason.UnknownMapTrap
\`\`\`
Engine void state has no useful exploration to do; the savestate reload at the start of the next run is cheap.

Existing rule preserved for `mapflags=1 + mapId>0 + mapId not in known` (still waits 3 idle turns) — that case is "we entered a real but unfamiliar interior, give the agent a chance to act before bailing". The mapId=0 short-circuit only catches the engine-void case.

## Test plan
- [x] 2 new RestartTrigger tests: immediate-bail on mapId=0+mapflags=1, no false-positive when mapflags=0+mapId=0 (overworld at spawn).
- [x] Full suite: **228 pass / 2 pre-existing fail / 7 skipped**.

## Combined effect with the rest of this session's PRs
After #106 + #107 + #108 + #109 + #110 + #111 + #112 + this PR:
- Explorer reaches warps deterministically (priority 0 + warmup + retry).
- Real-warp runs produce correctly-tagged landmarks (live mapId at trigger + screenshot, decideClassification gating).
- Bogus-warp runs end in <1s instead of ~5s.
- Vision backend swappable (Haiku default; Gemini Pro via `KNES_VISION=gemini-pro`).

Long-campaign productivity should improve materially. Next-session: full A/B test campaign.