### PR TITLE
fix(phase2): harden agent — postbattle cap, trap detection, frontier prompt

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,139 +1,163 @@
-# FF1 Koog Agent — Handoff (post-mapId-mismatch hardening, 2026-05-06 morning)
+# FF1 Koog Agent — Handoff (Phase 2 Garland-attempt session, 2026-05-06 afternoon)
 
-**Master HEAD:** `ebe52a3` — PR #114 merged. **Nine PRs this session: #106 + #107 + #108 + #109 + #110 + #111 + #112 + #113 + #114** (#105 closed unmerged).
-**Required env:** `ANTHROPIC_API_KEY` (default vision backend) or `GEMINI_API_KEY` (when `KNES_VISION=gemini-pro`).
+**Branch HEAD:** `69c8e53` on `ff1-phase2-garland-attempt-hardening`. **PR #115 open** against `master`. 12 attempts to reach Garland; agent infrastructure substantially hardened, but Garland NOT defeated.
+**Required env:** `ANTHROPIC_API_KEY` (Phase 2 vision is hardcoded to Anthropic in `Main.kt`).
 
 ---
 
-## TL;DR — Phase 1.5 + 2 closed live, explorer hardened end-to-end
+## TL;DR — Phase 2 agent hardened across 12 iterations; Coneria peninsula remains a wall
 
-Started session with one bug ("mapId mismatch in morning campaign") and ended with the entire explorer + agent Phase 2 pipeline verified live, plus a vision backend swap available.
+Tried to make `:knes-agent:run` actually reach Garland. Pre-populated `LandmarkMemory` with derived bridge + Temple coords from ROM tile bytes. Each iteration uncovered the next bug; cumulative fixes landed in **PR #115**.
 
 ```
-ebe52a3  PR #114 merge: atomic JSON memory file saves — crash-safe writes
-c4baf89  PR #113 merge: bail immediately on mapId=0 + mapflags=1 (UnknownMapTrap)
-f025f1a  PR #112 merge: GeminiVisionConsult — alt vision backend (Gemini 2.5 Pro)
-5cd7c11  PR #111 merge: skip handleNewInterior when ram mapId=0
-bf00bed  PR #110 merge: filter mapId=0 in auto-detected warps (AgentSession)
-ab0b677  PR #109 merge: post-loadState warm-up — bridges V5.2 input-frame drop
-30fb464  PR #107 merge: salience priority 0 — target known warp tiles
-7be39be  PR #108 merge: priority 0 must not filter recentlyFailed
-fc25534  PR #106 merge: tag landmarks with live mapId; skip Haiku on wipe / overworld
+PR #115 (open) — fix(phase2): harden agent — postbattle cap, trap detection, frontier prompt
+  WalkOverworldTo (V5.33) — 30-frame NOOP warmup + deferred fog.markBlocked
+  AgentSession (V5.34/V5.34.2/V5.34.3) — top-of-loop budget, postbattle cap=150,
+    confirmed UnknownMapTrap detection (3-obs threshold + Battle/PostBattle excl.)
+  AdvisorAgent prompt — V5.32 frontier bias + V5.34.4 Coneria overlay nav + V5.34.5 XP grind
+  ExecutorAgent — maxIterations 16 → 24
 ```
+
+**Net effect:** infinite postbattle zombie loops → clean `OutOfBudget` termination; false-positive trap-bails on tile 0x00 FIGHT-normal grass eliminated; agent now reaches Coneria town overlay and uses `exploreInteriorFrontier` as designed (327 calls in v11).
 
 ---
 
 ## Verified live this session
 
-| Bug / feature | Live evidence |
+| Fix | Live evidence |
 |---|---|
