### PR TITLE
Spec 5 (WIP): multi-mapId nav for buy + equip in Coneria

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,163 +1,137 @@
-# FF1 Koog Agent — Handoff (Spec 3a bridge→ToF + autonomous-run cold-start, 2026-05-08)
+# FF1 Koog Agent — Handoff (Spec 4 merged + Spec 5 WIP, 2026-05-08)
 
-**Branch HEAD:** `af500d0` on `ff1-bridge-and-walk-to-tof`. **No PR open.**
-**Parent branches:** `ff1-buy-at-shop` (Spec 2 + savestate cleanup) → `ff1-grind-strategy` (Spec 1, PR #116).
-**Tests:** 302 unit, 0 new regressions, 3 pre-existing baseline failures unchanged.
+**Branch HEAD:** `5bad78c` on `ff1-buy-and-equip-coneria`.
+**Open PR:** #120 (Spec 5 WIP) targeting `ff1-bridge-and-walk-to-tof`.
+**Merged this session:** PR #119 (Spec 4 — interior self-discovery vision pipeline).
+**Tests:** 333 unit (31 new pass · 3 baseline failures unchanged · 7 gated skipped).
+
+## Stack state
+
+```
+master
+  └─ ff1-grind-strategy           (PR #116 open — Spec 1)
+       └─ ff1-buy-at-shop         (no PR — Spec 2 + savestate cleanup)
+            └─ ff1-bridge-and-walk-to-tof   (no PR — Spec 3a)
+                 └─ Spec 4 merged here via PR #119 ← THIS SESSION
+                      └─ ff1-buy-and-equip-coneria  (PR #120 WIP — Spec 5, THIS SESSION)
+```
 
 ## What this session shipped
 
-### Spec 3a — bridge → walk to Temple of Fiends entrance
-Spec doc: `docs/superpowers/specs/2026-05-07-ff1-bridge-and-walk-to-tof-design.md`
-Plan: `docs/superpowers/plans/2026-05-07-ff1-bridge-and-walk-to-tof.md`
+### Spec 4 — Interior self-discovery vision scan (MERGED PR #119)
 
-7 implementation commits (`7f8c489` → `091e2ac`):
-- `LandmarkKind.TEMPLE_ENTRY` + `LandmarkMemory.findTempleEntry()` helper.
-- `HaikuConsult.classifyOverworldLandmark(image, kind)` interface method. `OverworldClassification` sealed type. Gemini implementation with chaos-shrine-specific prompt + parser. Anthropic stub returns `NotFound`.
-- `DiscoverChaosShrine` skill — captures viewport, calls Gemini, derives world coords via `ViewportMap.localToWorld`, persists `TEMPLE_ENTRY` landmark.
-- `BridgeTick` state machine — per-iteration: discover → walk → adjacency. Caps: 3 discover failures, 5 consecutive walk no-progress = sticky `BailToLlm`. `"encounter triggered"` message = no-stall continue.
-- `AgentSession` integration — 2 new optional ctor params, `bridgePhaseActive` flag (mutually exclusive with `grindModeActive`), main-loop gate, BRIDGE-decision flip site updated, terminal `bridge_phase_summary` trace events.
+Spec: `docs/superpowers/specs/2026-05-08-ff1-interior-self-discovery-design.md`
+Plan: `docs/superpowers/plans/2026-05-08-ff1-interior-self-discovery.md`
 
-15 new unit tests covering all 9 rows of spec §5 error matrix.
+Replaces brittle cold-start `discoverWeaponShop` probe with goal-aware `InteriorExplorer` composing existing `WalkInteriorVision` (unchanged) + new `InteriorScanner` (two-pass vision: Gemini Pass 1 candidate scan + Gemini Pro Pass 2 verify) + new `FrameChangeDetector` (PPU OAM with pixel-hash fallback).
 
-### Empirical fixes from real-API + real-ROM testing (5 commits)
+18 commits (12 implementation + 6 empirical-driven fixes from real ROM runs):
 
-`9f39387` **fix(vision): bump overworld classify maxOutputTokens 400→2000.** `gemini-2.5-pro` mandates thinking mode (`thinkingBudget=0` returns `400 Bad Request`); thinking consumes 400-600 tokens before producing output. Initial 400-token cap → empty responses 100% of the time.
+- `LandmarkKind` extended with `CHEST`, `SIGN`, `DIALOGUE_TRIGGER`
+- `HaikuConsult` interface: `scanInteriorCandidates` + `verifyLandmark` + `AdviceResponse` (Spec 5)
+- AnthropicHaikuConsult: real Pass 1 + Opus advisor; GeminiVisionConsult: real Pass 1+2
+- `FrameChangeDetector`: OAM primary + per-byte FNV-1a pixel-hash fallback
+- `InteriorScanner`: scanCandidates + verifyAndPersist + kind-string mapping
+- `InteriorExplorer`: full step loop with all error paths (StuckBailout/NotFoundCapReached/EncounterTriggered/Found)
+- Real adapters (`RealInteriorEmulatorState`, `RealWalkInteriorVisionAdapter`) — note OAM not exposed by emulator → fallback engaged automatically per spec §10.2
+- Wired into `OutfitBootPhase.discoverWeaponShop`
+- Telemetry: 7 new trace events (`interior_scan_*` + `interior_explore_outcome`)
 
-`29b3eee` **fix(vision): correct overworld viewport dimensions in prompt.** NES screen is 256×240 px = 16 tiles wide × **15** tall (not 16×16). Party renders at tile (8, 7), not (8, 8). `screenY` range 0..14 (not 0..15). Empirically verified by inspecting actual screenshots from `/screen` endpoint.
+Empirical-fix commits exposed by real runs:
+- pixel-hash detected only multi-byte changes (avg-truncation bug) → fixed to per-byte FNV-1a
+- `claude-opus-4-0` invalid → bumped `Opus_4` → `Opus_4_5` (max in koog 0.6.1)
+- `GeminiVisionConsult.scanInteriorCandidates` was Task 2 stub → real impl wired
+- `pass1-degraded` cap 3→10→30
+- walk-stuck cap 3→8→30, capSteps 50→100→200
+- `WalkInteriorVision` navigator Sonnet 4.6 → Opus 4.5
 
-`4defa54` **feat(main): wire HaikuConsult + outfit/bridge deps for autonomous agent runs.** `Main.kt` previously didn't wire any vision deps → boot phase + bridge phase silently no-op'd. Selected via `KNES_VISION` env var (mirrors `ExplorerMain` pattern); `gemini-pro` + `GEMINI_API_KEY` → `GeminiVisionConsult`, otherwise Anthropic Haiku stub.
+### Spec 5 — Multi-mapId nav for buy+equip (PR #120 WIP)
 
-`d74caff` **fix(session): defer OutfitBoot until first Overworld observation.** Previously `runOutfitBootPhase()` ran at the very top of `run()`, before any emulator stepping. At that point party is still at title screen, `worldX=worldY=0`, RAM uninitialized. `WalkOverworldTo(coneriaEntry)` failed with "stuck at (0,0): no path within viewport". Fix: gate boot trigger on first `phase is Overworld` observation inside the main loop.
+Branch: `ff1-buy-and-equip-coneria` cut from Spec 4 merge.
 
-`af500d0` **fix(boot): settle warp transition after walk-to-coneria.** `WalkOverworldTo` terminates the moment party RAM coords match destination, but FF1 engine's warp tile triggers a screen-fade + map-load that takes ~30 frames to update `currentMapId`. Without settling, step 3's `WalkInteriorVision` saw `mapId=0` → `NotInBuilding` → boot bailed before probing for shop. Fix: 30-frame idle + cardinal-tap nudge after walk.
+Goal: agent fizycznie wchodzi do weapon shop sub-interior, kupuje broń, ekwipuje. Spec 4 odkrył że BuyAtShop wymaga `landmark.mapId == currentMapId` AND party fizycznie stoi przed shopkeeperem — Spec 4 explorer scanuje ale nie navguje deliberately do shop interior.
 
-### Spec 2 cleanup (carried over from earlier in session)
+10 commits dwóch wariantów:
 
-Commit `9de2e94` on parent branch `ff1-buy-at-shop`: removed savestate-keyed `OutfitState` (file persistence, hash gate) in favor of RAM-derived skip (`StrategyContext.anyWeaponEquipped` for all 4 chars). Deleted `OutfitState.kt`, `OutfitStateTest.kt`, `OutfitBootPhaseE2ETest.kt`. -420 LOC. New no-savestate policy: `feedback_no_savestate.md`.
+**v1: hardcoded sweep** — `EnterConeriaWeaponShop` skill chodzi N+W per Mike's RPG Center map, sweep horizontal po hit wall, próbuje N at each X. Plus post-enter Pass 1 vision scan + walk-to-keeper.
 
-## Empirical validation results
+Empiryczny rezultat: party trafia w mapId=24 = Coneria CASTLE entrance hall (run 16 screenshot dump confirmed pillared corridor), nie weapon shop. Hardcoded sweep nie znajdzie shop door bez znajomości faktycznego layout.
 
-### What works (validated against real services)
-- Gemini 2.5 Pro API + production `SYSTEM_OVERWORLD_LANDMARK` prompt: returns `{"found": false}` reliably on overworld viewports without chaos shrine. Cost ~$0.005-0.007 per call.
-- `JSON_OBJECT` regex parser handles markdown-fenced JSON Gemini sometimes wraps responses in.
-- knes-api headless server + knes-mcp ROM driving + 256×240 PNG capture pipeline.
-- Spec 3a `BridgeTick` state machine — all 8 unit tests covering bail caps, encounter-aware stall, sticky bail.
-- `AgentSession.runOutfitBootPhase` correctly fires after first Overworld observation (post-`d74caff`).
-- Warp transition completes within 30-frame settle window (post-`af500d0`).
+**v2: Opus 4.5 advisor-driven** — `HaikuConsult.adviseShopApproach` interface; AnthropicHaikuConsult uses `claude-opus-4-5-20251101` directly via HTTP. Loop in `runOutfitBootPhase` calls advisor per iter z context (party position + Mike's map + stuck-count hint). Verify-and-retry: po mapId change, run Pass 1 — jeśli no shopkeeper, tap S 15× to exit, continue advisor loop. Dedicated `outfitAdvisor` ctor param (always Anthropic, bypasses KNES_VISION dispatch).
 
-### What does NOT yet work (next steps for future session)
+Empiryczny rezultat: Opus reasoning solid w tekście (run 21 trace ma rich reasoning per iter), stuck-detection works, verify-and-retry fires. ALE: run 22 entered castle ponownie po Left detour. Run 23: advisor stuck at (11, 23) iter 14-29 wszystkie Left, never Right. Agent nadal NIE kupił weapons.
 
-**Cold-start shop discovery is brittle.** Run #4 reached `boot_walk_settle: postWalkMapId=8` (party in Coneria town) but failed at:
-```
-boot_shop_probe: attempt=0 classify=ClassifyFailed: vision returned unknown
-boot_outfit_summary: boot_shop_not_found
-```
+## Empirical investment
 
-Root cause: `discoverWeaponShop`'s `maxAttempts = max(1, NPC_SHOPKEEPER landmark count)`. With **zero** seeded landmarks (cold start), only 1 probe attempt. The `WalkInteriorVision` (LLM-driven) walks somewhere, opens A-button menu, sends to Gemini for classification. If the menu isn't a BUY menu (or Gemini returns "unknown"), the boot phase exits.
+- Spec 4 validation: ~$18 across 6 runs (run 4-9)
+- Spec 5 validation: ~$45 across 14 runs (run 10-23)
+- **Total: ~$63 empirical validation** of Spec 4 + Spec 5 architecture
 
-Why Gemini returned "unknown" on attempt #0: probably because the probe didn't actually open a shop BUY menu — it might have walked into a non-shop tile and triggered a generic dialog instead. `WalkInteriorVision` is non-deterministic.
+Vision pipeline (Pass 1 + Pass 2) jest empirycznie potwierdzony. Multi-mapId navigation jest fundamentalnie trudna z aktualnym LLM spatial reasoning na NES pixel art.
 
-**Bridge phase never fired** — Spec 3a code path requires `min(char_level) ≥ 3` from grind which requires equipped weapons from outfit boot which is currently blocked above. So the actual `DiscoverChaosShrine` + `BridgeTick` code path is **unverified end-to-end against real ROM**.
+## What does NOT yet work
 
-**Adaptive anchor shift works** — run #4 logged `[strategy:grind] adaptive shift #1: anchor (146,158) -> (148,154)` after `NoEncounter`. Spec 1's adaptive grind eventually shifts toward the bridge area, but burns wall-clock budget along the way.
+- **Buy + equip e2e in Coneria**: agent identifies weapon shop position in text reasoning, ale spatial nav przez plaza zawodzi systematycznie. Czasami trafia w castle gate, czasami zacina się przy ścianach plazy mid-walk.
+- Both v1 (hardcoded sweep) i v2 (Opus advisor) failed — różne failure modes ale same outcome `weaponsBought=0`.
 
-## Branch state
+## Realistyczne ścieżki naprzód (Spec 6+ territory)
 
-```
-ff1-bridge-and-walk-to-tof  HEAD af500d0  (12 commits ahead of ff1-buy-at-shop)
-  ↑ cut from
-ff1-buy-at-shop             HEAD past 9de2e94  (Spec 2 + savestate cleanup)
-  ↑ cut from
-ff1-grind-strategy          PR #116 open (Spec 1)
-  ↑ open against
-master
-```
+1. **ROM-based interior pathfinder** — A* na `InteriorMapLoader` decoded tile data + door tile detection przez CHR-ROM analysis. Deterministic, generic, biggest effort. Eliminuje LLM cost dla nav entirely.
+2. **FF1 disasm vendoring** — extract sub-shop mapIds + door world coords z Disch FF1 disassembly. Hardcode preseed landmarks dla wszystkich miast/buildings. Deterministic, fast unblock.
+3. **Manualne gameplay-recorded path** — record exact tap sequence z Coneria spawn do weapon shop keeper przez human gameplay. Hardcode jako EnterConeriaWeaponShop. Brittle, Coneria-only, ale natychmiastowe. ~30 LoC.
 
-12 commits on Spec 3a branch:
-```
-af500d0 fix(boot): settle warp transition after walk-to-coneria
-d74caff fix(session): defer OutfitBoot until first Overworld observation
-4defa54 feat(main): wire HaikuConsult + outfit/bridge deps for autonomous agent runs
-29b3eee fix(vision): correct overworld viewport dimensions in prompt
-9f39387 fix(vision): bump overworld classify maxOutputTokens 400→2000
-091e2ac feat(session): wire BridgeTick — flip on BRIDGE, gate Overworld ticks, log summary
-5090824 feat(runtime): BridgeTick — deterministic post-BRIDGE walk to ToF entrance
-e42e5a8 feat(skill): DiscoverChaosShrine — vision-classify ToF entrance, persist landmark
-e6ed68e feat(vision): Gemini classifyOverworldLandmark — chaos shrine prompt + parser
-88aa89f feat(vision): add HaikuConsult.classifyOverworldLandmark + stubs
-8492d3e feat(perception): add LandmarkMemory.findTempleEntry() helper
-7f8c489 feat(perception): add LandmarkKind.TEMPLE_ENTRY for ToF entrance
-```
+Recommendation: opcja **3** najszybciej unblockuje buy+equip e2e (~30 min pracy, $0 run cost dla manual recording, $3 dla validation run). Opcja **2** scaling later (Pravoka, Elfheim, etc).
 
-## Conclusions / lessons from this session
-
-1. **Unit tests passing ≠ end-to-end works.** Spec 3a had 15 green unit tests when "implementation complete" was declared, but 4 distinct production bugs only surfaced when the agent actually ran against real ROM + real Gemini API. Two of those (warp-transition race, OutfitBoot fire timing) were latent in Spec 2 and never caught because Spec 2's e2e test loaded a savestate that pre-positioned the party past those code paths.
-
-2. **No-savestate policy increases empirical cost but improves coverage.** Removing `FF1_SAVESTATE`-gated tests (per `feedback_no_savestate.md`) means tests must run from genuine title-screen start. That's expensive but exposes real cold-start bugs that savestate-shortcut tests masked. The 3 fixes above (`4defa54`, `d74caff`, `af500d0`) are direct dividends.
-
-3. **Production prompts need empirical iteration against the real model.** The `SYSTEM_OVERWORLD_LANDMARK` prompt had three errors only visible from real Gemini calls: (a) `maxOutputTokens` too small for thinking mode, (b) viewport described as 16×16 when NES is 16×15, (c) party position misstated as (8,8) when actually (8,7). Unit tests with `FakeHaikuConsult` returning fake `Found(11,4)` would never catch these.
-
-4. **Cold-start without landmarks is genuinely hard.** The `discoverWeaponShop` flow assumes prior runs seeded `NPC_SHOPKEEPER` landmarks. From a fresh state, `maxAttempts=1` is too few; `WalkInteriorVision`'s LLM-driven probe may walk into a non-shop tile and never recover. This is upstream of Spec 3a but blocks its end-to-end validation.
-
-5. **Autonomous Anthropic Opus runs cost real money.** Each ~10 min run with executor LLM consumes $1-3 in API tokens. Empirical iteration against full game-flow is not free; budget caps must be tight, and bug-fix iterations should target one issue per run to avoid spending budget on already-known failures.
-
-6. **Agent's empirical run reproduced same failure I hit manually.** When I tried hand-driving FF1 via curl/MCP earlier in the session, I also got stuck navigating around water/forest near Coneria peninsula. The agent ran into the same bridge-finding difficulty. This suggests the BFS pathfinder + adaptive anchor shift work in principle but need either better seeding or coord-targeted interior nav.
-
-## Known concerns to flag in eventual PR
-
-1. **`SYSTEM_OVERWORLD_LANDMARK` prompt is heuristic for chaos shrine recognition** — empirically validated only on negative case (no shrine in viewport). Positive case (shrine present) needs first real run that reaches that viewport.
-2. **`WalkOverworldTo` BFS over bridge tile (157, 141)** — assumed walkable per FF1 overworld decoder; first validation run will confirm.
-3. **Cold-start shop discovery `maxAttempts=1`** is the upstream blocker for Spec 3a end-to-end validation. Follow-up spec needed: bump cap, or pre-seed shopkeeper landmarks via vision scan, or add deterministic shop-finding via FF1 ROM map data.
-4. **Manhattan ≤ 1 adjacency tolerates** the 1-tile Y offset between Gemini's reported coords (real party at tile (8,7)) and `ViewportMap.partyLocalXY=(8,8)` abstraction. Functionally OK; documented in `29b3eee` commit message.
-
-## Next session entry point
-
-**Highest-leverage:** unblock Spec 3a end-to-end validation by fixing cold-start shop discovery. Three options:
-- (A) Bump `discoverWeaponShop`'s `maxAttempts` to 4-8 unconditionally; let probe try multiple buildings.
-- (B) Pre-seed 4-6 candidate `NPC_SHOPKEEPER` landmarks for Coneria from FF1 disasm map data (deterministic, no run-time vision).
-- (C) Replace `WalkInteriorVision` with coordinate-targeted interior nav (Spec 3a known concern #1, deferred).
-
-After unblock: full autonomous run (~10 min, $3-5 budget) should reach BRIDGE decision → BridgePhase → discoverChaosShrine → first positive-case validation of Gemini overworld landmark recognition.
-
-**Lower priority:**
-- Open Spec 2 PR (parent: PR #116). Spec 2 cleanup (`9de2e94`) needs to land before Spec 3a PR.
-- Open Spec 3a PR (parent: ff1-buy-at-shop after Spec 2 lands).
-- Consider committing `HANDOFF.md` updates and any agent-discovered landmarks.
-
-## Run command (with current Main.kt wiring)
+## Run command (current state, KNES_VISION=gemini-pro)
 
 ```bash
-# Pre-seed Coneria TOWN_ENTRY (cold-start otherwise drops boot phase)
+rm -f ~/.knes/ff1-*.json
 cat > ~/.knes/ff1-landmarks.json <<'JSON'
-{
-  "version": 1,
-  "landmarks": [
-    {"id":"interior_entry_8_146_152","kind":"TOWN_ENTRY","worldX":146,"worldY":152,
-     "mapIdInterior":8,"visited":true,"note":"coneria-town entry","discoveredRunId":"preseed"}
-  ]
-}
+{"version":1,"landmarks":[
+  {"id":"interior_entry_8_146_152","kind":"TOWN_ENTRY","worldX":146,"worldY":152,
+   "mapIdInterior":8,"visited":true,"note":"coneria-town entry","discoveredRunId":"preseed"},
+  {"id":"weapon_shopkeeper_preseed","kind":"NPC_SHOPKEEPER","visited":false,
+   "note":"kind=weapon; preseed-mike-rpg-map; items=staff:5,dagger:5,nunchuck:10,rapier:10,hammer:10",
+   "discoveredRunId":"preseed"}
+]}
 JSON
-rm -f ~/.knes/ff1-overworld-warps.json ~/.knes/ff1-blockages.json \
-      ~/.knes/ff1-overworld-terrain.json ~/.knes/ff1-interior-memory.json \
-      ~/.knes/ff1-ow-memory.json
 
-KNES_VISION=gemini-pro \
+KNES_VISION=gemini-pro ANTHROPIC_API_KEY=... GEMINI_API_KEY=... \
   ./gradlew :knes-agent:run --args="--rom=$PWD/roms/ff.nes \
-    --wall-clock-cap-seconds=600 \
-    --cost-cap-usd=3.0 \
-    --max-skill-invocations=120"
+    --wall-clock-cap-seconds=600 --cost-cap-usd=5.0 --max-skill-invocations=120"
 ```
-
-Required env: `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`. Without `KNES_VISION=gemini-pro` the boot/bridge phases silently no-op.
 
 Watch traces:
 ```bash
 LATEST=$(ls -td ~/.knes/runs/*/ | head -1)
-grep -E '"phase":"BOOT"|bridge_phase_summary|bridge_tick' "$LATEST/trace.jsonl"
+grep -E 'boot_advisor|boot_purchase|boot_outfit_summary' "$LATEST/trace.jsonl"
+ls /tmp/spec5-postenter*.png  # diagnostic dumps
 ```
 
-Expected after cold-start fix:
-- `boot_outfit_summary: weaponsBought=N weaponsEquipped=M` with N,M ≥ 1
-- `[strategy] BRIDGE` after `min_level=3`
-- `bridge_phase_summary: reached at (x,y)` with `(x,y)` ≈ ToF entrance
-- `OUTCOME: AtGarlandBattle` would be Spec 3b/3c — Spec 3a stops at adjacency.
+## Repo paths
+
+- Spec 4 design: `docs/superpowers/specs/2026-05-08-ff1-interior-self-discovery-design.md`
+- Spec 4 plan: `docs/superpowers/plans/2026-05-08-ff1-interior-self-discovery.md`
+- Spec 5 (no spec doc — POC implementation directly): `knes-agent/src/main/kotlin/knes/agent/skills/EnterConeriaWeaponShop.kt`
+- Empirical observations: trace.jsonl per run in `~/.knes/runs/`
+
+## Lessons / observations
+
+1. **Vision pipeline (Pass 1+2) działa empirycznie** — Gemini Pro reliably identifies real NES sprites (`stairs_up`, `exit_tile`, `EXIT_TILE` confirmed). Pixel-hash fallback engaged automatically (PPU OAM not exposed by emulator).
+
+2. **LLM spatial reasoning na NES pixel art jest słaba** — Opus 4.5 produces solid text reasoning but cannot reliably navigate from screenshot. NES pixel art (256x240, 8-bit colormap) lacks signal for Opus to identify door tiles vs walls vs floor.
+
+3. **Hardcoded sweep nie skaluje się bez disasm knowledge** — guessing X offsets reliably lands in castle gate (top center of plaza), nie w shops. Coneria buildings spread laterally; doors not lined up at single Y.
+
+4. **Spec 4 i Spec 5 są separate concerns** — vision pipeline (Spec 4) działa niezależnie od navigation (Spec 5). Vision tylko **rozpoznaje** landmarks; nawigacja **dostaje** party do nich. Spec 4 merged unchanged; Spec 5 wymaga nowej drogi.
+
+5. **`autonomy_principle.md` constraint hard** — bez "agent gra grę" bypass-u (savestate, pre-recorded paths), każde discovery wymaga real LLM call + real movement. Drogo iterować.
+
+6. **Anthropic 5xx errors transient** — claude-opus-4-0 → 500 (invalid model id, fixed); 529 overloaded (transient, retry).
+
+7. **Gradle daemon corruption ujawniona** — first session miała hangs przez stale daemon registry; clean `~/.gradle/daemon/9.4.1` + new shell session resolved.
+
+## Autonomy + no-savestate principles (carried over)
+
+- Agent gra grę; dev nie. Per `autonomy_principle.md`.
+- New specs nie używają savestate-hash-keyed flags ani FF1_SAVESTATE-gated e2e tests; persistence flows through `landmarkMemory`. Per `feedback_no_savestate.md`.

--- a/knes-agent/src/main/kotlin/knes/agent/Main.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/Main.kt
@@ -80,6 +80,11 @@ fun main(args: Array<String>) {
                 }
             }
 
+            // Spec 5: dedicated Opus advisor for shop nav (always Anthropic,
+            // bypasses KNES_VISION dispatch). Implementation in
+            // AnthropicHaikuConsult.adviseShopApproach uses Opus 4.5 directly.
+            val outfitAdvisor: HaikuConsult = AnthropicHaikuConsult(apiKey = key)
+
             AgentSession(
                 toolset = toolset,
                 observer = observer,
@@ -90,6 +95,7 @@ fun main(args: Array<String>) {
                 fog = fog,
                 landmarkMemory = landmarkMemory,
                 outfitVision = visionBackend,
+                outfitAdvisor = outfitAdvisor,
                 outfitNavigator = visionInteriorNavigator,
                 outfitViewportSource = overworldMap,
                 outfitMapSession = mapSession,

--- a/knes-agent/src/main/kotlin/knes/agent/explorer/AnthropicHaikuConsult.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/explorer/AnthropicHaikuConsult.kt
@@ -240,28 +240,38 @@ class AnthropicHaikuConsult(
 
 The screenshot shows the FF1 NES viewport (256x240 px, 16x15 tiles). The party renders at viewport tile (8, 7).
 
-Coneria town map (per Mike's RPG Center reference):
-- Spawn: south of plaza, near building 1 (INN). Walking N enters the central plaza.
-- Building 1 (INN): south part of plaza, central
-- Building 2 (Armor shop): middle-row, west of plaza
-- Building 3 (Weapon shop): middle-row, east of armor (immediately right of building 2)
-- Building 4 (Black Magic): top-left, north of plaza
-- Building 5 (White Magic): top, immediately right of building 4
-- Building 6 (Clinic): top-right, far east
-- Building 7 (Item shop): middle-right, east side
-- Castle: north exit of plaza (gate at top-center, large pillared corridor leads to throne room)
+CONERIA TOWN MAP (mapId=8) — empirically observed coordinate layout:
+- Party SPAWN: smPlayer(12, 35) — south plaza, just north of town entry
+- Plaza area: smPlayerY 18-30, smPlayerX 4-22 (open floor)
+- CASTLE GATE: smPlayer(~10-12, ~16-18) — TOP CENTER of plaza, leads to mapId=24 (NOT a shop! It's a long pillared corridor — AVOID).
+- Building doors are on south walls. To enter, step N onto door tile.
 
-Doors are on the SOUTH wall of each building. To enter a building, walk to the door tile and step N — mapId will change.
+CRITICAL — buildings to AVOID:
+- CASTLE GATE at smPlayer(10-12, ~17): if party blocked moving Up at Y=18 with X near 11-12, the wall in front IS the castle entrance. DO NOT enter.
 
-Your task: recommend ONE single-step action to move party closer to the WEAPON SHOP (building 3). Look at the screenshot carefully — identify the party (4-character sprite at viewport center), then identify the surrounding buildings.
+Building positions (approximate smPlayer X — verify with screenshot landmarks):
+- Building 1 INN: south plaza X=10-13, Y~30
+- Building 2 ARMOR shop: middle-west, X~5-7, Y~18-20
+- Building 3 WEAPON shop: middle-west, X~8-9 (just east of armor), Y~18-20
+- Building 4 BLACK MAGIC: top-west, X~3-5, Y~10
+- Building 5 WHITE MAGIC: top, X~7-9, Y~10
+- Building 7 ITEM shop: middle-east, X~22-24, Y~18-20
+
+Strategy from spawn (12, 35):
+1. Walk N until Y~21 (mid-plaza)
+2. Walk W (Left) until X~8-9 (toward weapon shop)
+3. Walk N — should now hit weapon shop south wall
+4. Try Tap_A or step onto specific door tile (door is one-tile gap in wall)
+
+If blocked moving Up between Y=17 and Y=18, you are at CASTLE GATE — back off (Down) and re-route West/East.
 
 Output JSON only, no prose. Schema:
 {"action":"Up|Down|Left|Right|Tap_A|Done|Fail","reason":"<short>"}
 
 Rules:
 - Up/Down/Left/Right: move party one tile in that direction
-- Tap_A: try to interact with what's directly in front of party (e.g., open door, talk to NPC)
-- Done: party is already inside the weapon shop interior
+- Tap_A: try to interact with what's directly in front of party
+- Done: party is already inside the weapon shop interior (mapId changed AND keeper visible)
 - Fail: cannot determine path — abort
 """
 

--- a/knes-agent/src/main/kotlin/knes/agent/explorer/AnthropicHaikuConsult.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/explorer/AnthropicHaikuConsult.kt
@@ -103,6 +103,30 @@ class AnthropicHaikuConsult(
         return HaikuConsult.VerifyResult.Errored("stub-not-implemented", 0.0)
     }
 
+    /** Spec 5: Opus 4.5 advisor for one-step interior navigation. */
+    override suspend fun adviseShopApproach(
+        screenshotBase64: String?,
+        contextText: String,
+    ): HaikuConsult.AdviceResponse {
+        if (screenshotBase64.isNullOrEmpty()) {
+            return HaikuConsult.AdviceResponse("Fail", "no-screenshot", 0.0)
+        }
+        return try {
+            // Build body with Opus model override (bypassing default Haiku model).
+            val body = buildBodyWithModel(
+                modelOverride = ADVISOR_MODEL,
+                systemPrompt = SYSTEM_ADVISOR,
+                userText = contextText,
+                b64 = screenshotBase64,
+                maxTokens = 800,
+            )
+            val raw = postOrNull(body) ?: return HaikuConsult.AdviceResponse("Fail", "api-error", 0.0)
+            parseAdvice(raw)
+        } catch (e: Throwable) {
+            HaikuConsult.AdviceResponse("Fail", "exception: ${e.message}", 0.0)
+        }
+    }
+
     override fun close() { client.close() }
 
     private suspend fun postOrNull(body: String): String? {
@@ -138,9 +162,18 @@ class AnthropicHaikuConsult(
         return buildBody(systemPrompt = SYSTEM_DIALOG, userText = userText, b64 = b64, maxTokens = 200)
     }
 
-    private fun buildBody(systemPrompt: String, userText: String, b64: String?, maxTokens: Int): String {
+    private fun buildBody(systemPrompt: String, userText: String, b64: String?, maxTokens: Int): String =
+        buildBodyWithModel(model, systemPrompt, userText, b64, maxTokens)
+
+    private fun buildBodyWithModel(
+        modelOverride: String,
+        systemPrompt: String,
+        userText: String,
+        b64: String?,
+        maxTokens: Int,
+    ): String {
         val obj = buildJsonObject {
-            put("model", model)
+            put("model", modelOverride)
             put("max_tokens", maxTokens)
             put("system", systemPrompt)
             put("messages", buildJsonArray {
@@ -168,8 +201,69 @@ class AnthropicHaikuConsult(
         return obj.toString()
     }
 
+    private fun parseAdvice(raw: String): HaikuConsult.AdviceResponse {
+        return try {
+            val match = JSON_OBJECT.find(raw)?.value
+                ?: return HaikuConsult.AdviceResponse("Fail", "envelope-malformed", 0.0)
+            val envelope = json.parseToJsonElement(match).jsonObject
+            // Extract usage cost (Opus 4.5 pricing: $15/MTok in, $75/MTok out)
+            val usage = envelope["usage"]?.jsonObject
+            val inTok = usage?.get("input_tokens")?.jsonPrimitive?.intOrNull ?: 0
+            val outTok = usage?.get("output_tokens")?.jsonPrimitive?.intOrNull ?: 0
+            val cost = inTok * 15.0e-6 + outTok * 75.0e-6
+            // Extract content[0].text
+            val content = envelope["content"]?.jsonArray?.firstOrNull()?.jsonObject
+            val text = content?.get("text")?.jsonPrimitive?.contentOrNull
+                ?: return HaikuConsult.AdviceResponse("Fail", "no-content", cost)
+            // Find inner JSON in advice response
+            val innerMatch = JSON_OBJECT.find(text)?.value
+                ?: return HaikuConsult.AdviceResponse("Fail", "advice-not-json: ${text.take(80)}", cost)
+            val advice = json.parseToJsonElement(innerMatch).jsonObject
+            val action = advice["action"]?.jsonPrimitive?.contentOrNull ?: "Fail"
+            val reason = advice["reason"]?.jsonPrimitive?.contentOrNull ?: "no-reason"
+            HaikuConsult.AdviceResponse(action, reason, cost)
+        } catch (e: Throwable) {
+            HaikuConsult.AdviceResponse("Fail", "parse-exception: ${e.message}", 0.0)
+        }
+    }
+
     companion object {
         private const val API_URL = "https://api.anthropic.com/v1/messages"
+
+        // Spec 5: Opus 4.5 used for interior nav advice (richer spatial reasoning).
+        // The koog AnthropicModels enum tops out at Opus_4_5 in version 0.6.1; we
+        // hardcode the dated id directly to bypass the framework's model dispatch.
+        private const val ADVISOR_MODEL = "claude-opus-4-5-20251101"
+
+        private const val SYSTEM_ADVISOR =
+            """You are a navigation advisor for an autonomous Final Fantasy 1 (NES) agent inside Coneria town.
+
+The screenshot shows the FF1 NES viewport (256x240 px, 16x15 tiles). The party renders at viewport tile (8, 7).
+
+Coneria town map (per Mike's RPG Center reference):
+- Spawn: south of plaza, near building 1 (INN). Walking N enters the central plaza.
+- Building 1 (INN): south part of plaza, central
+- Building 2 (Armor shop): middle-row, west of plaza
+- Building 3 (Weapon shop): middle-row, east of armor (immediately right of building 2)
+- Building 4 (Black Magic): top-left, north of plaza
+- Building 5 (White Magic): top, immediately right of building 4
+- Building 6 (Clinic): top-right, far east
+- Building 7 (Item shop): middle-right, east side
+- Castle: north exit of plaza (gate at top-center, large pillared corridor leads to throne room)
+
+Doors are on the SOUTH wall of each building. To enter a building, walk to the door tile and step N — mapId will change.
+
+Your task: recommend ONE single-step action to move party closer to the WEAPON SHOP (building 3). Look at the screenshot carefully — identify the party (4-character sprite at viewport center), then identify the surrounding buildings.
+
+Output JSON only, no prose. Schema:
+{"action":"Up|Down|Left|Right|Tap_A|Done|Fail","reason":"<short>"}
+
+Rules:
+- Up/Down/Left/Right: move party one tile in that direction
+- Tap_A: try to interact with what's directly in front of party (e.g., open door, talk to NPC)
+- Done: party is already inside the weapon shop interior
+- Fail: cannot determine path — abort
+"""
 
         // Haiku 4.5 pricing (Anthropic, late 2025): $1 / MTok input, $5 / MTok output.
         // If pricing changes the absolute cost number drifts but the budget cap still triggers.

--- a/knes-agent/src/main/kotlin/knes/agent/explorer/GeminiVisionConsult.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/explorer/GeminiVisionConsult.kt
@@ -133,6 +133,13 @@ class GeminiVisionConsult(
         }
     }
 
+    /** Spec 5: advisor stubbed in Gemini — Anthropic Opus is used for nav advice. */
+    override suspend fun adviseShopApproach(
+        screenshotBase64: String?,
+        contextText: String,
+    ): HaikuConsult.AdviceResponse =
+        HaikuConsult.AdviceResponse("Fail", "gemini-stub-not-implemented", 0.0)
+
     override fun close() { client.close() }
 
     private suspend fun postOrNull(body: String): String? {

--- a/knes-agent/src/main/kotlin/knes/agent/explorer/HaikuConsult.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/explorer/HaikuConsult.kt
@@ -109,6 +109,19 @@ interface HaikuConsult {
         candidateScreenX: Int,
         candidateScreenY: Int,
     ): VerifyResult
+
+    /** Spec 5: Opus advisor for one-step navigation toward a goal. */
+    data class AdviceResponse(
+        /** "Up" | "Down" | "Left" | "Right" | "Tap_A" | "Done" | "Fail" */
+        val action: String,
+        val reason: String,
+        val costUsd: Double,
+    )
+
+    suspend fun adviseShopApproach(
+        screenshotBase64: String?,
+        contextText: String,
+    ): AdviceResponse
 }
 
 /** Test fake. Pass canned results in constructor; assert calls via `interiorCalls`/`dialogCalls`/`shopCalls`. */
@@ -181,5 +194,12 @@ class FakeHaikuConsult(
             ?: HaikuConsult.VerifyResult.Errored("fake-not-scripted", 0.0)
         verifyCalls++
         return res
+    }
+
+    override suspend fun adviseShopApproach(
+        screenshotBase64: String?,
+        contextText: String,
+    ): HaikuConsult.AdviceResponse {
+        return HaikuConsult.AdviceResponse("Fail", "fake-not-scripted", 0.0)
     }
 }

--- a/knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt
@@ -704,6 +704,50 @@ class AgentSession(
             }
         }
 
+        // 3c. Spec 5: post-enter vision-driven approach. Run 13 confirmed
+        //     EnterShop reaches a sub-shop (mapId=24) but blocks at a wall
+        //     before the keeper, so BuyAtShop's tap-A loop never opens the
+        //     BUY menu. Use Pass 1 vision to spot the shopkeeper in the
+        //     screen and walk party to (sx, sy+1) facing N — same Spec 4
+        //     pipeline already proven in §empirical run 8.
+        run {
+            val screenshot = toolset.getScreen().base64
+            val scan = outfitVision!!.scanInteriorCandidates(screenshot)
+            trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
+                note = "boot_post_enter_scan: count=${scan.candidates.size} " +
+                       "kinds=[${scan.candidates.joinToString(",") { it.kind }}] " +
+                       "costUsd=${scan.costUsd}"))
+            val keeper = scan.candidates
+                .filter { it.kind == "shopkeeper" }
+                .maxByOrNull { it.confidence }
+            if (keeper != null) {
+                // Party renders at viewport tile (8, 7). Walk so party stands at
+                // (sx, sy + 1) facing N — directly south of keeper.
+                val dx = keeper.screenX - 8
+                val dyTarget = (keeper.screenY + 1) - 7
+                val xDir = if (dx < 0) "Left" else "Right"
+                val yDir = if (dyTarget < 0) "Up" else "Down"
+                repeat(kotlin.math.abs(dx)) {
+                    toolset.tap(button = xDir, count = 1, pressFrames = 12, gapFrames = 8)
+                    toolset.step(buttons = emptyList(), frames = 8)
+                }
+                repeat(kotlin.math.abs(dyTarget)) {
+                    toolset.tap(button = yDir, count = 1, pressFrames = 12, gapFrames = 8)
+                    toolset.step(buttons = emptyList(), frames = 8)
+                }
+                // Final N-tap so facing stays N (in case last move was horizontal
+                // or a Down for descending toward keeper).
+                toolset.tap(button = "Up", count = 1, pressFrames = 12, gapFrames = 8)
+                toolset.step(buttons = emptyList(), frames = 8)
+                trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
+                    note = "boot_keeper_approach: keeper_screenXY=(${keeper.screenX},${keeper.screenY}) " +
+                           "walked dx=$dx dy=$dyTarget"))
+            } else {
+                trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
+                    note = "boot_keeper_approach: NO_SHOPKEEPER_IN_VIEW; BuyAtShop will likely fail"))
+            }
+        }
+
         // 4. Per-char buy loop.
         val buySkill = BuyAtShop(toolset, landmarkMemory)
         val charsBought = mutableListOf<Int>()

--- a/knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt
@@ -691,16 +691,72 @@ class AgentSession(
         //     sub-interior so BuyAtShop's `landmark.mapId == currentMapId` precondition
         //     holds. Skipped if party already inside a sub-shop (mapId != 8) — e.g.
         //     warm-start where an earlier run left the party in the shop.
-        val currentMapId = toolset.getState().ram["currentMapId"] ?: 0
-        if (currentMapId == 8) {
-            val enterSkill = EnterConeriaWeaponShop(toolset, landmarkMemory)
-            val r = enterSkill.invoke(emptyMap())
-            trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
-                note = "boot_enter_shop: ${r.message}"))
-            if (!r.ok) {
+        val initialMapId = toolset.getState().ram["currentMapId"] ?: 0
+        if (initialMapId == 8) {
+            // Spec 5 v2: Opus advisor-driven walk. Hardcoded sweep landed in
+            // castle (run 16 confirmed mapId=24 = castle entrance hall). Use
+            // Opus 4.5 with map context to find weapon shop door step-by-step.
+            val maxAdvisorIters = 20
+            var entered = false
+            var advisorTotalCost = 0.0
+            for (iter in 0 until maxAdvisorIters) {
+                val ram = toolset.getState().ram
+                val curMapId = ram["currentMapId"] ?: 0
+                if (curMapId != 8 && curMapId != 0) {
+                    entered = true
+                    break
+                }
+                val sx = ram["smPlayerX"] ?: 0
+                val sy = ram["smPlayerY"] ?: 0
+                val screenshot = toolset.getScreen().base64
+                val context = "Iteration $iter of $maxAdvisorIters. " +
+                    "Party is at smPlayer($sx, $sy) in Coneria town overlay (mapId=8). " +
+                    "Goal: enter the WEAPON SHOP (building 3 — middle row, just east of armor shop). " +
+                    "Avoid the CASTLE GATE at top-center of the plaza. Recommend ONE step toward the weapon shop."
+                val advice = outfitVision!!.adviseShopApproach(screenshot, context)
+                advisorTotalCost += advice.costUsd
                 trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
-                    note = "boot_outfit_summary: enter_shop_failed"))
+                    note = "boot_advisor[$iter]: action=${advice.action} reason=${advice.reason} costUsd=${advice.costUsd}"))
+                when (advice.action) {
+                    "Up", "Down", "Left", "Right" ->
+                        toolset.tap(advice.action, count = 1, pressFrames = 12, gapFrames = 8)
+                    "Tap_A" -> toolset.tap("A", count = 1, pressFrames = 5, gapFrames = 12)
+                    "Done", "Fail" -> {
+                        trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
+                            note = "boot_advisor_terminate: ${advice.action} after $iter iters"))
+                        break
+                    }
+                    else -> {
+                        trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
+                            note = "boot_advisor_unknown_action: ${advice.action}"))
+                        break
+                    }
+                }
+                toolset.step(buttons = emptyList(), frames = 8)
+            }
+            trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
+                note = "boot_advisor_summary: entered=$entered totalCostUsd=$advisorTotalCost"))
+            if (!entered) {
+                trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
+                    note = "boot_outfit_summary: advisor_failed_to_enter_shop"))
                 return
+            }
+            // Update cached weapon-shop landmark with discovered sub-shop mapId.
+            val postRam = toolset.getState().ram
+            val postMapId = postRam["currentMapId"] ?: 0
+            val postX = postRam["smPlayerX"] ?: 0
+            val postY = postRam["smPlayerY"] ?: 0
+            val cached = landmarkMemory.findByKind(LandmarkKind.NPC_SHOPKEEPER)
+                .firstOrNull { it.note.contains("kind=weapon") }
+            if (cached != null && cached.mapId != postMapId) {
+                landmarkMemory.recordIfNew(cached.copy(
+                    mapId = postMapId,
+                    localX = postX,
+                    localY = postY,
+                    visited = true,
+                    note = cached.note + "; entered_via=opus-advisor",
+                ))
+                landmarkMemory.save()
             }
         }
 

--- a/knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt
@@ -712,11 +712,17 @@ class AgentSession(
         //     pipeline already proven in §empirical run 8.
         run {
             val screenshot = toolset.getScreen().base64
+            // Always dump post-enter screenshot for diagnostic — gives visual
+            // evidence of which sub-shop we entered.
+            try {
+                val bytes = java.util.Base64.getDecoder().decode(screenshot)
+                java.io.File("/tmp/spec5-postenter.png").writeBytes(bytes)
+            } catch (_: Throwable) {}
             val scan = outfitVision!!.scanInteriorCandidates(screenshot)
             trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
                 note = "boot_post_enter_scan: count=${scan.candidates.size} " +
                        "kinds=[${scan.candidates.joinToString(",") { it.kind }}] " +
-                       "costUsd=${scan.costUsd}"))
+                       "costUsd=${scan.costUsd} (screenshot: /tmp/spec5-postenter.png)"))
             val keeper = scan.candidates
                 .filter { it.kind == "shopkeeper" }
                 .maxByOrNull { it.confidence }

--- a/knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt
@@ -697,9 +697,12 @@ class AgentSession(
             // Spec 5 v2: Opus advisor-driven walk. Hardcoded sweep landed in
             // castle (run 16 confirmed mapId=24 = castle entrance hall). Use
             // Opus 4.5 with map context to find weapon shop door step-by-step.
-            val maxAdvisorIters = 20
+            val maxAdvisorIters = 25
             var entered = false
             var advisorTotalCost = 0.0
+            var prevSx = -1
+            var prevSy = -1
+            var stuckCount = 0
             for (iter in 0 until maxAdvisorIters) {
                 val ram = toolset.getState().ram
                 val curMapId = ram["currentMapId"] ?: 0
@@ -709,11 +712,24 @@ class AgentSession(
                 }
                 val sx = ram["smPlayerX"] ?: 0
                 val sy = ram["smPlayerY"] ?: 0
+                if (iter > 0 && sx == prevSx && sy == prevSy) {
+                    stuckCount++
+                } else {
+                    stuckCount = 0
+                }
+                prevSx = sx
+                prevSy = sy
                 val screenshot = toolset.getScreen().base64
+                val stuckHint = if (stuckCount > 0) {
+                    " IMPORTANT: party position has not changed for $stuckCount iteration(s) — " +
+                        "you are BLOCKED by a wall. Try a different direction (Left/Right) to find a door."
+                } else ""
                 val context = "Iteration $iter of $maxAdvisorIters. " +
                     "Party is at smPlayer($sx, $sy) in Coneria town overlay (mapId=8). " +
                     "Goal: enter the WEAPON SHOP (building 3 — middle row, just east of armor shop). " +
-                    "Avoid the CASTLE GATE at top-center of the plaza. Recommend ONE step toward the weapon shop."
+                    "Avoid the CASTLE GATE at top-center of the plaza." +
+                    stuckHint +
+                    " Recommend ONE step toward the weapon shop."
                 val advisor = outfitAdvisor ?: outfitVision!!
                 val advice = advisor.adviseShopApproach(screenshot, context)
                 advisorTotalCost += advice.costUsd

--- a/knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt
@@ -5,6 +5,7 @@ import knes.agent.advisor.StrategyAdvice
 import knes.agent.executor.ExecutorAgent
 import knes.agent.explorer.HaikuConsult
 import knes.agent.skills.BuyAtShop
+import knes.agent.skills.EnterConeriaWeaponShop
 import knes.agent.skills.EquipWeapon
 import knes.agent.skills.ExitInterior
 import knes.agent.skills.GrindLoop
@@ -684,6 +685,23 @@ class AgentSession(
             trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
                 note = "boot_outfit_summary: boot_shop_not_found"))
             return
+        }
+
+        // 3b. Spec 5: navigate from town overlay (mapId=8) into the weapon shop
+        //     sub-interior so BuyAtShop's `landmark.mapId == currentMapId` precondition
+        //     holds. Skipped if party already inside a sub-shop (mapId != 8) — e.g.
+        //     warm-start where an earlier run left the party in the shop.
+        val currentMapId = toolset.getState().ram["currentMapId"] ?: 0
+        if (currentMapId == 8) {
+            val enterSkill = EnterConeriaWeaponShop(toolset, landmarkMemory)
+            val r = enterSkill.invoke(emptyMap())
+            trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
+                note = "boot_enter_shop: ${r.message}"))
+            if (!r.ok) {
+                trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
+                    note = "boot_outfit_summary: enter_shop_failed"))
+                return
+            }
         }
 
         // 4. Per-char buy loop.

--- a/knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt
@@ -743,8 +743,15 @@ class AgentSession(
                     note = "boot_keeper_approach: keeper_screenXY=(${keeper.screenX},${keeper.screenY}) " +
                            "walked dx=$dx dy=$dyTarget"))
             } else {
+                // Diagnostic dump: save the post-enter screenshot for manual inspection.
+                try {
+                    val bytes = java.util.Base64.getDecoder().decode(screenshot)
+                    java.io.File("/tmp/spec5-postenter-no-keeper.png").writeBytes(bytes)
+                } catch (_: Throwable) {}
                 trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
-                    note = "boot_keeper_approach: NO_SHOPKEEPER_IN_VIEW; BuyAtShop will likely fail"))
+                    note = "boot_keeper_approach: NO_SHOPKEEPER_IN_VIEW; " +
+                           "screenshot dumped to /tmp/spec5-postenter-no-keeper.png; " +
+                           "BuyAtShop will likely fail"))
             }
         }
 

--- a/knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt
@@ -697,18 +697,47 @@ class AgentSession(
             // Spec 5 v2: Opus advisor-driven walk. Hardcoded sweep landed in
             // castle (run 16 confirmed mapId=24 = castle entrance hall). Use
             // Opus 4.5 with map context to find weapon shop door step-by-step.
-            val maxAdvisorIters = 25
+            val maxAdvisorIters = 30
             var entered = false
             var advisorTotalCost = 0.0
             var prevSx = -1
             var prevSy = -1
             var stuckCount = 0
+            var enteredWrongBuildingCount = 0
             for (iter in 0 until maxAdvisorIters) {
                 val ram = toolset.getState().ram
                 val curMapId = ram["currentMapId"] ?: 0
                 if (curMapId != 8 && curMapId != 0) {
-                    entered = true
-                    break
+                    // Verify it's a shop with shopkeeper visible (not castle).
+                    val verifyShot = toolset.getScreen().base64
+                    val verifyScan = outfitVision!!.scanInteriorCandidates(verifyShot)
+                    val keeperPresent = verifyScan.candidates.any { it.kind == "shopkeeper" }
+                    trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
+                        note = "boot_advisor_verify[$iter]: mapId=$curMapId " +
+                               "candidates=${verifyScan.candidates.size} " +
+                               "kinds=[${verifyScan.candidates.joinToString(",") { it.kind }}] " +
+                               "keeperPresent=$keeperPresent"))
+                    if (keeperPresent) {
+                        entered = true
+                        break
+                    }
+                    // Wrong building — exit and continue.
+                    enteredWrongBuildingCount++
+                    trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
+                        note = "boot_advisor_wrong_building[$iter]: mapId=$curMapId, " +
+                               "exiting via Down spam (count=$enteredWrongBuildingCount)"))
+                    if (enteredWrongBuildingCount > 3) {
+                        trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
+                            note = "boot_advisor_give_up: 3+ wrong buildings entered"))
+                        break
+                    }
+                    // Tap S many times to exit.
+                    repeat(15) {
+                        toolset.tap("Down", count = 1, pressFrames = 12, gapFrames = 8)
+                        toolset.step(buttons = emptyList(), frames = 6)
+                        if ((toolset.getState().ram["currentMapId"] ?: 0) == 8) return@repeat
+                    }
+                    continue  // back to advisor loop in town overlay
                 }
                 val sx = ram["smPlayerX"] ?: 0
                 val sy = ram["smPlayerY"] ?: 0

--- a/knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt
@@ -67,6 +67,7 @@ class AgentSession(
      * tests + e2e callers that don't yet wire vision/MapSession keep working.
      */
     private val outfitVision: HaikuConsult? = null,
+    private val outfitAdvisor: HaikuConsult? = null,
     private val outfitNavigator: VisionInteriorNavigator? = null,
     private val outfitViewportSource: ViewportSource? = null,
     private val outfitMapSession: MapSession? = null,
@@ -713,7 +714,8 @@ class AgentSession(
                     "Party is at smPlayer($sx, $sy) in Coneria town overlay (mapId=8). " +
                     "Goal: enter the WEAPON SHOP (building 3 — middle row, just east of armor shop). " +
                     "Avoid the CASTLE GATE at top-center of the plaza. Recommend ONE step toward the weapon shop."
-                val advice = outfitVision!!.adviseShopApproach(screenshot, context)
+                val advisor = outfitAdvisor ?: outfitVision!!
+                val advice = advisor.adviseShopApproach(screenshot, context)
                 advisorTotalCost += advice.costUsd
                 trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
                     note = "boot_advisor[$iter]: action=${advice.action} reason=${advice.reason} costUsd=${advice.costUsd}"))

--- a/knes-agent/src/main/kotlin/knes/agent/skills/EnterConeriaWeaponShop.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/skills/EnterConeriaWeaponShop.kt
@@ -40,8 +40,11 @@ class EnterConeriaWeaponShop(
     private val settleFrames = 8
     private val maxNorthTaps = 15
 
-    /** X-axis offsets (relative to wall-hit X) to sweep when probing for the door. */
-    private val sweepOffsets = listOf(0, -1, +1, -2, +2, -3, +3, -4, +4, -5, +5)
+    /** X-axis offsets (relative to wall-hit X) to sweep when probing for the door.
+     *  Prior runs (12-14) entered mapId=24 at offset -2 (assumed wrong building —
+     *  Gemini Pass 1 saw zero landmarks there). Reorder to prefer further offsets
+     *  to find the actual weapon shop door. */
+    private val sweepOffsets = listOf(0, -3, +3, -4, +4, -2, +2, -1, +1, -5, +5)
 
     override suspend fun invoke(args: Map<String, String>): SkillResult {
         val pre = toolset.getState().ram

--- a/knes-agent/src/main/kotlin/knes/agent/skills/EnterConeriaWeaponShop.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/skills/EnterConeriaWeaponShop.kt
@@ -1,115 +1,142 @@
 package knes.agent.skills
 
-import knes.agent.perception.Landmark
 import knes.agent.perception.LandmarkKind
 import knes.agent.perception.LandmarkMemory
 import knes.agent.tools.EmulatorToolset
+import kotlin.math.abs
+import kotlin.math.sign
 
 /**
- * Spec 5 POC: deterministic walk from Coneria town spawn to the weapon shop
- * shopkeeper, crossing the building boundary (mapId change).
+ * Spec 5 POC v2: deterministic walk from Coneria town spawn to weapon shop
+ * shopkeeper.
  *
- * Hardcoded for Coneria FF1 NES layout — building 3 on Mike's RPG Center map
- * (middle row, west side of central plaza). Replaces the explorer's failed
- * attempts to find a shopkeeper directly in mapId=8 (town overlay): the
- * shopkeeper actually lives in a sub-shop mapId reached by entering the
- * building's south door.
+ * v1 (failed): hardcoded N+W tap sequence — party hit a wall at smPlayer(7,30)
+ * without finding the weapon shop door.
  *
- * Sequence (post-spawn, party at smPlayer ≈ (12, 35)):
- *   1. Walk N until party crosses building boundary (mapId changes from 8).
- *      Coneria weapon shop entrance is roughly N+W of spawn; we issue a
- *      best-effort tap pattern and let RAM signal entry.
- *   2. After mapId change, walk N a few steps to face the shopkeeper sprite
- *      (FF1 shop layouts position the keeper north of the entry tile).
- *   3. Update the cached NPC_SHOPKEEPER landmark with the discovered mapId
- *      so BuyAtShop's `landmark.mapId == currentMapId` precondition holds.
+ * v2 strategy:
+ *   1. Walk N until party Y stops decreasing (hit a building's south wall).
+ *   2. Try one more N step in case the current X aligns with the door.
+ *   3. Sweep horizontal positions (-3..+5 from origin) along the wall, trying
+ *      a single N tap at each. Whichever X is the door tile triggers a mapId
+ *      change.
+ *   4. Once mapId changes, walk N a few steps to face the shopkeeper sprite
+ *      inside the sub-shop.
+ *   5. Persist the discovered sub-shop mapId on the cached weapon-shop
+ *      landmark so BuyAtShop can match `landmark.mapId == currentMapId`.
  *
- * This skill is intentionally narrow: Coneria-only, weapon-shop-only. It is
- * a stepping stone toward a generic interior nav (Spec 6+).
+ * Tap timing: pressFrames=12, gapFrames=8 — empirically required for FF1 to
+ * register a full 1-tile movement (v1 used 6/6 which was too short and yielded
+ * partial moves).
  */
 class EnterConeriaWeaponShop(
     private val toolset: EmulatorToolset,
     private val landmarks: LandmarkMemory,
 ) : Skill {
     override val id = "enter_coneria_weapon_shop"
-    override val description = "POC: walk from Coneria spawn to weapon shopkeeper."
+    override val description = "POC: walk Coneria spawn → weapon shopkeeper, crossing mapId boundary."
 
-    /** Max steps in the outer-walk phase before declaring stuck. */
-    private val maxOuterWalkSteps = 30
+    private val pressFrames = 12
+    private val gapFrames = 8
+    private val settleFrames = 8
+    private val maxNorthTaps = 15
 
-    /** Settle frames after each tap so RAM coords + mapId stabilize. */
-    private val settleFrames = 6
+    /** X-axis offsets (relative to wall-hit X) to sweep when probing for the door. */
+    private val sweepOffsets = listOf(0, -1, +1, -2, +2, -3, +3, -4, +4, -5, +5)
 
     override suspend fun invoke(args: Map<String, String>): SkillResult {
         val pre = toolset.getState().ram
         val preMapId = pre["currentMapId"] ?: 0
         if (preMapId != 8) {
-            return SkillResult(
-                ok = false,
-                message = "NotInTownOverlay: currentMapId=$preMapId (expected 8)",
-                ramAfter = pre,
-            )
+            return fail("NotInTownOverlay: currentMapId=$preMapId (expected 8)", pre)
         }
 
-        // Phase 1: walk N+W to weapon shop door, taking RAM mapId change as signal.
-        // Pattern derived from Mike's RPG Center map: weapon shop is north-northwest
-        // of spawn. Try a generous tap sequence covering the typical path.
-        val pattern = buildList {
-            repeat(7) { add("Up") }
-            repeat(3) { add("Left") }
-            repeat(4) { add("Up") }
-            repeat(2) { add("Left") }
-            repeat(4) { add("Up") }
-        }
-
-        var entered = false
-        var enteredMapId = preMapId
-        var stepsBeforeEntry = 0
-        for ((i, dir) in pattern.withIndex()) {
-            if (i >= maxOuterWalkSteps) break
-            toolset.tap(button = dir, count = 1, pressFrames = 6, gapFrames = 6)
-            toolset.step(buttons = emptyList(), frames = settleFrames)
-            val mid = toolset.getState().ram["currentMapId"] ?: 0
+        // Phase 1: walk N until Y stops decreasing (= south wall of some building).
+        var prevY = pre["smPlayerY"] ?: 0
+        var sameYcount = 0
+        var northSteps = 0
+        for (i in 0 until maxNorthTaps) {
+            tapMove("Up")
+            northSteps++
+            val ram = toolset.getState().ram
+            val mid = ram["currentMapId"] ?: 0
             if (mid != preMapId && mid != 0) {
-                entered = true
-                enteredMapId = mid
-                stepsBeforeEntry = i + 1
-                break
+                return onEntered(mid, ram, "wall-hit-aligned", northSteps, sweepDone = 0)
+            }
+            val curY = ram["smPlayerY"] ?: 0
+            if (curY == prevY) {
+                sameYcount++
+                if (sameYcount >= 2) break
+            } else {
+                sameYcount = 0
+                prevY = curY
             }
         }
 
-        if (!entered) {
-            val ram = toolset.getState().ram
-            return SkillResult(
-                ok = false,
-                message = "DidNotEnterBuilding: ${pattern.size} taps issued, mapId still ${ram["currentMapId"]}",
-                ramAfter = ram,
-            )
+        // Phase 2: at wall. Try one more N (may be door at this X).
+        tapMove("Up")
+        var ram = toolset.getState().ram
+        var mid = ram["currentMapId"] ?: 0
+        if (mid != preMapId && mid != 0) {
+            return onEntered(mid, ram, "first-try-N", northSteps + 1, sweepDone = 0)
         }
 
-        // Phase 2: in sub-shop, walk N a few steps to face the shopkeeper.
-        // FF1 weapon shops typically position the keeper 4-6 tiles N of the door.
-        repeat(6) {
-            toolset.tap(button = "Up", count = 1, pressFrames = 6, gapFrames = 6)
-            toolset.step(buttons = emptyList(), frames = settleFrames)
+        // Phase 3: sweep horizontal positions along the wall, trying N at each.
+        val originX = ram["smPlayerX"] ?: 0
+        var lastSweepX = originX
+        for (off in sweepOffsets.drop(1)) {
+            val targetX = originX + off
+            val deltaToTarget = targetX - lastSweepX
+            val dir = if (deltaToTarget > 0) "Right" else "Left"
+            repeat(abs(deltaToTarget)) {
+                tapMove(dir)
+                ram = toolset.getState().ram
+                mid = ram["currentMapId"] ?: 0
+                if (mid != preMapId && mid != 0) {
+                    return onEntered(mid, ram, "sweep-while-walking-$dir", northSteps + 1,
+                        sweepDone = sweepOffsets.indexOf(off))
+                }
+            }
+            lastSweepX = targetX
+            tapMove("Up")
+            ram = toolset.getState().ram
+            mid = ram["currentMapId"] ?: 0
+            if (mid != preMapId && mid != 0) {
+                return onEntered(mid, ram, "sweep-N-at-offset=$off",
+                    northSteps + 1, sweepDone = sweepOffsets.indexOf(off))
+            }
         }
 
+        return fail(
+            "DidNotEnterBuilding: walkedN=$northSteps swept ${sweepOffsets.size} offsets, " +
+                "mapId still ${ram["currentMapId"]}, party=${ram["smPlayerX"]},${ram["smPlayerY"]}",
+            ram,
+        )
+    }
+
+    private suspend fun onEntered(
+        newMapId: Int,
+        entryRam: Map<String, Int>,
+        via: String,
+        northSteps: Int,
+        sweepDone: Int,
+    ): SkillResult {
+        // Phase 4: walk N inside sub-shop to face the shopkeeper.
+        repeat(6) { tapMove("Up") }
         val post = toolset.getState().ram
-        val postMapId = post["currentMapId"] ?: 0
-        val postLocalX = post["smPlayerX"] ?: post["localX"] ?: 0
-        val postLocalY = post["smPlayerY"] ?: post["localY"] ?: 0
+        val postMapId = post["currentMapId"] ?: newMapId
+        val postX = post["smPlayerX"] ?: 0
+        val postY = post["smPlayerY"] ?: 0
 
-        // Phase 3: refresh the cached weapon-shop landmark with the actual sub-shop
-        // mapId so BuyAtShop's preflight (landmark.mapId == currentMapId) matches.
+        // Phase 5: refresh cached weapon-shop landmark with discovered mapId.
         val cached = landmarks.findByKind(LandmarkKind.NPC_SHOPKEEPER)
             .firstOrNull { it.note.contains("kind=weapon") }
-        if (cached != null && cached.mapId != postMapId) {
+        if (cached != null) {
             val updated = cached.copy(
                 mapId = postMapId,
-                localX = postLocalX,
-                localY = postLocalY,
+                localX = postX,
+                localY = postY,
                 visited = true,
-                note = cached.note + "; entered_via=EnterConeriaWeaponShop",
+                note = cached.note + "; entered_via=$via",
             )
             landmarks.recordIfNew(updated)
             landmarks.save()
@@ -117,8 +144,17 @@ class EnterConeriaWeaponShop(
 
         return SkillResult(
             ok = true,
-            message = "Entered: stepsToEntry=$stepsBeforeEntry subShopMapId=$postMapId localXY=($postLocalX,$postLocalY)",
+            message = "Entered: via=$via northSteps=$northSteps sweepDone=$sweepDone " +
+                "subShopMapId=$postMapId localXY=($postX,$postY)",
             ramAfter = post,
         )
     }
+
+    private suspend fun tapMove(dir: String) {
+        toolset.tap(button = dir, count = 1, pressFrames = pressFrames, gapFrames = gapFrames)
+        toolset.step(buttons = emptyList(), frames = settleFrames)
+    }
+
+    private fun fail(message: String, ram: Map<String, Int>) =
+        SkillResult(ok = false, message = message, ramAfter = ram)
 }

--- a/knes-agent/src/main/kotlin/knes/agent/skills/EnterConeriaWeaponShop.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/skills/EnterConeriaWeaponShop.kt
@@ -120,8 +120,27 @@ class EnterConeriaWeaponShop(
         northSteps: Int,
         sweepDone: Int,
     ): SkillResult {
-        // Phase 4: walk N inside sub-shop to face the shopkeeper.
-        repeat(6) { tapMove("Up") }
+        // Phase 4: walk N inside sub-shop until party Y stops decreasing
+        // (= keeper sprite blocking forward movement). Run 12 showed 6 steps
+        // wasn't enough — party landed at (12,14) far below keeper, and the
+        // first BuyAtShop "Down" cursor tap walked the party back out the
+        // south door, dropping mapId back to 8 mid-purchase loop.
+        var prevY = entryRam["smPlayerY"] ?: 0
+        var sameYcount = 0
+        var subShopWalkSteps = 0
+        for (i in 0 until 14) {
+            tapMove("Up")
+            subShopWalkSteps++
+            val ram = toolset.getState().ram
+            val curY = ram["smPlayerY"] ?: 0
+            if (curY == prevY) {
+                sameYcount++
+                if (sameYcount >= 2) break
+            } else {
+                sameYcount = 0
+                prevY = curY
+            }
+        }
         val post = toolset.getState().ram
         val postMapId = post["currentMapId"] ?: newMapId
         val postX = post["smPlayerX"] ?: 0
@@ -145,7 +164,7 @@ class EnterConeriaWeaponShop(
         return SkillResult(
             ok = true,
             message = "Entered: via=$via northSteps=$northSteps sweepDone=$sweepDone " +
-                "subShopMapId=$postMapId localXY=($postX,$postY)",
+                "subShopWalkSteps=$subShopWalkSteps subShopMapId=$postMapId localXY=($postX,$postY)",
             ramAfter = post,
         )
     }

--- a/knes-agent/src/main/kotlin/knes/agent/skills/EnterConeriaWeaponShop.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/skills/EnterConeriaWeaponShop.kt
@@ -1,0 +1,124 @@
+package knes.agent.skills
+
+import knes.agent.perception.Landmark
+import knes.agent.perception.LandmarkKind
+import knes.agent.perception.LandmarkMemory
+import knes.agent.tools.EmulatorToolset
+
+/**
+ * Spec 5 POC: deterministic walk from Coneria town spawn to the weapon shop
+ * shopkeeper, crossing the building boundary (mapId change).
+ *
+ * Hardcoded for Coneria FF1 NES layout — building 3 on Mike's RPG Center map
+ * (middle row, west side of central plaza). Replaces the explorer's failed
+ * attempts to find a shopkeeper directly in mapId=8 (town overlay): the
+ * shopkeeper actually lives in a sub-shop mapId reached by entering the
+ * building's south door.
+ *
+ * Sequence (post-spawn, party at smPlayer ≈ (12, 35)):
+ *   1. Walk N until party crosses building boundary (mapId changes from 8).
+ *      Coneria weapon shop entrance is roughly N+W of spawn; we issue a
+ *      best-effort tap pattern and let RAM signal entry.
+ *   2. After mapId change, walk N a few steps to face the shopkeeper sprite
+ *      (FF1 shop layouts position the keeper north of the entry tile).
+ *   3. Update the cached NPC_SHOPKEEPER landmark with the discovered mapId
+ *      so BuyAtShop's `landmark.mapId == currentMapId` precondition holds.
+ *
+ * This skill is intentionally narrow: Coneria-only, weapon-shop-only. It is
+ * a stepping stone toward a generic interior nav (Spec 6+).
+ */
+class EnterConeriaWeaponShop(
+    private val toolset: EmulatorToolset,
+    private val landmarks: LandmarkMemory,
+) : Skill {
+    override val id = "enter_coneria_weapon_shop"
+    override val description = "POC: walk from Coneria spawn to weapon shopkeeper."
+
+    /** Max steps in the outer-walk phase before declaring stuck. */
+    private val maxOuterWalkSteps = 30
+
+    /** Settle frames after each tap so RAM coords + mapId stabilize. */
+    private val settleFrames = 6
+
+    override suspend fun invoke(args: Map<String, String>): SkillResult {
+        val pre = toolset.getState().ram
+        val preMapId = pre["currentMapId"] ?: 0
+        if (preMapId != 8) {
+            return SkillResult(
+                ok = false,
+                message = "NotInTownOverlay: currentMapId=$preMapId (expected 8)",
+                ramAfter = pre,
+            )
+        }
+
+        // Phase 1: walk N+W to weapon shop door, taking RAM mapId change as signal.
+        // Pattern derived from Mike's RPG Center map: weapon shop is north-northwest
+        // of spawn. Try a generous tap sequence covering the typical path.
+        val pattern = buildList {
+            repeat(7) { add("Up") }
+            repeat(3) { add("Left") }
+            repeat(4) { add("Up") }
+            repeat(2) { add("Left") }
+            repeat(4) { add("Up") }
+        }
+
+        var entered = false
+        var enteredMapId = preMapId
+        var stepsBeforeEntry = 0
+        for ((i, dir) in pattern.withIndex()) {
+            if (i >= maxOuterWalkSteps) break
+            toolset.tap(button = dir, count = 1, pressFrames = 6, gapFrames = 6)
+            toolset.step(buttons = emptyList(), frames = settleFrames)
+            val mid = toolset.getState().ram["currentMapId"] ?: 0
+            if (mid != preMapId && mid != 0) {
+                entered = true
+                enteredMapId = mid
+                stepsBeforeEntry = i + 1
+                break
+            }
+        }
+
+        if (!entered) {
+            val ram = toolset.getState().ram
+            return SkillResult(
+                ok = false,
+                message = "DidNotEnterBuilding: ${pattern.size} taps issued, mapId still ${ram["currentMapId"]}",
+                ramAfter = ram,
+            )
+        }
+
+        // Phase 2: in sub-shop, walk N a few steps to face the shopkeeper.
+        // FF1 weapon shops typically position the keeper 4-6 tiles N of the door.
+        repeat(6) {
+            toolset.tap(button = "Up", count = 1, pressFrames = 6, gapFrames = 6)
+            toolset.step(buttons = emptyList(), frames = settleFrames)
+        }
+
+        val post = toolset.getState().ram
+        val postMapId = post["currentMapId"] ?: 0
+        val postLocalX = post["smPlayerX"] ?: post["localX"] ?: 0
+        val postLocalY = post["smPlayerY"] ?: post["localY"] ?: 0
+
+        // Phase 3: refresh the cached weapon-shop landmark with the actual sub-shop
+        // mapId so BuyAtShop's preflight (landmark.mapId == currentMapId) matches.
+        val cached = landmarks.findByKind(LandmarkKind.NPC_SHOPKEEPER)
+            .firstOrNull { it.note.contains("kind=weapon") }
+        if (cached != null && cached.mapId != postMapId) {
+            val updated = cached.copy(
+                mapId = postMapId,
+                localX = postLocalX,
+                localY = postLocalY,
+                visited = true,
+                note = cached.note + "; entered_via=EnterConeriaWeaponShop",
+            )
+            landmarks.recordIfNew(updated)
+            landmarks.save()
+        }
+
+        return SkillResult(
+            ok = true,
+            message = "Entered: stepsToEntry=$stepsBeforeEntry subShopMapId=$postMapId localXY=($postLocalX,$postLocalY)",
+            ramAfter = post,
+        )
+    }
+}

--- a/knes-agent/src/main/kotlin/knes/agent/skills/EnterConeriaWeaponShop.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/skills/EnterConeriaWeaponShop.kt
@@ -38,10 +38,15 @@ class EnterConeriaWeaponShop(
     private val pressFrames = 12
     private val gapFrames = 8
     private val settleFrames = 8
-    private val maxNorthTaps = 15
 
-    /** X-axis offsets (relative to wall-hit X) to sweep when probing for the door. */
-    private val sweepOffsets = listOf(0, -1, +1, -2, +2, -3, +3, -4, +4, -5, +5)
+    /** Run 16 confirmed mapId=24 reached via 16 N-taps was Coneria CASTLE entrance,
+     *  not weapon shop. Castle gate sits at top center of plaza; shop doors are
+     *  *between* spawn and castle. Walk only ~7 N steps to mid-plaza, then sweep
+     *  wider X range for shop doors. */
+    private val maxNorthTaps = 7
+
+    /** Sweep offsets up to ±8 — Coneria buildings span the whole plaza width. */
+    private val sweepOffsets = listOf(0, -1, +1, -2, +2, -3, +3, -4, +4, -5, +5, -6, +6, -7, +7, -8, +8)
 
     override suspend fun invoke(args: Map<String, String>): SkillResult {
         val pre = toolset.getState().ram

--- a/knes-agent/src/main/kotlin/knes/agent/skills/EnterConeriaWeaponShop.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/skills/EnterConeriaWeaponShop.kt
@@ -40,11 +40,8 @@ class EnterConeriaWeaponShop(
     private val settleFrames = 8
     private val maxNorthTaps = 15
 
-    /** X-axis offsets (relative to wall-hit X) to sweep when probing for the door.
-     *  Prior runs (12-14) entered mapId=24 at offset -2 (assumed wrong building —
-     *  Gemini Pass 1 saw zero landmarks there). Reorder to prefer further offsets
-     *  to find the actual weapon shop door. */
-    private val sweepOffsets = listOf(0, -3, +3, -4, +4, -2, +2, -1, +1, -5, +5)
+    /** X-axis offsets (relative to wall-hit X) to sweep when probing for the door. */
+    private val sweepOffsets = listOf(0, -1, +1, -2, +2, -3, +3, -4, +4, -5, +5)
 
     override suspend fun invoke(args: Map<String, String>): SkillResult {
         val pre = toolset.getState().ram


### PR DESCRIPTION
## Summary

**Spec 5 WIP** — close the multi-mapId nav gap exposed by Spec 4 empirical run 9. Spec 4 vision pipeline scans correctly but cannot lead party into a shop sub-interior; this PR adds an `EnterConeriaWeaponShop` skill + post-enter vision scan + walk-to-keeper. **9 paid runs (~\$27)** iterated through the empirical bug-fix cycle. **End state: not yet successful** at full buy + equip e2e — ground-truth Coneria layout knowledge is required (FF1 disasm or curated coords).

## What this PR delivers

1. `EnterConeriaWeaponShop` skill (`knes-agent/.../skills/EnterConeriaWeaponShop.kt`) — hardcoded N-walk + horizontal sweep pattern from Coneria spawn, detects mapId change as building entry signal, walks N inside sub-shop until blocked to face the keeper.
2. Wire-up in `runOutfitBootPhase` (`AgentSession.kt`) — gated on `currentMapId==8`, runs before BuyAtShop.
3. Post-enter Pass 1 vision scan + walk-to-keeper using existing Spec 4 pipeline:
   - Captures screenshot post-enter
   - Calls `outfitVision.scanInteriorCandidates`
   - Walks party to keeper's reported screen tile
   - Final N-tap to ensure facing N before BuyAtShop
4. Diagnostic: dumps post-enter screenshot to `/tmp/spec5-postenter.png` for manual inspection.

## Empirical runs

| Run | Outcome |
|---|---|
| 10 (v1) | Hit west wall at smPlayer(7,30); didNotEnterBuilding |
| 11 | Anomaly — gradle daemon stale state, party started in Indoors mapId=24, BOOT phase skipped |
| 12 | Entered mapId=24 at (12,14); BuyAtShop 12× WrongClass |
| 13 (sub-shop walk fix) | Entered mapId=24 at (12,18); same WrongClass |
| 14 (Pass 1 post-enter) | **Pass 1 saw count=0 in mapId=24** → wrong building |
| 15 (sweep reorder) | Stranded at (9,18) mapId=8; reverted |
| 16 (always-dump) | Screenshot revealed **mapId=24 = Coneria CASTLE entrance hall** (pillared corridor), not weapon shop |
| 17 (limit walkN=7) | Walked through plaza into castle gate again at (9,18); didNotEnter at any sweep offset |

## Key insight (run 16)

The post-enter screenshot dump confirmed mapId=24 is **Coneria Castle**, not a shop. The hardcoded N+sweep pattern from spawn naturally lands at the castle gate (top-center of plaza) rather than any shop building. Shop doors are scattered laterally across the plaza at varied Y levels — not lined up at a single \"south wall\" sweep target.

## What's needed for full e2e (out of this PR's scope)

The architectural gap is **\"agent doesn't know Coneria layout\"**. Three concrete paths forward:

1. **FF1 disasm vendoring** — extract sub-shop mapIds + door world coords from Disch FF1 disassembly, hardcode as preseed landmarks. Deterministic, no run-time guessing.
2. **LLM Opus advisor with map vision** — give Opus the screenshot + building list (mike's RPG center map), let it advise step-by-step nav. Costs more per run but reuses existing infrastructure.
3. **ROM-based interior pathfinder** — A* on `InteriorMapLoader` decoded tile data with door tile classification. Requires CHR-ROM analysis to identify door tiles. Largest effort, most generic.

## Files changed

```
knes-agent/src/main/kotlin/knes/agent/skills/EnterConeriaWeaponShop.kt  +154 (NEW)
knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt           +60
```

## Test plan

- [x] Compiles
- [x] EnterShop reaches *some* sub-shop (mapId=24, confirmed castle)
- [x] Post-enter Pass 1 scan emits diagnostic event with kinds + cost
- [x] Screenshot dumped on no-keeper-in-view
- [ ] Lands in weapon shop specifically — BLOCKED on Coneria layout knowledge
- [ ] BuyAtShop succeeds — BLOCKED on positioning at correct keeper
- [ ] EquipWeapon succeeds — BLOCKED on prior step