-| Fix A — live mapId tag (#106) | Overworld campaign produced 7× NPC_KING tagged `mapId=24` (Castle), entry tagged `mapIdInterior=8` (Coneria Town overlay). Pre-fix the throne was tagged `mapId=8`. |
-| Fix B — PartyWipe gate (#106) | Interior-fixture campaign run-1 stop=PartyWiped → cost=$0.0 (was $0.000578 pre-fix), zero "NEW GAME" garbage. |
-| Priority 0 warp targeting (#107/#108) | First overworld run reached (147,154) for the first time across the entire session. |
-| LoadState warm-up (#109) | Without 30 NOOP frames after loadState, every first walk fails "input not responding". With it, agent moves on iter-1. |
-| Auto-detect mapId=0 filter (#110) | Real Haiku 4.5 + Gemini 2.5 Pro empirical comparison on the void-state screen confirmed 4-vs-0 false positive ratio. |
-| Skip handleNewInterior on mapId=0 (#111) | Same evidence as #110. |
-| Gemini 2.5 Pro alt backend (#112) | A/B on real Castle throne (mapId=24): both correctly identify NPC_KING; Haiku also hallucinates a STAIRS_DOWN, Pro doesn't. Pro adds accurate detail _"flanked by two golden dragon emblems"_. |
-| Trap bail-early (#113) | Unit-tested; with #111 already in place the live impact is freeing ~80 frames per trap-hitting run. |
-| Atomic memory saves (#114) | Unit-tested via simulated mid-write crash. Operational impact: today's debugging campaigns lost state to non-atomic saves several times — won't repeat. |
-| Phase 2 LandmarkContext (#106 byproduct) | `runAgent` trace in `~/.knes/runs/2026-05-06T05-36-14.521274Z/trace.jsonl`: rendered landmark block in advisor input, advisor output references (146,152) + "castle with King/throne room" verbatim. |
+| WalkOverworldTo WARMUP_FRAMES=30 (V5.33) | v5+ runs no longer flag input-dead on first overworld step post-spawn / post-battle. |
+| WalkOverworldTo deferred fog mark (V5.33) | v5 evidence vs v4: agent stopped declaring false deadlock at (152,151) after one failed W step. |
+| AgentSession postbattle cap (V5.34, 60→150) | v6 first clean OutOfBudget after 20 dismiss; v11 at 150 dismiss across 23 battles → cap = working but multi-screen postbattle dwarfs initial estimates. |
+| Top-of-loop budget enforcement (V5.34) | wallClock check no longer skipped by `continue` branches. v6 ran 4m 7s and terminated cleanly. |
+| Trap detection 3-obs threshold + phase exclusion (V5.34.3) | v9: 0 trap-bails despite phase=Indoors(mapId=0,isTown=true) Coneria overlay reached. v11: 0 trap-bails across 9m 44s + 23 battles. |
+| Advisor frontier prompt (V5.32) | v4 advisor invoked findPath 69× (was 0); chose verified GRASS waypoint (168,144) instead of WATER (168,145). |
+| Advisor Coneria-overlay nav prompt (V5.34.4) | v10/v11: agent used `exploreInteriorFrontier` 135× / 327× respectively instead of cycling exitInterior. |
+| Pre-populated bridge + stepping-stone landmarks | Advisor visibly references EXIT_TILE(157,141) and EXIT_TILE(168,144) in turn-2 plan output. |
 
 ---
 
-## Vision backend comparison (live A/B, 2 data points)
+## Iteration progression
 
-| Screen | Haiku 4.5 | Gemini 2.5 Pro | Truth |
-|--------|-----------|-----------------|-------|
-| **UnknownMapTrap mapId=0 void** | 4 false: NPC_KING + NPC_GENERIC + 2× STAIRS_DOWN | `[]` (empty) | empty (no real interior) |
-| **Coneria Castle throne mapId=24** | NPC_KING ✓ + STAIRS_DOWN ✗ (false) | NPC_KING ✓ with accurate detail | NPC_KING only |
+Spawn at world (146, 158); spawn → bridge = ~22 manhattan tiles; spawn → Temple = ~50.
 
-**Pattern:** Haiku over-generates landmarks (especially false-positive STAIRS), Pro is conservatively accurate. Cost ratio ~6x ($0.005-0.007 vs $0.001 per call). For a 50-run campaign: $0.30 (Pro) vs $0.05 (Haiku) — absolute differential trivial; precision gain matters more.
+| Iter | Outcome | Max y N | Battles | Postbattle | Trap-bail | Key change |
+|------|---------|---------|---------|------------|-----------|------------|
+| v2 | zombie loop | 153 | — | infinite | — | baseline |
+| v3 | zombie loop | 151 | — | infinite | — | bridge landmark + maxIter 24 |
+| v4 | zombie loop | 151 | — | infinite | — | frontier prompt + stepping stone |
+| v5 | zombie loop | 149 | — | infinite | — | WARMUP + deferred fog |
+| **v6** | **`OutOfBudget`** ✅ | 149 | — | 20 (cap) | — | V5.34 postbattle cap |
+| v7 | trap-bail (false) | 153 | — | 0 | 1 | UnknownMapTrap detection (eager) |
+| v8 | trap-bail (false) | 153 | — | 0 | 1 | pre-pop trap warps |
+| **v9** | **`OutOfBudget`** ✅ | 149 | **51** | 60 (cap) | 0 | V5.34.3 confirmed trap detection |
+| v10 | (Anthropic 60s timeout) | 149 | 5 | 0 | 0 | postbattle cap 60→150, town nav prompt |
+| **v11** | **`OutOfBudget`** ✅ | 149 | 23 | 150 (cap) | 0 | retry of v10 |
+| v12 | (killed for PR) | — | — | — | — | XP grind prompt (V5.34.5) |
 
-Switch via env var: `KNES_VISION=gemini-pro` (default `haiku`).
+Bridge (157, 141), mainland north of Coneria, Temple of Fiends (168, 117), Garland — **none reached**.
 
 ---
 
-## Open work
+## Research finding: FF1 NES warp table (datacrystal + Entroper/FF1Disassembly)
 
-### High-value
-- **F. Full A/B campaign** — 20 runs each backend, empirical campaign-level metrics. Marginal value vs the 2 data points already collected, but cleanest dataset for "should we default to Pro?".
-- **E. Coverage metric** — `terrainTilesKnown delta=0` every run because savestate has full overworld scan. Replace with `visited-landmarks` delta in plateau heuristic.
+The "hidden warp" hypothesis at (147,153)/(147,154) was wrong. Per `bank_0F.asm` (`GetOWTile` + `SetOWTileProps`), each visual tile_id 0x00–0x7F has a 2-byte property entry in `tileset_prop` (NES $8000 in BANK_OWINFO = file offset 0x10):
+
+- byte 1 `[SSdf ascw]` = walking + vehicle restrictions
+- byte 2: `$80` set → TELEPORT (low 6 bits = teleport_id, indexes `lut_EntrTele_X/Y/Map`); `$40` set → FIGHT (random encounter trigger)
+
+Dumped the table for our ROM. Tile 0x00 has byte2 = `0x40` = **FIGHT-normal**, NOT teleport. The empirical (mapflags=1, mapId=0) state on stepping onto (147, 154) was a 1-frame battle-entry artifact, not a hidden warp. V5.34.3 (3-obs threshold + Battle/PostBattle exclusion) addresses this directly.
+
+Real overworld warp tile_ids (byte2 & 0x80):
+- 0x01–0x02 (id 9), 0x0E (id 14), 0x1B–0x1C (id 10), 0x1D (id 24, chime-gated),
+- 0x29–0x2A (id 11), 0x2B (id 16), 0x2F (id 20), **0x32 (id 21 — Temple of Fiends)**,
+- 0x34 (id 25), 0x35 (id 26), 0x38–0x39 (id 12), 0x3A (id 22), 0x46 (id 19, currently misclassified as BRIDGE),
+- 0x49–0x4E (ids 1–5), 0x57–0x58 (id 13), 0x5A/5D (ids 6–7), 0x64/0x65 (id 15),
+- 0x66–0x6E (ids 17, 27, 28, 29, 0, 18, 8, 23).
+
+`OverworldTileClassifier` already buckets most of these as CASTLE/TOWN (impassable transit). Notable misclassifications:
+- 0x46 currently → BRIDGE; should be WARP (post-Garland bridge cutscene teleport).
+- 0x1D currently → UNKNOWN; could be WARP_CHIME_GATED.
+
+Coneria warp at world (145, 152) tile = 0x76; tileset_prop[0x76] byte2 = 0x00 (no teleport). Coneria overlay activates via a different mechanism (proximity-based town overlay, not per-tile warp lookup) — separate codepath in the engine, out of scope of `tileset_prop`.
+
+---
+
+## Open work for next session
+
+### Primary blocker: encounter density on Coneria peninsula
+
+v9 + v11 evidence: spawn → bridge needs ~22 tiles of traversal. Random encounters fire every 4–8 tiles in grass/forest, producing 23–51 battles. Multi-screen postbattle (XP / level-up / gold) × 4 chars = 60–150 dismiss cycles per run. Even with `POSTBATTLE_DISMISS_CAP=150`, full budget exhausts before reaching the bridge.
+
+**Candidate fixes (not yet implemented):**
+- (a) **Savestate fixture past the bridge** (10 min manual): boot game, walk through Coneria, cross bridge, save state at world ~(180, 150). Set as `FF1_SAVESTATE` for Phase 2 runs that target Garland specifically.
+- (b) **Waypoint-aware advisor planning**: V5.34.5 prompt added the *concept* of 8-10 tile waypoints, but advisor still defaulted to `walkOverworldTo(157,141)` end-to-end in v11. May need to enforce in code (split single long walks at intermediate fog frontiers).
+- (c) **Wire Gemini into Phase 2** (1–2h, 3 new classes + Main.kt router) — better vision precision; not a root-cause fix for encounter density but would help downstream once past the bridge.
 
 ### Smaller / opportunistic
-- **Discover more warps** — current `~/.knes/ff1-overworld-warps.json` has only the manually-annotated `(145,152)`. AgentSession's auto-detect (now mapId-correct via #110) needs runs to populate. Without trap recovery — wait, that's already done via #111+#113. So just need actual runs producing data.
-- **Explorer doesn't accumulate warps cross-run** (only AgentSession does). Harmonise so explorer can grow `warpMemory` from its own discoveries.
-- **`isDialogBoxOpen` is a `false` stub** — `Trigger.DialogBoxVisible` never fires. Need a real RAM signature.
-- **Anthropic prompt caching is no-op** — Koog 0.6.x lacks `cache_control`. The HaikuConsult HTTP path is direct; could add it.
+- Update `OverworldTileClassifier` to consume `tileset_prop` from ROM, so 0x46 → WARP (not BRIDGE) and 0x1D → WARP. Would let BFS treat all true warp tiles as impassable transit.
+- Postbattle handler diagnosis: 23 battles × ~6.5 dismiss avg suggests level-up animations or cascading encounters mid-postbattle. Could add a per-battle dismiss counter (vs current consecutive cross-battle counter).
+- `OverworldWarpMemory` has 1 entry: (145, 152) Coneria. The two false UnknownMapTrap entries from attempt8 were cleaned up.
 
 ---
 
-## Code architecture (post-#114)
+## Code architecture (post-PR-#115)
 
 ```
 knes-agent/src/main/kotlin/knes/agent/
-  explorer/
-    ExplorerSession.kt — V5.2 warmup post-loadState (#109)
-    ExplorerMain.kt — KNES_VISION env router (haiku | gemini-pro)
-    SingleRun.kt
-      handleNewInterior(): live mapId tag, skip on mapId=0 (#106 + #111)
-      Companion: decideClassification(triggerMapId, ramAfter): null on
-                 wipe / overworld / mapId=0 (#106 + #111)
-      checkRestart: mapId=0+mapflags=1 → immediate UnknownMapTrap (#113)
-    SalienceStrategy.kt
-      Priority 0: closest known warp not yet entered this run (#107),
-                  no recentlyFailed filter (#108)
-      Priorities 1A/1B/2-5 unchanged
-    AnthropicHaikuConsult.kt — Haiku 4.5 backend
-    GeminiVisionConsult.kt — Gemini 2.5 Pro backend (#112)
-  perception/
-    AtomicJsonWriter.kt — write-temp-then-rename (#114)
-    {Landmark,Blockage,OverworldWarp,Interior,OverworldTerrain,Overworld}Memory.kt
-      — all save() now via AtomicJsonWriter
-  runtime/
-    AgentSession.kt
-      Companion: FAILED_WARP_REGEX captures (worldX, worldY, mapId)
-      Auto-detect skips mapId=0 transitions (#110)
-      LandmarkContext.render(landmarkMemory) injected into both advisor +
-      executor observations on every phase change (Phase 2)
-    LandmarkContext.kt — unchanged; renders LandmarkMemory grouped by kind.
+  advisor/AdvisorAgent.kt
+    systemPrompt — V5.32 FRONTIER, V5.34.4 CONERIA OVERLAY, V5.34.5 XP GRIND
+  executor/ExecutorAgent.kt
+    maxIterations = 24 (V5.23.2 update — was 16)
+  runtime/AgentSession.kt
+    Top-of-loop budget enforcement
+    POSTBATTLE_DISMISS_CAP = 150 + consecutivePostBattle reset
+    UnknownMapTrap detection: TRAP_CONFIRM_THRESHOLD=3 + phase!=Battle/PostBattle
+      On confirmed trap: failedWarpTiles += tile, fog.markBlocked,
+                          warpMemory.record(mapId=0) + save, return OutOfBudget
+  skills/WalkOverworldTo.kt
+    WARMUP_FRAMES=30 NOOP at skill start
+    fog.markBlocked deferred to consecutiveNoMove >= 2
 ```
+
+Explorer pipeline (`SingleRun.kt`, `ExplorerSession.kt`) unchanged this session — its #111/#113 trap-bail logic is what V5.34.2/3 ports into Phase 2.
 
 ---
 
-## Test status
+## Test status (post-PR-#115)
 
-```
-./gradlew :knes-agent:test
-```
+`./gradlew :knes-agent:test` not re-run this session — last green was **233 pass / 2 pre-existing fail / 7 skipped** at master (`ca2972f`). PR test plan checkbox open.
 
-**233 pass / 2 pre-existing fail / 7 skipped** (master HEAD `ebe52a3`).
+---
 
-Pre-existing failures: `Coneria8VisualDiffTest`, `ConeriaTownEmpiricalDiscoveryTest` (unchanged from master baseline at session start).
+## Pre-populated memory state
+
+`~/.knes/ff1-landmarks.json` (16 entries; 2 manually added this session):
+- `EXIT_TILE at world(157,141)` — N bridge from Coneria peninsula (manual ROM derivation).
+- `EXIT_TILE at world(168,144)` — verified GRASS stepping stone S of Temple of Fiends.
+- `DUNGEON_ENTRY at world(168,117)` — Temple of Fiends candidate.
+- `DUNGEON_ENTRY at world(210,149)` — alternative candidate (Pravoka or Temple cluster).
+- 12 NPC_KING / STAIRS_DOWN / TOWN_ENTRY entries from prior explorer runs.
+
+`~/.knes/ff1-overworld-warps.json`: 1 entry — Coneria (145,152) → mapId=8. Two false trap entries from attempt8 were cleaned out after V5.34.3 fix.
 
 ---
 
 ## Useful CLI
 
 ```bash
-# Cheap explorer with default Haiku backend.
-./gradlew :knes-agent:runExplorer
+# Phase 2 with bumped budget (matches PR #115 test plan).
+./gradlew :knes-agent:run --args="--rom=/Users/askowronski/Priv/kNES/roms/ff.nes \
+  --max-skill-invocations=200 --cost-cap-usd=10.0 --wall-clock-cap-seconds=1800"
 
-# Same campaign with Gemini 2.5 Pro vision backend.
+# Explorer (unchanged, Gemini-capable).
 KNES_VISION=gemini-pro ./gradlew :knes-agent:runExplorer
 
-# Override savestate to interior fixture.
-FF1_SAVESTATE=knes-agent/src/test/resources/fixtures/ff1-coneria-interior-discovery.savestate \
-  ./gradlew :knes-agent:runExplorer
+# Verify fog state mid-run by checking log for trap detector + postbattle counter.
+grep -E "unknown-map-trap|postbattle auto-dismiss|OUTCOME:" /tmp/knes-garland-attempt*.log
 
-# Phase 2 agent (uses LandmarkContext).
-./gradlew :knes-agent:run --args="--rom=/Users/askowronski/Priv/kNES/roms/ff.nes \
-  --max-skill-invocations=8 --cost-cap-usd=0.5 --wall-clock-cap-seconds=120"
-
-# Inspect memory
-jq '.landmarks | length' ~/.knes/ff1-landmarks.json
-jq '[.landmarks | group_by(.kind)[] | {k: .[0].kind, n: length, mapIds: ([.[].mapId, .[].mapIdInterior] | map(select(. != null)) | unique)}]' ~/.knes/ff1-landmarks.json
-jq '.tiles' ~/.knes/ff1-overworld-warps.json
-jq -r 'select(.role == "advisor") | .input' ~/.knes/runs/<latest>/trace.jsonl | head -100
+# Inspect landmarks (incl. our manual additions).
+jq '.landmarks[] | {kind, x: .worldX, y: .worldY, note}' ~/.knes/ff1-landmarks.json
 ```
 
 ---
@@ -141,21 +165,26 @@ jq -r 'select(.role == "advisor") | .input' ~/.knes/runs/<latest>/trace.jsonl | 
 ## Repo paths
 
 - Main: `/Users/askowronski/Priv/kNES`
-- Worktree: `/Users/askowronski/Priv/kNES-ff1-agent-v2`
+- Branch: `ff1-phase2-garland-attempt-hardening` (HEAD `69c8e53`)
+- PR: https://github.com/ArturSkowronski/kNES/pull/115
 - ROM (gitignored): `/Users/askowronski/Priv/kNES/roms/ff.nes`
-- Persistent memory: `~/.knes/ff1-{overworld-terrain,landmarks,blockages,overworld-warps,interior-memory}.json`
-- Run traces: `~/.knes/runs/<ISO-timestamp>/trace.jsonl`
-- Archives:
-  - `~/.knes/archive-2026-05-05-pre-mapid-fix/`
-  - `~/.knes/archive-2026-05-05-pre-warp-targeting/`
-  - `~/.knes/archive-2026-05-05-pre-warmup/`
+- Persistent memory: `~/.knes/ff1-{landmarks,overworld-warps,interior-memory,overworld-terrain,blockages,ow-memory}.json`
+- Run logs (this session): `/tmp/knes-garland-attempt{2..12}.log`
+
+Pre-session archive (rollback target if PR rejected):
+- `~/.knes/archive-2026-05-06-pre-gemini-campaign/`
+
+---
 
 ## Test fixtures
-- `ff1-post-boot.savestate` — overworld at (146, 158)
-- `ff1-coneria-interior-discovery.savestate` — inside mapId=8 at party=(11, 32) (warning: PPU vblank desync per V5.16; Coneria8VisualDiffTest uses live boot instead)
+
+- `ff1-post-boot.savestate` — overworld at (146, 158); used by explorer, NOT by Phase 2 (Phase 2 boots from ROM intro).
+- `ff1-coneria-interior-discovery.savestate` — inside mapId=8.
+
+**Missing fixture for next session:** post-bridge savestate at world ~(180, 150) — would skip the encounter-dense Coneria peninsula entirely. See "Open work" section.
 
 ---
 
 ## First message to send to next session (suggestion)
 
-> Master at `ebe52a3`. Nine PRs merged this session (#106 + #107 + #108 + #109 + #110 + #111 + #112 + #113 + #114; #105 closed unmerged). Phase 1.5 + Phase 2 verified live. Vision backend swappable (Haiku default; `KNES_VISION=gemini-pro` for Gemini 2.5 Pro — better on edge cases per 2-point A/B). Memory writes are now crash-safe. UnknownMapTrap recovery in place. 233 / 2 pre-existing fail / 7 skipped. Open: full A/B campaign (20 runs each backend) for empirical metrics, coverage metric improvement (terrainTilesKnown delta is always 0 — needs replacement with visited-landmarks delta). Conversation in Polish; PR-flow + tests-first + commit per closed phase.
+> Branch `ff1-phase2-garland-attempt-hardening` at `69c8e53`, PR #115 open. 12 Phase 2 attempts this session — agent now terminates cleanly (no zombie postbattle, no false UnknownMapTrap), reaches Coneria town overlay, fights 23–51 battles per run. Garland not reached: encounter density on Coneria peninsula consumes the full postbattle dismiss budget (cap=150) before agent crosses the N bridge. **Highest-leverage next step: capture a savestate past the bridge and set `FF1_SAVESTATE` so Phase 2 runs targeting Garland skip the peninsula entirely.** FF1 disasm research dumped `tileset_prop` table — `OverworldTileClassifier` should consume it (0x46 is WARP not BRIDGE; 0x1D is WARP_CHIME_GATED) for true overworld passability. Conversation in Polish; PR-flow + tests-first + commit per closed phase.

--- a/knes-agent/src/main/kotlin/knes/agent/advisor/AdvisorAgent.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/advisor/AdvisorAgent.kt
@@ -131,6 +131,76 @@ class AdvisorAgent(
             128), or recommend a different sub-map target if the screenshot
             shows one. Budget spent escaping Coneria is budget lost to
             Garland — at some point declare the run unsalvageable and accept it.
+
+            FRONTIER EXPLORATION BIAS (V5.32): when walkOverworldTo fails
+            twice in a row on the same target with reasons like
+            "target tile is impassable", "no path within viewport", or
+            "did not reach in N steps", STOP retrying that target. The
+            picked coordinate is likely WATER/MOUNTAIN or unreachable from
+            current position. Instead:
+              (a) Pick a waypoint at the EDGE of the visible 16×16
+                  viewport in the rough direction of the goal. Edge tiles
+                  expand the fog and reveal new structure even when the
+                  long-range goal can't be reached directly.
+              (b) PREFER fog frontiers — '?' tiles in the ASCII map —
+                  over re-trying known-walkable targets. Unexplored
+                  tiles often hide the path forward; "weird" isolated
+                  glyphs in the viewport (single C/T amid GRASS) are
+                  often dungeon entries worth probing.
+              (c) Before committing to a long-range walkOverworldTo,
+                  consult findPath with that target. If findPath returns
+                  no path, pick a different waypoint within ±3 tiles —
+                  prefer GRASS/FOREST tiles you can SEE in the ASCII map
+                  rather than blind training-data coords. NEVER pick a
+                  target without verifying it's a passable terrain glyph
+                  in the current viewport or at minimum near a passable
+                  glyph.
+              (d) Map boundaries are valid exploration targets in their
+                  own right. If the ASCII map shows water/forest/mountain
+                  walls, target a tile that REACHES the wall (forces
+                  viewport shift) rather than picking a coord that's
+                  already unreachable. Iterate: walk to edge, observe
+                  new viewport, re-plan.
+
+            XP / LEVEL GRIND STRATEGY (V5.34.5): the default party at level 0
+            is FRAGILE — single battle takes ~10 rounds, char1 HP can drop to
+            10/35 after one encounter. attempt11 evidence: walking from spawn
+            toward bridge (157,141) triggers ~23 random encounters in
+            high-encounter Coneria peninsula terrain; multi-screen postbattle
+            (dmg / XP / level / gold) per fight × 23 = ~150 dismiss cycles =
+            full budget spent before reaching bridge. Therefore:
+              (a) After 5+ battles in a single overworld walk, expect HP to
+                  be low. Plan a Coneria castle/town visit ONLY for
+                  buying potions OR resting at inn (heal 1 gp); do NOT detour
+                  to inn unless char_hp < 30% maxHp.
+              (b) Random encounter chains are FEATURE not bug — XP from
+                  overworld walks reduces battle length quadratically (lvl 1
+                  party = 10-rd battles; lvl 3 party = 3-rd battles). Don't
+                  panic-restart a run after few fights; ride them out.
+              (c) If a single walkOverworldTo skill call triggers 5+ encounters,
+                  the postbattle dismiss budget will exhaust before reaching
+                  target. Break long walks into intermediate waypoints
+                  (every 8-10 tiles) so per-skill encounter count stays low.
+                  After waypoint reached, fresh advisor call → fresh budget.
+              (d) Level-up screens add 3-5 extra postbattle dismiss cycles per
+                  character that levels. Plan budget accordingly: 4-char
+                  level-up = ~20 extra dismiss cycles on top of standard
+                  battle resolution.
+
+            CONERIA TOWN OVERLAY NAVIGATION (V5.34.4): when phase becomes
+            `Indoors(mapId=0, isTown=true)`, the party has entered the
+            Coneria town overlay layer (not a real interior, not a trap).
+            DO NOT cycle exitInterior repeatedly — V5.29 evidence shows
+            ~13% step success per call on town overlays. After 1 failed
+            exitInterior, switch strategy:
+              (a) exploreInteriorFrontier with maxSteps=64 — covers town
+                  tiles tile-by-tile, naturally exposing exits.
+              (b) If that also fails, walkOverworldTo to a coord OUTSIDE
+                  the Coneria overlay zone (~6+ tiles away from castle),
+                  e.g. (140,160) west or (157,141) bridge, to escape the
+                  overlay re-entry trap.
+              (c) NEVER call exitInterior more than 2 times in a row in
+                  town overlay — it burns budget without exiting.
             Skill repertoire (V5.26 — INTENT-LEVEL only, deterministic):
               - pressStartUntilOverworld: title screen → overworld with default party
               - exitInterior: deterministic BFS to nearest interior exit. FIRST

--- a/knes-agent/src/main/kotlin/knes/agent/executor/ExecutorAgent.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/executor/ExecutorAgent.kt
@@ -56,7 +56,7 @@ class ExecutorAgent(
         toolRegistry = registry,
         strategy = singleRunStrategy(),
         systemPrompt = systemPrompt,
-        maxIterations = 16,   // V5.23.2: 10 still hit ITERATION_CAP (iter6). Even single-tool calls in Koog 0.6.1 singleRunStrategy can take 8-10 nodes when tool result triggers extra LLM reasoning. Bumped to 16 — empirically below the 20-cap chain risk seen in V2-V5, while leaving room for legitimate single-tool flows. Tracking ITERATION_CAP rate across iterations.
+        maxIterations = 24,   // V5.23.2: 10 still hit ITERATION_CAP (iter6). Even single-tool calls in Koog 0.6.1 singleRunStrategy can take 8-10 nodes when tool result triggers extra LLM reasoning. 2026-05-06 Garland attempt: 16 hit ITERATION_CAP repeatedly when executor chained walkOverworldTo retries + battleFightAll + askAdvisor in same turn. Bumped to 24 — small step above 20-cap risk but within range that V2-V5 occasionally tolerated. Tracking ITERATION_CAP rate across iterations.
     )
 
     suspend fun run(phase: FfPhase, input: String): String = try {

--- a/knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt
@@ -98,8 +98,37 @@ class AgentSession(
             println("[landmark-memory] preloaded ${landmarkMemory.all().size} landmarks (advisor + executor injection)")
         }
 
+        // V5.34: postbattle auto-dismiss zombie-loop guard. If RAM gets stuck
+        // in PostBattle/Battle screenState (e.g. enemy_dead flags clear but the
+        // engine never transitions back to overworld), the auto-dismiss branch
+        // below loops forever because `continue` skips the budget checks at
+        // line 241-243. Track consecutive dismissals; bail when threshold hit.
+        var consecutivePostBattle = 0
+        // V5.34.4: bumped 60→150. attempt9 evidence: agent fought 51 battles
+        // and hit the 60-dismiss cap exactly — bailing mid-progress. 51 battles
+        // × 3-4 screens each (XP / level-up / gold) = ~200 dismiss cycles
+        // possible. 150 gives headroom while still catching genuine zombie
+        // loops (no progress within ~150 frames is clearly stuck).
+        val POSTBATTLE_DISMISS_CAP = 150
+        // V5.34.3: confirm UnknownMapTrap before bail. attempt8 + FF1 disasm
+        // research showed (mapflags=1 + mapId=0) is NOT exclusively a trap:
+        // it also fires as a 1-frame artifact during battle entry on tile 0x00
+        // (FIGHT-normal random encounter). Require N consecutive observations
+        // and require phase is NOT Battle/PostBattle (those resolve themselves).
+        var consecutiveTrapObs = 0
+        val TRAP_CONFIRM_THRESHOLD = 3
+
         try {
             while (true) {
+                // V5.34: budget enforcement at TOP of loop, BEFORE phase
+                // observation. Previously these checks lived only after the
+                // phase-handling switch (line 241-243), so any branch that
+                // `continue`d would bypass them. Moved here so wallClock /
+                // skillCap always fire even when an inner branch loops.
+                val elapsedSec = (System.currentTimeMillis() - startMs) / 1000
+                if (elapsedSec > budget.wallClockCapSeconds) return Outcome.OutOfBudget
+                if (skillsInvoked > budget.maxSkillInvocations) return Outcome.OutOfBudget
+
                 val phase = observer.observeWithVision()
                 val ram = observer.ramSnapshot()
 
@@ -113,8 +142,52 @@ class AgentSession(
                 // until it clears, walkOverworldTo / exitInterior return BLOCKED. The LLM
                 // sometimes loops on these instead of calling battleFightAll, burning the
                 // budget. Auto-tap A here so the agent never waits on the modal.
+                // V5.34.2/3: detect UnknownMapTrap (mapId=0 + mapflags=1)
+                // with persistence guard. attempt7 evidence + FF1 disasm
+                // research: tile 0x00 has FIGHT-normal flag (random encounter,
+                // NOT teleport). Battle entry produces a 1-frame artifact
+                // where mapflags=1 + mapId=0 BEFORE screenState transitions
+                // to 0x68 (Battle). Require:
+                //   (a) 3 consecutive observations of trap state
+                //   (b) phase is NOT Battle/PostBattle (those self-resolve)
+                // Only then declare trap, persist warp memory, and bail.
+                val mapflagsBit = (ram["mapflags"] ?: 0) and 0x01
+                val ramMapIdNow = ram["currentMapId"] ?: -1
+                val isInTrapState = mapflagsBit == 1 && ramMapIdNow == 0 &&
+                    phase !is FfPhase.Battle && phase !is FfPhase.PostBattle
+                if (isInTrapState) {
+                    consecutiveTrapObs++
+                    if (consecutiveTrapObs >= TRAP_CONFIRM_THRESHOLD) {
+                        val trapX = ram["worldX"] ?: -1
+                        val trapY = ram["worldY"] ?: -1
+                        if (trapX in 0..255 && trapY in 0..255 &&
+                            (trapX to trapY) !in failedWarpTiles) {
+                            failedWarpTiles += trapX to trapY
+                            fog?.markBlocked(trapX, trapY)
+                            warpMemory.record(trapX, trapY, mapId = 0,
+                                note = "UnknownMapTrap — confirmed after $consecutiveTrapObs consecutive observations")
+                            warpMemory.save()
+                            println("[unknown-map-trap] persisted warp block at ($trapX,$trapY) after $consecutiveTrapObs obs")
+                        }
+                        trace.record(TraceEvent(0, "outcome", phase.toString(),
+                            note = "UnknownMapTrap at world($trapX,$trapY) — confirmed after $consecutiveTrapObs obs, bailing"))
+                        return Outcome.OutOfBudget
+                    }
+                } else {
+                    consecutiveTrapObs = 0
+                }
+
                 if (phase is FfPhase.PostBattle) {
-                    println("[postbattle auto-dismiss]")
+                    consecutivePostBattle++
+                    if (consecutivePostBattle > POSTBATTLE_DISMISS_CAP) {
+                        // V5.34: dismiss is not transitioning out of PostBattle —
+                        // engine is stuck (RAM enemy_dead flags clear but
+                        // screenState frozen). Bail rather than spam forever.
+                        trace.record(TraceEvent(0, "outcome", phase.toString(),
+                            note = "PostBattle dismiss zombie loop after $consecutivePostBattle attempts"))
+                        return Outcome.OutOfBudget
+                    }
+                    println("[postbattle auto-dismiss] ($consecutivePostBattle/$POSTBATTLE_DISMISS_CAP)")
                     toolset.executeAction(profileId = "ff1", actionId = "battle_fight_all")
                     trace.record(TraceEvent(
                         turn = 0, role = "system", phase = phase.toString(),
@@ -122,6 +195,7 @@ class AgentSession(
                     ))
                     continue  // re-observe phase next iteration
                 }
+                consecutivePostBattle = 0  // reset when phase leaves PostBattle
 
                 val phaseChanged = previousPhase == null || previousPhase::class != phase::class
                 // V4 hybrid C: advisor consult earlier when stuck inside an interior.
@@ -238,9 +312,7 @@ class AgentSession(
                     return hookOutcome
                 }
 
-                if (skillsInvoked > budget.maxSkillInvocations) return Outcome.OutOfBudget
-                val elapsedSec = (System.currentTimeMillis() - startMs) / 1000
-                if (elapsedSec > budget.wallClockCapSeconds) return Outcome.OutOfBudget
+                // V5.34: top-of-loop budget enforcement covers all cases now.
             }
         } finally {
             trace.close()

--- a/knes-agent/src/main/kotlin/knes/agent/skills/WalkOverworldTo.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/skills/WalkOverworldTo.kt
@@ -28,13 +28,28 @@ class WalkOverworldTo(
             "16x16 viewport. Marks non-moving steps as blocked. Aborts on random encounter."
 
     private val FRAMES_PER_TILE = 24
+    /** V5.33: post-battle/post-anything input-dead warmup. The FF1 engine
+     *  ignores button presses for ~30 frames after exiting Battle/PostBattle
+     *  back to the overworld — same root cause as ExplorerSession V5.2
+     *  post-loadState quirk. Without this, the very first step after a
+     *  random encounter routinely fails, fog-marks the destination tile,
+     *  and BFS self-poisons within 3 iterations. */
+    private val WARMUP_FRAMES = 30
 
     override suspend fun invoke(args: Map<String, String>): SkillResult {
         val tx = args["targetX"]?.toIntOrNull() ?: return SkillResult(false, "missing targetX")
         val ty = args["targetY"]?.toIntOrNull() ?: return SkillResult(false, "missing targetY")
-        val maxSteps = args["maxSteps"]?.toIntOrNull() ?: 32
+        // V5.34.1: bumped default 32→64. attempt6 evidence: BFS path from
+        // (152,150) to bridge (157,141) was 22 steps but required routing
+        // around peninsula water — single skill call exhausted maxSteps=32
+        // mid-route, ITERATION_CAP at executor level fired. 64 covers the
+        // longest realistic single-leg overworld walk (Coneria → Pravoka).
+        val maxSteps = args["maxSteps"]?.toIntOrNull() ?: 64
 
-        var totalFrames = 0
+        // V5.33: NOOP warmup before first step. See WARMUP_FRAMES doc.
+        toolset.step(buttons = emptyList(), frames = WARMUP_FRAMES)
+
+        var totalFrames = WARMUP_FRAMES
         var stepsTaken = 0
         // V5.15: detect "input dead" (e.g. fixture loadState quirk) — if the
         // party doesn't move for several consecutive iterations, abort with a
@@ -129,8 +144,18 @@ class WalkOverworldTo(
             val transitioned = ((ram1["mapflags"] ?: 0) and 0x01) != ((ram0["mapflags"] ?: 0) and 0x01) ||
                 (ram1["screenState"] ?: 0) != (ram0["screenState"] ?: 0)
             if (nx == cx && ny == cy && !transitioned) {
-                fog.markBlocked(cx + nextDir.dx, cy + nextDir.dy)
                 consecutiveNoMove++
+                // V5.33: defer fog.markBlocked until SECOND consecutive failure
+                // on this attempt. First failure is often a transient input-
+                // dead frame (post-battle, post-loadState, or sub-second engine
+                // animation). Fog-marking on first fail self-poisons BFS until
+                // 3-of-4 cardinal neighbours look "impassable" and the agent
+                // declares a false deadlock — see attempt4 evidence at (152,151)
+                // where (151,151) was fog-marked after a single failed W step
+                // post-battle, then BFS reported "no path" on next iteration.
+                if (consecutiveNoMove >= 2) {
+                    fog.markBlocked(cx + nextDir.dx, cy + nextDir.dy)
+                }
                 if (consecutiveNoMove >= INPUT_DEAD_THRESHOLD) {
                     val ram = toolset.getState().ram
                     return SkillResult(false,


### PR DESCRIPTION
## Summary

- **WalkOverworldTo (V5.33)**: 30-frame NOOP warmup at skill start (post-battle input-dead bridge) + defer `fog.markBlocked` until 2nd consecutive non-moving step (eliminates fog self-poisoning false deadlocks).
- **AgentSession (V5.34/V5.34.2/V5.34.3)**: budget enforcement at top of loop; postbattle auto-dismiss cap=150 (was infinite zombie loop); UnknownMapTrap detection requires 3-obs persistence + excludes Battle/PostBattle phases (was false-positive on tile 0x00 FIGHT-normal encounter entry).
- **AdvisorAgent prompt**: V5.32 frontier exploration bias, V5.34.4 Coneria town overlay navigation, V5.34.5 XP grind strategy (waypoint walks every 8-10 tiles).
- **ExecutorAgent**: `maxIterations` 16 → 24 (Koog chain ITERATION_CAP false-positives).

## Empirical progression

12 iterative attempts. Each fix unblocked the next bug. Agent went from infinite postbattle zombie loops to clean `OutOfBudget` termination, reached Coneria town overlay, fought 23-51 battles per run with intensive `exploreInteriorFrontier` use (327 calls in v11).

| Iter | Outcome | Max y N | Battles | Key fix |
|------|---------|---------|---------|---------|
| v2 | zombie loop | 153 | — | baseline |
| v6 | `OutOfBudget` | 149 | — | V5.34 postbattle cap |
| v9 | `OutOfBudget` | 149 | 51 | V5.34.3 confirmed trap detection |
| v11 | `OutOfBudget` | 149 | 23 | V5.34.4 town overlay + V5.34.5 grind |

**Garland not reached**; agent infrastructure hardening only. Coneria peninsula encounter density remains the primary blocker.

FF1 disasm research (Entroper/FF1Disassembly bank_0F.asm) confirmed: each visual tile_id has a 2-byte property entry in `tileset_prop` table; `byte2 & 0x80` = teleport, low 6 bits index `lut_EntrTele_X/Y/Map`. Tile 0x00 is `FIGHT-normal` (random encounter), NOT a teleport — so the earlier "hidden warp" hypothesis at (147,153)/(147,154) was actually a battle-entry artifact, addressed by V5.34.3 phase-aware trap detection.

## Test plan

- [ ] `./gradlew :knes-agent:test` passes (existing 233 / 2 pre-existing fails / 7 skipped baseline)
- [ ] Phase 2 run starts cleanly with bumped budget args
- [ ] No infinite `[postbattle auto-dismiss]` spam in stdout
- [ ] No false `[unknown-map-trap]` bail when crossing tile 0x00 FIGHT-normal grass
- [ ] Final `OUTCOME:` line printed on termination