### PR TITLE
feat(ff1): Coneria post-buy exit + grind pipeline (Spec 5 cont-4/5)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,105 +1,89 @@
-# FF1 Koog Agent — Handoff (Spec 5 cont. — vision advisor purchase 2/4, 2026-05-09)
+# FF1 Koog Agent — Handoff (Spec 5 — 4/4 buy MERGED, next: exit + grind, 2026-05-09)
 
-**Branch HEAD:** `fb46d3c` on `ff1-buy-and-equip-coneria`. Subsequent local mapper fixes still in place.
-**Open PR:** #121 in `ArturSkowronski/kNES` targeting `master` — <https://github.com/ArturSkowronski/kNES/pull/121>.
-**Tests:** 348 unit (3 baseline failures unchanged · 7 gated skipped).
+**Master HEAD:** `361e88e` (merge of PR #122).
+**Branch:** `ff1-buy-and-equip-coneria` (still active for follow-up work).
+**Tests:** 348 unit + 3 new in `SavestateRoundtripDebug` (round-trip identity, Main.kt-flow regression, manual diagnostic).
 
-## TL;DR — class-aware vision advisor working; navigation flaps; savestate fix architectural
+## TL;DR — milestone reached: 4/4 weapon purchase, end-to-end
 
-Two big architectural moves landed this continuation, plus one open question:
+Three architectural wins this session:
 
-1. **Spec 5 architectural blocker (NPC-overlay shops) is closed.** Run #5 + #11 + #13 + #21 + #24 all made successful weapon purchases. char1 (Fighter) gets Small Knife reliably; char2 (Thief) typically follows. Bought = up to 2/4 per run with current cap.
-2. **Vision-advisor-driven shop nav** replaces the brittle deterministic state machine — Gemini reads sub-screen + cursor at each step, decides next single tap. Cost ~$0.4 per run inside the shop, way more reliable than tap-counts.
-3. **MMC1 savestate fix** committed but not empirically validated yet. Loading a pre-fix savestate drifts back to title screen because MMC1 internal registers weren't serialized. Theoretical fix is in place; needs a post-fix successful nav to dump + reload.
+1. **First-ever 4/4 character purchase** (Run B2-v3, 2026-05-09 14:59Z). Vision-advisor reads each sub-screen and decides the next single tap; class-aware item selection; 77 advisor calls, ~\$1.0 spend, 45G in-game.
+2. **vNES NameTable.stateSave bug fixed.** Leftover debug-print guard nested the per-tile `putByte` loop body inside an effectively-never-true condition, so save wrote ~0 bytes per nametable while load read full `width*height` — corrupting PPU snapshots for every MMC1 + non-MMC1 game. Round-trip identity test added.
+3. **Savestate runtime handling.** Pre-warm 120 frames before `loadState` + post-pump 120 after (PPU pipeline must engage); skip walk + nav-advisor when `KNES_FF1_LOAD_SAVESTATE` is set (savestate already places us in shop). Without these, RAM restored fine but framebuffer rendered gray / title.
 
-26 runs ran today, ~$10-12 API spend. Gemini nav advisor success rate today ≈ 30% (10 successes vs 16 timeouts/oscillation/api-error). All purchase-side wins came on the successful navs.
+## What landed this continuation (PR #122, 2 commits)
 
-## What landed this continuation session (8 commits)
+1. `631e5e1` — `fix(emulator)`: NameTable.stateSave wrote 0 bytes, corrupted PPU snapshots. Round-trip identity test added.
+2. `8fdce68` — `feat(spec5)`: full 4/4 character weapon purchase via savestate + advisor. Stack:
+   - Main.kt: 120-frame pre-warm before loadState + 120-frame post-pump.
+   - AgentSession.runOutfitBootPhase: skip walk-to-coneria + nav-advisor when `KNES_FF1_LOAD_SAVESTATE` set.
+   - `maxAdvisorCalls` 50 → 120.
+   - SYSTEM_SHOP_PURCHASE prompt: POST-PURCHASE FLOW section (cursor reset to char1 between buys, counted-Down recipe), ERROR_DIALOG handling, mid-subflow Done guardrail.
+   - Per-iter advisor screenshot dump in BuyAtShop (`/tmp/spec5-buy-advisor-iter-NN-served-XXXX.png`).
 
-In order:
+## Empirical milestone
 
-1. `18e58cd` — `ShopUiDetector` (vision-primary, RAM negative gate). Replaces `inSubShop = mapId != 0` with `mapflags.bit0=1` recognition. `BuyAtShop` precondition relaxed for town-overlay. SYSTEM_ADVISOR rewritten.
-2. `7bd2a91` — `BuyAtShop.menuAlreadyOpen` flag — skip the dialog-opening A-tap when shop UI already drawn at acceptance time.
-3. `86faf9b` — kind-aware Done acceptance: require `kind == "weapon"` (rejects accidental armor-shop entries with feedback to advisor's action log).
-4. `16f33a5` — handoff update declaring Spec 5 architectural blocker closed (run #5 milestone).
-5. `a1086ea` — per-call menu probe + 5-B exit (intermediate iteration; superseded by stateful + advisor approaches).
-6. `40012ce` — SYSTEM_ADVISOR prompt: town NPCs move, blocked entries time-decay (require recent confirmation in TOWN_OVERLAY).
-7. `5f4493d` — vision-classified shop menu state machine (intermediate; partially superseded by full advisor).
-8. `1ed46ba` — **vision-advisor-driven shop purchase**. Replaces state machine with per-step Gemini advice. Adds `char1_class..char4_class` registers to ff1.json profile (offsets `$6100/$6140/$6180/$61C0` per Disch disasm). New `HaikuConsult.adviseShopPurchase` method + `SYSTEM_SHOP_PURCHASE` prompt teaching all eight FF1 shop sub-screens + per-class equip rules.
-9. `91a1074` — accept Done iff EITHER `kind=weapon` OR `phase != CLOSED` (run #19 trace: nav reached BUY/SELL/EXIT but kind classifier returned null on same screen — dual classifier saves the entry).
-10. `7ce67e6` — savestate dump on `entered=true` to `/tmp/spec5-shop-entered.savestate`, env var `KNES_FF1_LOAD_SAVESTATE=<path>` to skip pressStart + advisor nav for dev iteration. `EmulatorToolset.session` was private, now public.
-11. `4f8a2b4` — bumped `maxAdvisorCalls` 30 → 50 (run #21 hit cap mid-purchase of char3).
-12. `fb46d3c` — **MMC1 + MapperDefault savestate bugs**. MapperMMC1 had no `stateSave`/`stateLoad` override → internal registers (shiftRegister, regControl, regCHR0/1, regPRG) defaulted to power-on values after load → ANY subsequent bank switch after restore corrupted PRG mapping → title-screen drift. Plus MapperDefault.mapperInternalStateLoad/Save bodies were SWAPPED (Load wrote, Save read).
+Run B2-v3 (2026-05-09 14:59Z): **4/4 chars BOUGHT in single run.**
+```
+boot_savestate_skip_walk_nav: KNES_FF1_LOAD_SAVESTATE set, skipping walk-to-coneria + nav advisor
+boot_post_enter_detect: open=false source=vision_unknown kind=null phase=MAIN_MENU phaseSaysOpen=true
+char1 BOUGHT iter=8   (Fighter,    Small Knife,     5G)
+char2 BOUGHT iter=41  (Thief,      Small Knife,     5G)
+char3 BOUGHT iter=65  (BlackBelt,  Wooden Nunchuck, 10G)
+char4 BOUGHT iter=77  (RedMage,    Rapier or Hammer, 25G)
+boot_outfit_summary: weaponsBought=4 weaponsEquipped=0 totalGoldSpent=45
+```
 
-## Empirical results (this session)
+Run-by-run progression toward 4/4:
 
-| Run  | Phase reached                   | Result                                                  |
-|------|---------------------------------|---------------------------------------------------------|
-| #5   | nav OK, shop OK                 | char1 bought Wooden Staff (5G). First ever purchase.    |
-| #6   | nav stuck 80 iters              | $1.45, no entry                                         |
-| #7   | nav api-error iter 8            | Fail                                                    |
-| #8   | nav OK, shop OK                 | char1 Bought                                            |
-| #11  | nav OK, shop OK                 | char1 Bought (5-B exit fix verified for char1)          |
-| #13  | nav OK, shop OK                 | char1 Bought + char2 may have bought silently (13G)     |
-| #15  | nav OK, post-enter scrambled    | All 4 ShopClosed                                        |
-| #16  | nav OK, post-enter scrambled    | All 4 ShopClosed                                        |
-| #17-20| nav api-error / oscillation    | various Fail                                            |
-| **#21**| **nav OK, vision advisor**    | **char1 (Knife) + char2 (Knife) Bought, 10G.** Hit cap=30 mid-char3.  |
-| #22  | savestate-load test             | Title screen — pre-fix savestate                        |
-| #23-26| various nav fails             | mostly $1.45 stuck-loop; #24 was vision advisor success |
-| **#24**| **nav OK, vision advisor**    | **char1 + char2 Bought, 20G.** Cap=50 reached during char3/char4 nav confusion. |
+| Run  | Bought | Notes                                                              |
+|------|--------|--------------------------------------------------------------------|
+| #21, #24 (pre-fixes)                                | 2/4 | cap=50, FOR_WHOM cursor confusion                                  |
+| Run A2 (post-NameTable, fresh nav, cap=80)          | 3/4 | char3 finished iter 75, char4 starved (cap exhausted)              |
+| **Run B2-v3 (post-NameTable + savestate runtime, cap=120)** | **4/4** | char1@i8, char2@i41, char3@i65, char4@i77; ~\$1.0 advisor spend |
 
-## Architecture (post-session)
+## Next goal: post-purchase exit + grind phase
+
+User-defined next milestone (2026-05-09 cont 2): **after buy, exit shop and start grind.**
+
+Skipping EquipWeapon for now — chars can grind bare-handed (lower DPS but works). Equip is a separate follow-up.
+
+Subgoals (concrete, in order):
+
+1. **Exit shop dialog cleanly post-buy.** Today the boot phase ends at `boot_outfit_summary: weaponsBought=4`, control returns to strategic loop. Need to verify `ExitInterior` (or B-spam to dismiss BUY/SELL/EXIT → land back on town overlay) actually walks the party out of Coneria town and back to the overworld at world(147,155) or nearby. Likely already partially wired via `ExitInterior` skill — need to confirm + add a post-buy exit step in `runOutfitBootPhase`.
+2. **Walk to grind tile / encounter area.** Coneria is surrounded by grasslands south + east. Strategic loop already has GRIND/REST/BRIDGE token routing (visible in earlier Run B2 trace `output:"raw=GRIND parsed=GRIND"`). Need: after exit, agent should enter encounter zone and trigger random battle.
+3. **Win battle (≥1 fight).** `battleFightAll` skill exists in `knes-debug/src/main/resources/profiles/ff1.json`. Mostly tap-A through. Should mostly work even with no weapons equipped (chars do bare-hand damage).
+4. **Track XP gain → level-up.** Strategic loop's GRIND target `min_level >= 3 before BRIDGE` already in place — just needs the exit + walk-to-grass to actually fire.
+
+## Architecture (post-merge)
 
 ```
 session.run()
 ├── pre-boot
-│   ├── if KNES_FF1_LOAD_SAVESTATE set → session.loadState(file) and skip pressStart
+│   ├── if KNES_FF1_LOAD_SAVESTATE set
+│   │   ├── advanceFrames(120)         ← V5.46.5 pre-warm (PPU engagement)
+│   │   ├── session.loadState(file)
+│   │   └── advanceFrames(120)         ← V5.46.5 post-pump (re-render)
 │   └── else → PressStartUntilOverworld if RAM shows title screen
 ├── main turn loop
 │   ├── observe phase + RAM
 │   ├── BOOT TRIGGER (RAM-based, fires once):
 │   │   └── if !done && mapId==0 && char1_str>0:
 │   │       └── runOutfitBootPhase()
-│   │           ├── walk to TOWN_ENTRY landmark
-│   │           ├── settle 120 frames
-│   │           ├── advisor loop (max 80 iters) — Gemini decides next nav tap
-│   │           │   └── on Done: dual-classifier (kind=weapon OR phase != CLOSED) → entered=true
-│   │           ├── on entered=true: dump savestate, post-enter detect
-│   │           ├── if menuAlreadyOpen → skip keeper-approach
-│   │           ├── BuyAtShop.invokeWithAdvisor:
-│   │           │   ├── per-iter context: char classes from $6100..$61C0 + remaining gold + served list
-│   │           │   ├── Gemini decides next single tap (Up/Down/Tap_A/Tap_B/Done/Fail)
-│   │           │   └── delta-tracks gold + per-char weaponSum to mark "Bought"
-│   │           └── ExitInterior + EquipWeapon × 4 chars
-│   └── strategic LLM loop
+│   │           ├── if savestateLoaded: skip walk + advisor   ← NEW
+│   │           ├── else walk to TOWN_ENTRY landmark + 120f settle
+│   │           ├── (if !savestateLoaded) advisor loop (max 80 iters)
+│   │           ├── post-enter detect (ShopUiDetector + classifyShopMenuPhase)
+│   │           ├── BuyAtShop.invokeWithAdvisor (cap=120, per-iter screenshots)
+│   │           └── ExitInterior + EquipWeapon × 4 chars   ← NEXT: validate exit
+│   └── strategic LLM loop                                  ← NEXT: GRIND token
 ```
 
-## Remaining work
-
-### Validated direction, needs more iter cap
-
-**4/4 char buy in single run.** Run #24 trace shows the advisor's Gemini gets confused by FOR_WHOM cursor positioning across multiple purchases — cursor returns to char1 each time, advisor needs to Down past served chars. With cap=50, advisor reaches char3 attempt but runs out of iter when navigating FOR_WHOM. Two complementary fixes:
-- Bump cap to 80 (~1.5x cost, ~$0.6/run).
-- Improve `SYSTEM_SHOP_PURCHASE` prompt: explicitly teach that after each purchase, FOR_WHOM cursor resets to char1 and the advisor needs to count Downs from char1 to target. Also: encourage the advisor to use the `served` flag in context to skip already-served chars.
-
-### Architectural: not yet validated empirically
-
-**Savestate restore still drifts to title.** Despite MMC1 fix (`fb46d3c`), runs that load /tmp/spec5-shop-entered.savestate land at title menu. Possible causes (each requires investigation):
-- Old savestate files were written before mapper fix; need a fresh nav success → dump → load to verify. Today's clean-rebuild + run #26 nav failed before dump.
-- `ByteBuffer.getBytes()` returns the full buf array (size 397569 stable across runs), not curPos. Padding zeros at end of file. Save/load alignment is what matters; could the truncation handling cause issues?
-- PPU state save may not capture chr-rom bank pointers (CHR-ROM/RAM mode). Worth checking PPU.stateSave/stateLoad for completeness with respect to MMC1's CHR bank registers.
-
-**EquipWeapon MenuStuck.** Earliest evidence run #5: `60 taps without equipped-flag transition`. Skill drives in-menu equip flow but the equipped-flag (high bit of `char{N}_weapon{slot}`) never flips. Same brittle-state-machine pattern that the BUY side hit; same fix likely applies — replace with a vision-advisor `adviseEquip` method.
-
-### Misc / lower priority
-
-- Strategic-loop budget pressure post-boot (`maxSkillInvocations=120` cap consumed by strategic Anthropic LLM after boot succeeds).
-- Fanslated-ROM dialog noise ("No Shit." text observed at smPlayer (10,11)) — not a code issue, advisor occasionally misreads; current dual-classifier neutralises most cases.
-
-## Run command (next-session)
+## Run command (current — buy then strategic loop)
 
 ```bash
+# Fresh nav with NameTable fix produces a fresh-format savestate post-buy.
 rm -f ~/.knes/ff1-*.json /tmp/spec5-shop-entered.savestate
 cat > ~/.knes/ff1-landmarks.json <<'JSON'
 {"version":1,"landmarks":[
@@ -113,37 +97,34 @@ JSON
 KNES_VISION=gemini-pro ANTHROPIC_API_KEY=... GEMINI_API_KEY=... \
   ./gradlew :knes-agent:run --args="--rom=$PWD/roms/ff.nes \
     --wall-clock-cap-seconds=900 --cost-cap-usd=3.0 --max-skill-invocations=120"
-```
 
-If a fresh successful nav dumps `/tmp/spec5-shop-entered.savestate`, validate the savestate fix:
-
-```bash
+# Once savestate exists, fast-iterate buy+exit+grind via:
 KNES_VISION=gemini-pro KNES_FF1_LOAD_SAVESTATE=/tmp/spec5-shop-entered.savestate \
   ./gradlew :knes-agent:run --args="--rom=$PWD/roms/ff.nes \
-    --wall-clock-cap-seconds=600 --cost-cap-usd=2.0 --max-skill-invocations=80"
+    --wall-clock-cap-seconds=600 --cost-cap-usd=3.0 --max-skill-invocations=120"
 ```
-
-Expected on successful load: skip pressStart, boot phase trigger fires immediately, post-enter detect sees shop UI, vision advisor runs purchase loop. If still drifts to title menu: the mapper fix isn't sufficient; investigate PPU CHR-bank register serialization next.
 
 Watch trace:
 ```bash
 LATEST=$(ls -td ~/.knes/runs/*/ | head -1)
-grep -E 'boot_advisor_done_verify|boot_advisor_summary|boot_savestate|boot_purchase_advisor|boot_purchase|boot_equip|boot_outfit_summary|loaded savestate' "$LATEST/trace.jsonl"
+grep -E 'boot_savestate|BOUGHT|boot_purchase_advisor_done|boot_outfit_summary|boot_equip|boot_exit|GRIND|BATTLE' "$LATEST/trace.jsonl"
 ```
 
-Diagnostic dumps in `/tmp/spec5-buy-*.png` for screen state at each purchase step.
+Per-iter advisor frames in `/tmp/spec5-buy-advisor-iter-*.png` for post-mortem.
 
 ## Lessons (carried forward)
 
-- **Vision-advisor beats deterministic state machines for FF1 NES UI navigation.** Run #21 + #24 were the first successful buys after we replaced tap-count guessing with `adviseShopPurchase`. The state machine version (commits `5f4493d` → `a232050`) bought 0/4 across multiple runs. The advisor version bought 2/4 reliably and would do 4/4 with more iter cap.
-- **Two independent vision classifiers reduce stochastic flips.** Run #19 had nav reach BUY/SELL/EXIT but kind classifier returned null on the same screen. Adding phase classifier as a fallback (`91a1074`) recovered ~$1.40 wasted runs.
-- **vNES MMC1 savestate had multiple latent bugs** (`fb46d3c`). Architectural fix posted; needs empirical validation. If you fix savestate next, the dev iteration loop on shop-side bugs becomes 30s instead of 15min.
-- **Class-aware item picking works** — char_class register at $6100/$6140/$6180/$61C0 + per-class equip rules in advisor prompt = advisor correctly picks Knife for Fighter, Knife for Thief, Nunchuck for Black Belt (run #21 trace).
+- **Vision-advisor > deterministic state machines** for FF1 NES UI navigation (validated 4/4). Cap=120 + POST-PURCHASE prompt section. Pre-fix state machine: 0/4. Pre-fix advisor: 2/4. Post-fix advisor: 4/4.
+- **Savestate runtime needs PPU warm-up.** 120-frame pre-warm before loadState + 120-frame post-pump. 0-frame: RAM resets. 1-frame: RAM sticks but renderer gray. 120-frame: both correct.
+- **vNES NameTable.stateSave was silently broken since the original Java port** — caught by round-trip identity test. Worth running similar round-trip tests for other Memory subclasses.
+- **When KNES_FF1_LOAD_SAVESTATE is honoured, skip walk + nav advisor.** Walking presses cardinals on the active shop dialog and the resulting B-press exit chain landed the agent on title menu with `char_str=0` after PressStartUntilOverworld kicked in to "fix" it.
+- **Class-aware item picking + counted-Down FOR_WHOM** = reliable multi-char buy. Each new BUY_CONFIRM resets cursor to char1; Party state tags ("served"/"NEEDS WEAPON") let the advisor count Downs from char1 to next unserved.
 
 ## Carried-over principles
 
-- **Autonomy:** agent gra grę; dev nie. Per `autonomy_principle.md`. Savestate dumping is dev-tool only — captured by agent-driven nav, not hand-recorded.
-- **No-savestate persistence:** new specs nie używają savestate-hash-keyed flags ani FF1_SAVESTATE-gated e2e tests; persistence flows through `landmarkMemory`. Per `feedback_no_savestate.md`. (The savestate dev-tool here is for iteration speed, not for unit-test fixtures.)
+- **Autonomy:** agent gra grę; dev nie. Per `autonomy_principle.md`. Savestate dumping is dev-tool only — captured by agent-driven nav.
+- **No-savestate persistence:** new specs nie używają savestate-hash-keyed flags ani FF1_SAVESTATE-gated e2e tests. Per `feedback_no_savestate.md`. (Savestate dev-tool here is for iteration speed, not for unit-test fixtures.)
 - **Vision-primary UI detection:** see `feedback_vision_primary.md`.
 - **Locate-party-first vision prompts:** still in effect. Per `feedback_locate_party_first.md`.
 - **FF1 NPCs move:** action log "blocked" entries time-decay. Per `reference_ff1_npcs_move.md`.
+- **Per-iter buy screenshots:** dumped to `/tmp/spec5-buy-advisor-iter-NN-served-XXXX.png`. Per `feedback_buy_screenshots.md`.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,8 +1,186 @@
-# FF1 Koog Agent — Handoff (Spec 5 — 4/4 buy MERGED, next: exit + grind, 2026-05-09)
+# FF1 Koog Agent — Handoff (Spec 5 — exit-from-Coneria BLOCKED, 2026-05-09 cont 3)
 
 **Master HEAD:** `361e88e` (merge of PR #122).
-**Branch:** `ff1-buy-and-equip-coneria` (still active for follow-up work).
-**Tests:** 348 unit + 3 new in `SavestateRoundtripDebug` (round-trip identity, Main.kt-flow regression, manual diagnostic).
+**Branch:** `ff1-buy-and-equip-coneria` (still active for follow-up work; this cont session adds 4 working pieces + 1 known-broken fallback, **uncommitted** at handoff time).
+**Tests:** 348 unit + 3 in `SavestateRoundtripDebug`. Compiles clean.
+
+## TL;DR — 2026-05-09 cont 3 progress
+
+**Goal:** post-buy → exit Coneria town → walk to grass → first random encounter.
+**Result:** Buy still works (4/4 in 47–57 advisor iters across 3 reruns). **Exit fails** — agent gets stuck in Coneria town courtyard at smPlayer y=14. Strategic loop fires `GRIND` but `worldX/Y` doesn't change inside town overlay → `UnknownMapTrap` detector kills the run after 3 obs.
+
+**What's new and committable:**
+1. **Skip-equip in `runOutfitBootPhase`** — gated on `KNES_FF1_BOOT_EQUIP=1`, default skip. Saves ~240 useless A-taps × 4 chars between buy and strategic loop.
+2. **`boot_exit_interior_result` trace** — captures exit ok/msg/world/mapId/mapflags + `via=vision|bfs` so post-buy exit state is visible from `trace.jsonl` alone.
+3. **`strategy_grind_result` + `strategy_grind_anchor_shift` traces** — `GrindLoop` outcomes (EncounteredBattle / NoEncounter / Blocked / WanderedOff) now in trace. Previously only `println` to stdout — invisible in run dirs.
+4. **Post-buy savestate dump** — `/tmp/spec5-post-buy.savestate` written immediately after `boot_purchase_advisor_done`. Skips the 5-min buy phase on subsequent dev iterations.
+5. **Vision-LLM exit wired post-buy** — `runOutfitBootPhase` now uses `WalkInteriorVision(outfitNavigator)` (max 60 steps) when navigator configured, falling back to `ExitInterior` BFS only for offline/test runs. Pre-flight 8 B-taps to dismiss any lingering shop dialog before exit attempts.
+6. **`ExitInterior` town-overlay fallback** — `walkOutOfTownOverlay` for the `mapId=0 + mapflags.bit0=1` case (used by `SkillRegistry`/`ExitBuilding` paths that don't have a navigator). Blind cardinal walker with screenshot dumps to `/tmp/spec5-town-exit-{entry,mid,exit}.png`. **Known limitation: insufficient for Coneria** — works for first 4 tiles south, deadlocks at courtyard wall. Acceptable as defensive fallback only; vision-nav is the primary path.
+
+**What's still failing in cont-3 validation runs:**
+- Vision-LLM nav (`WalkInteriorVision`) **also** fails to exit Coneria after 30 steps in cont-3 run #4 (`mapflags=3` at end). Bumped to 60 in this commit but un-validated. Possible causes: (a) insufficient iterations, (b) navigator prompt doesn't ban training-data Coneria geography (per `feedback_locate_party_first.md`), (c) party walks into a building doorway and gets stuck on dialog.
+- The strategic loop's `UnknownMapTrap` detector at `AgentSession.kt:314` **still bails after 3 obs** when stuck in town overlay. This is a safety valve (clean OutOfBudget exit) but means: if vision-exit fails, the run terminates within ~5 turns post-buy. Tried adding a TOWN_ENTRY whitelist; it caused an infinite loop burning advisor LLM calls. **Reverted.** Properly fixing requires splitting trap detection from the grind-anchor capture, not done in this commit.
+
+## 2026-05-09 cont 3 FINAL — HONEST STATUS: stuck in town across runs, scratchpad infrastructure built, exit + encounter UNRESOLVED
+
+**User-corrected reality (per visual screenshot evidence at 21:24):** despite extensive iteration with tree-detour heuristics, the agent **remains stuck in Coneria town** at the end of multiple runs. The "exit success" RAM signal (`mapflags=0`) was misleading — sometimes it briefly clears mid-scroll then reverts, sometimes the agent is structurally still in town overlay. Running 8+ iterations of fixes (tree-detour, approach-to-(14,22) pre-nav, mapflags-bit-1 settle waits, longer post-exit walks) did NOT produce a reliable end-to-end exit + grind + battle pipeline.
+
+**What's solid (committable):**
+
+1. **`AgentScratchpad`** — coding-agent-style action notebook persisted alongside the savestate (`/tmp/spec5-post-buy.savestate` ↔ `/tmp/spec5-post-buy.actions.json`). Records phase markers + cardinal taps with smPre/smPost/mapflagsPost. `walkInEntryTile()` returns the warp coord; `reverseTrajectoryFromTownEntry()` returns the reversed walk-in cardinals. `loadSister()` reads back on next run startup. Skips empty walk-in pairs from savestate-load skip cycles.
+2. **Walk-in trajectory captured perfectly** — fresh-run scratchpad shows `[16,23] → UP×9, LEFT×1, UP×1, LEFT×1, UP×1, LEFT×2, UP×1, LEFT×1, UP×1 → [11,10]`.
+3. **Post-buy savestate dump** at `boot_post_buy_savestate_dumped` — fast-iter (~30s) without re-running buy advisor.
+4. **Vision-LLM hint API** — `historyHint: String?` parameter wired through `VisionInteriorNavigator.nextDirection()` and `WalkInteriorVision`. Prompt includes scratchpad render with directive "use as reasoning hint, not literal replay". Plus encoded "GRIND/ENCOUNTER zone = solid GREEN grass tiles, NOT stone walls or trees".
+5. **Per-step screenshot evidence dumps** — `tree-detour-NN-DIR-smX_Y-mfN.png`, `postexit-NN-DIR-wX_Y-mfN.png`, `grind-stepNN-wX_Y-mfN.png`. Visual proof of every cardinal tap; user can audit.
+6. **Per-step `encounterCounter` log in GrindLoop** — confirmed encounterCounter stays at 0 throughout walks, suggesting either we're never on a real encounter tile OR `0x00F5` isn't the right byte for FF1 NES.
+7. **GrindLoop docstring updated** — trees ARE walkable (encounter zone, not obstacles). Town/castle entry tiles ARE warps. Mountains/water block movement.
+
+**What's broken (uncommitted scaffolding):**
+
+- **`ExitTownEmpirical`** — empirical adjacency-explorer + tree-detour heuristic (U R R D D D from (14,22)). Sometimes works (run #N reached `mapflags=0` and walked post-exit to (146,159) on overworld grass), sometimes the empirical phase ends at a different position (cont-3 N at (13,14)) where tree-detour can't reach the warp, sometimes pre-existing mid-scroll state makes ALL taps no-ops. Approach-to-(14,22) pre-navigation was added but doesn't help when intermediate tiles block the approach. **Net: unreliable, not a path forward as-is.**
+- **Post-exit south walk** — sometimes works (Down×4 reaches (146,159)), sometimes worldY doesn't change (south of (147,155) gate is blocked by water). Coneria peninsula geography is more complex than my hardcoded heuristics handle.
+- **GrindLoop encounter rate** — 72+ steps walked across multiple grind cycles, `encounterCounter` always reads 0, no `EncounteredBattle` ever fires. Either this byte is wrong, or Coneria peninsula tiles around the gate genuinely have no encounters (FF1 has "safe zone" buffer near Coneria starting town), or the engine's per-step encounter check isn't being triggered by our tap pattern.
+- **`UnknownMapTrap`** detector at AgentSession:316 still bails after 10 obs of `mapflags.bit0=1 + mapId=0`. With unreliable exit, every run ends with this trap.
+- **TRAP_CONFIRM_THRESHOLD bumped 3→10**, GrindLoop corridor 6→2, GrindLoop maxSteps 12→24 — none of these tuning changes resolved the encounter-zero problem.
+
+## What worked once but isn't reliable
+
+In one specific run earlier this session, the full pipeline completed: tree-detour exit → 2 LEFT to (145,155) overworld grass → 5 GrindLoop UP steps → walked into Coneria CASTLE (mapId=8) → ExecutorAgent walked deeper into castle (mapId=24 throne). That sequence proved the pieces CAN connect, but the empirical exploration phase that precedes tree-detour is non-deterministic — different starting positions for tree-detour cause different outcomes.
+
+## Recommended next-session direction
+
+Fundamentally, we need a navigator that doesn't depend on heuristic hardcoded sequences. Options:
+
+1. **Vision-LLM exit only** — drop `ExitTownEmpirical` + tree-detour entirely. Use `WalkInteriorVision(navigator, historyHint=scratchpad)` as the exclusive exit path. The historyHint API is already wired. Audit + upgrade `AnthropicVisionInteriorNavigator`'s system prompt for town overlays specifically. Refresh the model ID — current default (`claude-opus-4-5-20251101`) may be invalid.
+2. **Read PPU nametable for real walkability** — currently `mapId=0` decodes to overworld tile data via `InteriorMapLoader`, useless for town overlays. The town's actual tile layout lives in PPU nametable RAM (`$2000-$23FF`). Add a `TownOverlayTileSource` that reads PPU and classifies tiles. Then BFS works for `mapId=0+mapflags.bit0=1`.
+3. **Investigate FF1 encounter mechanic** — what's the real RAM byte for encounter timer? Disasm research on `$00F5` and surrounding bytes. Is there a specific CPU instruction we need to step through to trigger encounter checks? Maybe our tap+settle pattern bypasses the engine's step-based encounter check.
+
+## Carried over (kept below for context)
+
+## 2026-05-09 cont 3 FINAL — EXIT CONERIA WORKS via tree-detour + scratchpad infrastructure
+
+**The breakthrough:** user-provided tree-detour hint after observing screenshot of stuck state — `Up Right Right Down Down` from (14,22). With pressFrames=6 (1-tile precision), this navigates around the south-edge tree obstacle to the warp tile (16,23), where one more DOWN commits the transition: `mapflags 1 → 0` = on overworld!
+
+```
+[exit-town-empirical] tree-detour starting from smPlayer=(14,22)
+[exit-town-empirical] tree-detour[0] Up    → smPlayer=(14,21) mapflags=1
+[exit-town-empirical] tree-detour[1] Right → smPlayer=(15,21) mapflags=3 (mid-scroll)
+[exit-town-empirical] tree-detour[2] Right → smPlayer=(16,21) mapflags=3 (mid-scroll)
+[exit-town-empirical] tree-detour[3] Down  → smPlayer=(16,22) mapflags=1
+[exit-town-empirical] tree-detour[4] Down  → smPlayer=(16,23) mapflags=1 ← warp tile
+[exit-town-empirical] tree-detour[5] Down  → smPlayer=(16,23) mapflags=0 ← TRANSITION!
+```
+
+End-to-end pipeline now working from `/tmp/spec5-post-buy.savestate`:
+1. ✅ Buy 4/4 (47-79 advisor iters fresh, instant from savestate)
+2. ✅ Exit Coneria via tree-detour (6 cardinal taps)
+3. ✅ Post-exit walk to overworld grass at (145,155) via 2 LEFT
+4. ✅ GrindLoop walks 5 tiles north on overworld (encounters can fire)
+5. ⚠️ At y=152 walks into Coneria CASTLE entry — encounter rate didn't fire in 5 steps (~50% probability)
+
+**The mapflags=3 mystery solved:** bit 1 = "column-drawing" (PPU mid-scroll). It's TRANSIENT — drops back to 1 (or 0 after exit) once the scroll completes. cont-3 #4-#7 ran into mid-scroll states and falsely concluded "stuck"; the engine was fine, just sampled mid-frame. Tree-detour with shorter pressFrames (6 not 18) and 60-frame settles avoids the false-stuck.
+
+## Remaining tuning (not blocking)
+
+- **GrindLoop corridor radius bumped 6→2** in this session to stay y=153-157 between town south and castle north. With anchor at (145,155), corridor is safe. But the ADAPTIVE shift logic (after 3 NoEncounter, shift +2E -4N) moves anchor to (149,151) which puts corridor=(149-153) into castle territory again. Either disable shifts or change shift vector.
+- **Encounter rate near Coneria gate appears very low** — 3 cycles × 24 steps = 72 walks at corridor (145,153-157) with NO encounter triggered. Either FF1 encounter rate is genuinely low here (classic grind is at the bridge area further north, not town entry), OR GrindLoop's UP/DOWN at this corridor re-enters town overlay each step (mapflags=1 transient — mapId stays 0, so GrindLoop's `mapId != 0` check doesn't catch). Worth verifying with `encounterCounter` RAM byte over time.
+- **`grindAnchor` captures stale worldX** — anchor=(147,155) when party already at (145,155) post-exit walk. Engine has ~1-2 frame lag in updating worldX after warp. Fix: re-read RAM after a brief settle before capturing anchor.
+- **After castle re-entry, ExecutorAgent's ExitInterior walks DEEPER** (mapId=8 → mapId=24 throne) instead of out. ExitInterior's BFS picks "nearest exit" but throne stairs may be closer than south door. Needs distance + south-bias.
+- **TRAP_CONFIRM_THRESHOLD bumped 3→10** to give anchor-shift logic time to fire.
+
+## 2026-05-09 cont 3 EARLIER PROGRESS — scratchpad infrastructure built (kept below for context)
+
+**Architectural breakthrough (committable):**
+
+`AgentScratchpad` (knes-agent/src/main/kotlin/knes/agent/runtime/AgentScratchpad.kt, 145 lines) — coding-agent-style action notebook that:
+- Records every meaningful agent action: phase markers, cardinal taps with smPre/smPost, dialogs, exits
+- Persists alongside savestate as sister `*.actions.json` (e.g. `/tmp/spec5-post-buy.savestate` ↔ `/tmp/spec5-post-buy.actions.json`)
+- Loads on next run startup (Main.kt handles sister-file detection)
+- Provides `renderForLLM()` for prompt injection, `walkInEntryTile()` for warp coord, `reverseTrajectoryFromTownEntry()` for cardinal replay
+- Skips empty walk-in pairs (savestate-load skip pairs that have no taps)
+
+The walk-in is captured perfectly. Fresh run output:
+```
+walk-in: 18 taps
+  start smPlayer: [16, 23]   ← warp tile (town entry)
+  end   smPlayer: [11, 10]   ← shop tile
+Path: UP×9, LEFT×1, UP×1, LEFT×1, UP×1, LEFT×2, UP×1, LEFT×1, UP×1
+```
+
+Vision-LLM hint API (also wired): added `historyHint: String?` parameter to `VisionInteriorNavigator.nextDirection()`; the implementation prepends scratchpad render to the user prompt with the directive "use as reasoning hint, not literal replay" per user direction.
+
+`ExitTownEmpirical` skill (knes-agent/src/main/kotlin/knes/agent/skills/ExitTownEmpirical.kt, 200+ lines) — deterministic adjacency-mapping explorer with Manhattan-gradient bias toward the warp coord from scratchpad.
+
+**The wall hit (uncommittable, root-cause unsolved):**
+
+The post-buy exit deadlocks at smPlayer `(13,22)`/`(14,22)` with `mapflags=3` (bit 0 set: in-interior; bit 1 set: PPU "column-drawing" per FF1 profile). **No input clears bit 1**:
+- 300-frame idle waits: no clear
+- 32 B-spam taps: no clear
+- Multi-tap DOWN with settle: no clear
+- Long-held DOWN (24 frames): no clear
+
+`/tmp/spec5-mf3-stuck-14-22.png` screenshot shows the party VISUALLY on overworld grass at the south edge of Coneria, with the INN sign visible above. The camera has scrolled out, but the engine state is frozen. **All cardinals at this position return smPlayer-unchanged** (the engine literally ignores input in this state) → empirical explorer marks them as walls → exhausts edges → bails.
+
+This happens in BOTH fresh runs (no savestate) AND savestate-loaded runs. It's not a savestate-restoration artifact; it's a real FF1 engine state we don't know how to commit. The walk-in tile `(16,23)` is presumably the only tile that would commit the transition (warp-out), but the empirical south-walk lands at `(14,22)` which is one tile west and one row north of the entry — close, but the engine treats it as "non-warp tile" and refuses to transition. The agent can't walk from `(14,22)` to `(16,23)` because at mapflags=3 cardinals are no-ops.
+
+## Empirical evidence — what's actually happening at the deadlock
+
+User-provided hint: **"to exit the city you need to go down from shop"**. We did. Six runs in cont-3 testing different exit strategies, with the following progression of evidence:
+
+| Run | Strategy | Outcome | Evidence |
+|---|---|---|---|
+| #1 | BFS pathfinder over mapId=0 | 64 useless iters, oscillation | trace `did not exit interior in 64 steps` |
+| #2 | Cardinal: DOWN→RIGHT→LEFT→UP rotate | DOWN to y=14, RIGHT side-step → mapflags=3 | (12,14) opens building dialog |
+| #3 | Cardinal: DOWN→LEFT→RIGHT→UP rotate | DOWN to y=14, LEFT side-step → mapflags=3 | (10,14) opens building dialog |
+| #4 | Vision-LLM `WalkInteriorVision` | 30 LLM calls, mapflags=3 final | LLM walks into building too |
+| #5 | DOWN-only, NPC patience (5 idle-waits) | 17 stuck taps at (11,14), no progress | mid screenshot shows dialog, was an artifact of run #2/#3 not this run |
+| #6 (this) | DOWN-only, full RAM dump at deadlock | Diff entry-vs-stuck: ONLY `localY` and `smPlayerY` change | **all 117 watched bytes identical except party position** |
+
+**Definitive ground truth from run #6:** at smPlayer=(11,14) pressing DOWN, NO byte changes. mapflags=1, screenState=0, menuCursor=0, menuHandX/Y=0 — all stable. The wall at (11,15) is just a wall. **The "Welcome" dialog in `/tmp/spec5-town-exit-mid.png` was an artifact of LEFT/RIGHT side-stepping in earlier runs — those moves walked into the weapon-shop and inn doorways, opening dialog (mapflags=3). DOWN-only never opens any dialog.**
+
+## Why cardinal walking is fundamentally insufficient
+
+The Coneria south town exit is **NOT on column x=11**. From (11,10), DOWN reaches (11,14) and hits a hard wall. Both LEFT and RIGHT at y=14 are building doorways. The actual south overworld exit requires walking RIGHT (or LEFT) through the courtyard at higher Y, then DOWN past the buildings. The exact non-cardinal route requires map awareness — either:
+1. Vision-LLM with a much better prompt (run #4 attempted but failed in 30 iters; locate-party-first per memory may not be enough)
+2. Hardcoded route knowledge from manually mapping Coneria
+3. Decoding the actual mapId=0 town overlay tile data — but `mapId=0` decodes to OVERWORLD tiles, not town tiles. The town overlay's tile data lives somewhere else (PPU nametable or a different RAM region) and isn't currently exposed to the agent.
+
+## Next path forward
+
+The Coneria-exit problem is **map-aware navigation**, not dialog detection or NPC patience. Both rabbit holes were thoroughly explored and ruled out by run #6's full-RAM diff.
+
+**Recommended next-session moves, in order (autonomy-compatible — agent plays, dev does not, per `autonomy_principle.md`):**
+
+1. **Build an "empirical Coneria explorer" skill.** Loop from (11,10): for each cardinal, tap → check if smPlayer changed → if yes, record edge (X,Y)→(X',Y') in adjacency map; if no, mark blocked; if mapflags.bit0 cleared, that's an exit tile — record. After exploring breadth-first up to N tiles, BFS the recorded adjacency for shortest path from (11,10) to any exit tile. Then drive the party along that path. Bonus: detect dialog opens (mid-walk RAM dump diff vs entry — currently ALL bytes stable so dialog opens are detectable as "any byte that flipped"; from `/tmp/spec5-ram-diff.log` we know the baseline).
+   - Pure deterministic logic, zero LLM cost, runs offline. Cost: ~30-60 min of Kotlin code in a new `ExploreTownOverlay` skill.
+   - This approach gracefully handles ANY town overlay, not just Coneria — same logic works for Pravoka, Elfheim, etc. once we get there.
+
+2. **Upgrade `VisionInteriorNavigator` prompt** (`knes-agent/src/main/kotlin/knes/agent/perception/VisionInteriorNavigator.kt`, 245 lines) for town overlays. Current prompt is castle/dungeon-oriented. Add a town-specific path: enforce locate-party→locate-south-exit→derive-direction (per `feedback_locate_party_first.md`), ban training-data Coneria geography (per same memory), emphasize "walk AROUND buildings, not through them — building entrances LOOK like exits but aren't". Pass `ToolCallLog` for per-step visibility. This is the right primary tool per `feedback_vision_primary.md` IF empirical explorer (option 1) proves too slow.
+
+3. **Long-term:** expose town-overlay tile data via a `TownOverlayTileSource`. Currently `mapId=0` decodes to OVERWORLD tile data (which is why BFS run #1 found bogus exits). The town overlay's tile data lives in PPU nametable — read it at $2000-$23FF region and convert to walkable/blocked tile classifications. Once available, normal BFS works for `mapId=0+mapflags.bit0=1`.
+
+4. **After exit lands**: validate GrindLoop fires battle. Strategic loop is already wired and traced. `rm ~/.knes/ff1-ow-memory.json` to clear bogus warp record at (147,155) from cont-3 failed runs before validating.
+
+5. **EquipWeapon revisit** — separate follow-up; not on the critical path. Bare-handed grinding works.
+
+**Fast-iter setup carried into next session:**
+- `/tmp/spec5-post-buy.savestate` — load via `KNES_FF1_LOAD_SAVESTATE` to skip the 5-min buy advisor (~30s startup)
+- `/tmp/spec5-town-exit-entry.png` — what the agent sees post-buy at smPlayer=(11,10)
+- `/tmp/spec5-ram-diff.log` — full per-tap log from cont-3 #6 run with all 117 watched bytes dumped at entry + every stuck position. Use as ground truth.
+- `/tmp/spec5-town-exit-mid.png` — kept for reference but **not** evidence of dialog state in current code path; was a side-step artifact from cont-3 #2/#3.
+
+## Known-broken interactions (notes for the would-be fixer)
+
+- **Naive trap-whitelist + grindAnchor gate creates infinite loop.** Trap whitelist (skip bail near TOWN_ENTRY) without an alternative bail → `UnknownMapTrap` never fires. If `grindAnchor` capture is also gated on `mapflags.bit0=0` with `continue` on miss, the strategic loop spins: phase observe (vision call!) → strategic advisor (LLM call!) → not on OW → continue. ~$1/min. **Both reverted in this commit.** Future fix needs to split trap-bail from grind-anchor capture, e.g. add a separate "stuck-in-town for N obs" bail that doesn't poison the persisted warp memory.
+- **Persisted warp memory `(147,155)`** — failed cont-3 runs wrote this to `~/.knes/ff1-ow-memory.json`. Subsequent runs preload it but the trap detector uses an in-memory set, so it's mostly cosmetic. Worth `rm ~/.knes/ff1-ow-memory.json` before validating the exit fix.
+
+## Files changed this cont session (uncommitted)
+
+- `knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt` — items 1–5 above
+- `knes-agent/src/main/kotlin/knes/agent/skills/ExitInterior.kt` — item 6 above
+- `HANDOFF.md` — this file
+
+## Earlier session (2026-05-09 cont 2 — unchanged below)
 
 ## TL;DR — milestone reached: 4/4 weapon purchase, end-to-end
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,8 +1,44 @@
-# FF1 Koog Agent — Handoff (Spec 5 — Coneria pipeline rework, 2026-05-09 cont 4)
+# FF1 Koog Agent — Handoff (Spec 5 — Coneria pipeline rework, 2026-05-10 cont 5)
 
-**Master HEAD:** `598df2d` (model-ID hotfix on top of plan Tasks 1–4).
+**Master HEAD:** `2371e6e` (recent-moves history on top of cont-4).
 **Branch:** `ff1-buy-and-equip-coneria`.
-**Tests:** 353 unit (348 baseline + 5 new in `GrindAnchorSelectorTest`) + 3 in `SavestateRoundtripDebug`. Compiles clean. 3 pre-existing failures (`Coneria8VisualDiffTest`, `ConeriaTownEmpiricalDiscoveryTest`, `ExploreOverworldFrontierTest`) unchanged from `41b01df` baseline — out of scope for this rework.
+**Tests:** 353 unit (348 baseline + 5 in `GrindAnchorSelectorTest`) + 3 in `SavestateRoundtripDebug`. Compiles clean.
+
+## TL;DR — 2026-05-10 cont 5 progress (vision diagnostics + history)
+
+**What landed:**
+
+- `2412b58 feat(nav): per-iter PNG dump in WalkInteriorVision` — fixes a diagnostic blind spot the user surfaced ("Czemu nie widziałem żadnych screenów"). Each vision call now writes `/tmp/spec5-vision-exit-iter-NN-smX_Y-mfM.png` BEFORE the navigator decision, so a 60-step drift leaves 60 visible artefacts. Per `feedback_per_iter_screenshots.md` (new memory: *every* iter-driven LLM skill must dump per-iter PNG, not just BuyAtShop).
+- `2371e6e feat(nav): vision-exit recent-moves history` — fixes the user-diagnosed "circles LEFT, doesn't know to go DOWN because no history" failure mode. `WalkInteriorVision` now maintains an 8-entry rolling buffer of `step=N dir=X smPre=(a,b) smPost=(c,d) moved=Y/N` and concatenates it into `historyHint`. `VisionInteriorNavigator.SYSTEM_PROMPT` extended: "If same direction repeats with moved=false 2+ times → pick PERPENDICULAR cardinal. RECENT MOVES is STRONGER evidence than the still image (image cannot show that the last 5 cardinals were no-ops)."
+
+**Smoke #1 retry (post both fixes):** `boot_phase3_exit_result: ok=false msg=vision returned UNCLEAR 2x in a row after 12 steps world=(147,155) mapflags=3 via=vision`. Trajectory:
+
+- iter 00: `sm(11,10) mf1` — in shop (post-load).
+- iter 09: `sm(14,22) mf1` — south edge of town. **The cont-3 deadlock position.** Vision walked the party from shop counter to south edge in 9 steps — the LEFT-LEFT-LEFT loop is broken.
+- iter 10–12: drift WEST to `sm(9,22)`, `mapflags=3` (mid-scroll bit 1 set).
+- iter 12: vision UNCLEAR x2 → bail.
+
+This is **less-bad** than cont-4 (60-step drift west, never reached south edge). Recent-moves history clearly works as a control signal. But the cont-3 sm(14,22) deadlock — solvable in cont-3 only via hardcoded `Up Right Right Down Down` tree-detour — still defeats vision. The model sees the south horizon, walks west toward visible grass, hits mid-scroll mapflags=3 at sm(9,22), gets confused (UNCLEAR).
+
+**Savestate corruption discovered:** `runOutfitBootPhase` always dumps `/tmp/spec5-post-buy.savestate` after BuyAtShop returns, REGARDLESS of `bought=N`. The previously-good 4/4 buy savestate from 2026-05-09 21:24 was overwritten by subsequent runs where buy advisor returned `Fail` (shop classified CLOSED on savestate-load path). The current `/tmp/spec5-post-buy.savestate` represents party post-buy-failed, not post-buy-success. Workaround: regenerate via fresh-run (~5 min, ~$2). Proper fix: gate savestate dump on `charsBought.isNotEmpty() == originalNeeds`. Out of cont-5 scope.
+
+## Honest cont-5 assessment
+
+**Vision-LLM is not the right primary tool for Coneria town-exit.** Two independent runs with progressively richer prompts (cont-4 POST-SHOP-TOWN-EXIT paragraph, cont-5 RECENT MOVES history) made measurable but insufficient progress: drift west → south-edge-deadlock. The Coneria south exit requires either (a) the cont-3 hardcoded tree-detour `Up Right Right Down Down` from `sm(14,22)`, which is non-deterministic across savestate restore points, or (b) genuine map-aware navigation that knows the town overlay tile data.
+
+Per spec § Risks Risk #1: this is the documented escalation path. **Approach B (PPU nametable read) is the next-session direction.**
+
+## Next-session direction (cont 6)
+
+1. **Approach B — PPU nametable read for town overlay tile data.** Read `$2000-$23FF`, classify tiles by tile-ID (wall / floor / NPC / doorway / warp), build a walkable graph for `mapId=0+mapflags.bit0=1`. Once available, deterministic BFS works. New spec required. Vision-LLM stays as fallback for non-Coneria towns until each one is mapped.
+
+2. **Fix savestate-dump regression.** `runOutfitBootPhase` must NOT overwrite `/tmp/spec5-post-buy.savestate` when `weaponsBought < expected`. Quick fix: gate the dump on the `charsBought` count. Without this, every dev iteration corrupts the fast-iter test fixture.
+
+3. **Run Smoke #2 (fresh-run, ~$2-3) before any merge to master.** Critical regression check: `weaponsBought=4` on a clean ROM. cont-4 + cont-5 changes have NOT been empirically validated against the 4/4 buy baseline. Compile-time pinning + `OutfitBootPhaseTest` greenness give partial confidence; full validation requires the run.
+
+4. **Per-iter PNG + recent-moves history are good-enough for vision-LLM diagnostics now.** Reuse pattern in any future iter-LLM skill (overworld nav, advisor variants).
+
+5. **EquipWeapon revisit** — separate follow-up; bare-hand grinding works.
 
 ## TL;DR — 2026-05-09 cont 4 progress
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,8 +1,72 @@
-# FF1 Koog Agent — Handoff (Spec 5 — exit-from-Coneria BLOCKED, 2026-05-09 cont 3)
+# FF1 Koog Agent — Handoff (Spec 5 — Coneria pipeline rework, 2026-05-09 cont 4)
 
-**Master HEAD:** `361e88e` (merge of PR #122).
-**Branch:** `ff1-buy-and-equip-coneria` (still active for follow-up work; this cont session adds 4 working pieces + 1 known-broken fallback, **uncommitted** at handoff time).
-**Tests:** 348 unit + 3 in `SavestateRoundtripDebug`. Compiles clean.
+**Master HEAD:** `598df2d` (model-ID hotfix on top of plan Tasks 1–4).
+**Branch:** `ff1-buy-and-equip-coneria`.
+**Tests:** 353 unit (348 baseline + 5 new in `GrindAnchorSelectorTest`) + 3 in `SavestateRoundtripDebug`. Compiles clean. 3 pre-existing failures (`Coneria8VisualDiffTest`, `ConeriaTownEmpiricalDiscoveryTest`, `ExploreOverworldFrontierTest`) unchanged from `41b01df` baseline — out of scope for this rework.
+
+## TL;DR — 2026-05-09 cont 4 progress
+
+**Goal:** post-buy → exit Coneria → walk to grass → first random encounter (per `docs/superpowers/specs/2026-05-09-coneria-pipeline-design.md`).
+**Result:** **Phase 3 (exit) still fails empirically** — vision-LLM with new POST-SHOP TOWN EXIT prompt + scratchpad historyHint walked 60 steps without exiting Coneria town overlay. This is the documented Risk #1 in the spec; mitigation (longer step budget + new prompt + history hint) was insufficient. Tasks 1–4 of the plan landed cleanly with all unit tests green and the regression baseline preserved.
+
+**What landed (committable, all green tests):**
+
+1. `12f4e10 feat(grind): GrindAnchorSelector` — pure helper picks nearest GRASS/FOREST anchor from `OverworldMap` with south-then-east tie-break + `fellBack` flag. 5 unit tests.
+2. `1e04d3a feat(nav): post-shop town-exit hints` — appends POST-SHOP TOWN EXIT paragraph to `VisionInteriorNavigator.SYSTEM_PROMPT` encoding user gameplay hints (DOWN-from-shop, overworld-trees-walkable, avoid LEFT/RIGHT building doorways).
+3. `62f118f feat(grind): encounterCounter delta` — per-step delta log + one-shot `grind_encounter_byte_dead` WARN when all 12 deltas are zero across the loop. Pure diagnostic, zero behaviour change.
+4. `b4d7fb5 feat(boot): vision-only Phase 3 exit + Phase 4 grind` — `runOutfitBootPhase` post-buy block reworked. Drops `ExitTownEmpirical`/tree-detour from hot path (kept as offline fallback when `outfitNavigator==null`). Vision-LLM (`WalkInteriorVision(maxSteps=60, historyHint=scratchpad)`) is the sole hot-path exit. Phase 4 picks a `GrindAnchorSelector` anchor, runs `GrindLoop` (corridorRadius=3, maxSteps=12) with up to 2 re-anchors on `NoEncounter`. 5 new trace markers: `boot_phase3_exit_result`, `boot_phase4_grind_anchor`, `boot_phase4_grind_result`, `boot_phase4_grind_reanchor`, `boot_pipeline_end`.
+5. `598df2d fix(nav): refresh stale model ID` — `VisionInteriorNavigator.kt:87` defaulted to `claude-opus-4-5-20251101` which is not a current Anthropic model ID; every API call 404'd → parser returned `UNCLEAR` → exit bailed after 2 in a row. HANDOFF cont-3 had flagged this. Switched to `claude-sonnet-4-6` matching the surrounding KDoc intent ("Uses Sonnet 4.6").
+
+Plus checkpoint commit `41b01df chore(cont-3): checkpoint scaffolding for cont-4 rework` capturing the previously-uncommitted cont-3 work (`AgentScratchpad`, `ExitTownEmpirical`, vision historyHint, GrindLoop screenshots, `boot_exit_interior_result` trace) as a clean base for cont-4.
+
+**Spec + plan committed:** `d286184` + `c7d0b44` (spec design + regression-protection section), `b5597ed` (7-task implementation plan).
+
+## Smoke #1 — savestate-load (executed)
+
+Run command:
+```bash
+KNES_VISION=gemini-pro KNES_FF1_LOAD_SAVESTATE=/tmp/spec5-post-buy.savestate \
+  ./gradlew :knes-agent:run --args="--rom=$PWD/roms/ff.nes \
+    --wall-clock-cap-seconds=300 --cost-cap-usd=2.0 --max-skill-invocations=120"
+```
+
+Run 1 (HEAD `b4d7fb5`, pre-model-ID-fix): `boot_phase3_exit_result: ok=false msg=vision returned UNCLEAR 2x in a row after 3 steps world=(147,155) mapflags=1 via=vision`. Cause: stale Anthropic model ID. Fixed in `598df2d`.
+
+Run 2 (HEAD `598df2d`, post-fix): `boot_phase3_exit_result: ok=false msg=walked 60 steps without exit world=(147,155) mapflags=1 via=vision`. Vision was responding cleanly (no UNCLEAR), but 60 cardinal steps did not transition the party out of the Coneria town overlay; final position is the same warp-entry tile `(147,155)` we started near.
+
+`boot_pipeline_end: victory=false lastPhase=phase3_exit_failed` on both runs. No Phase 4 grind data (skipped on exit failure).
+
+**Smoke #2 (fresh-run) NOT executed** per user gate (option "Tylko Smoke #1, Smoke #2 do osobnej sesji").
+
+## Honest assessment
+
+The cont-4 plan delivered the architectural rework cleanly: 4 well-bounded commits, all unit tests green (`OutfitBootPhaseTest` regression baseline preserved), spec + code-quality reviews passed for every task. **But the empirical Coneria-exit problem is unsolved.** The spec's Risk #1 was: "Vision-LLM still fails to exit Coneria reliably even with hint paragraph — mitigation: scratchpad historyHint + 60 steps. If this still fails, fallback escalation is documented as Approach B (PPU nametable) — separate spec." We hit exactly that risk path.
+
+`weaponsBought=4` regression baseline NOT empirically validated this session — Smoke #2 (fresh-run) was deferred. Compile-time pinning + `OutfitBootPhaseTest` greenness give some confidence but not full empirical proof. Worth running before next merge to master.
+
+## Recommended next-session direction
+
+Per plan self-review + spec § Risks:
+
+1. **DO NOT re-enable `ExitTownEmpirical` / tree-detour in the hot path.** The cont-4 plan explicitly drops it; reverting that breaks the architectural intent. The fallback path is reachable when `outfitNavigator==null` (offline tests) — keep it there.
+
+2. **Open a new spec for Approach B — PPU nametable read.** The town overlay's tile data lives in PPU `$2000-$23FF`; `mapId=0` decodes to overworld tiles which is why the standard BFS finds bogus exits. A new `TownOverlayTileSource` reading PPU and classifying tiles by tile-ID would give the agent a real walkable graph for `mapId=0+mapflags.bit0=1`. Once available, normal BFS works deterministically — no LLM cost on exit.
+
+3. **Investigate why vision walked 60 steps in place.** The trace shows party never left `(147,155)`. Possible causes: (a) walking into NPCs (transient blockers per `reference_ff1_npcs_move`); (b) walking into building doorways triggering dialog (mapflags bit1); (c) cardinal returns valid but party doesn't move because vision misjudges where the south-edge is. A per-step `[walkInteriorVision.dir]` + `[walkInteriorVision.step]` dump in `toolCallLog` already exists — surface it to a per-iter screenshot dir like `/tmp/spec5-vision-exit-iter-NN.png` to diagnose offline before any new code goes in.
+
+4. **Run Smoke #2 (fresh-run, ~$2-3) to validate Phase 1+2 baseline before merging this branch.** The plan's revert-instruction stands: if `weaponsBought < 4` on a fresh run, revert the rework commits.
+
+5. **EquipWeapon advisor revisit** — separate follow-up; not on the critical path. Bare-handed grinding works.
+
+## Files changed this session
+
+- New: `knes-agent/src/main/kotlin/knes/agent/runtime/GrindAnchorSelector.kt` (+test).
+- Modified: `knes-agent/src/main/kotlin/knes/agent/perception/VisionInteriorNavigator.kt` (prompt + model ID).
+- Modified: `knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt` (Phase 3+4 rework).
+- Modified: `knes-agent/src/main/kotlin/knes/agent/skills/GrindLoop.kt` (delta log).
+- New docs: `docs/superpowers/specs/2026-05-09-coneria-pipeline-design.md`, `docs/superpowers/plans/2026-05-09-coneria-pipeline.md`.
+
+## Carried over (kept below for context)
 
 ## TL;DR — 2026-05-09 cont 3 progress
 

--- a/docs/superpowers/plans/2026-05-09-coneria-pipeline.md
+++ b/docs/superpowers/plans/2026-05-09-coneria-pipeline.md
@@ -1,0 +1,651 @@
+# Coneria End-to-End Pipeline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire reliable post-buy `EXIT` and `GRIND` phases so a Coneria run goes Entry → Buy → Exit → Grind → first-encounter-won, without regressing Phase 1 (walk-in) or Phase 2 (4/4 buy).
+
+**Architecture:** Approach A from the spec — vision-LLM is the only town-exit path on the hot path; `ExitTownEmpirical` and `ExitInterior.walkOutOfTownOverlay` are dropped from the hot path (they remain reachable as offline fallback when `outfitNavigator == null`). Post-exit, a small pure helper picks a grind anchor by reading `OverworldMap` tile classifications (GRASS/FOREST = encounter zone). User gameplay hints land in `VisionInteriorNavigator.SYSTEM_PROMPT` (one paragraph). `GrindLoop` keeps its existing logic; we add an `encounterCounter` delta diagnostic log.
+
+**Tech Stack:** Kotlin 1.9, kotest FunSpec for unit tests, Gradle (`./gradlew :knes-agent:test`, `./gradlew :knes-agent:run`).
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `knes-agent/src/main/kotlin/knes/agent/runtime/GrindAnchorSelector.kt` | Create | Pure function: pick grind anchor from party position + `OverworldMap`. Returns `(anchor, tileClass, fellBack)`. |
+| `knes-agent/src/test/kotlin/knes/agent/runtime/GrindAnchorSelectorTest.kt` | Create | Unit tests for the selector across the 4 cases (party on grass / on forest / on town tile / surrounded by water). |
+| `knes-agent/src/main/kotlin/knes/agent/perception/VisionInteriorNavigator.kt` | Modify (lines 233–260) | Append one paragraph to `SYSTEM_PROMPT` encoding user hints #1/#3. |
+| `knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt` | Modify (lines 1465–1497) | Replace exit block: vision-only when navigator wired, drop `ExitTownEmpirical` from hot path. Add anchor selection + grind orchestration with re-anchor (max 2 retries). Emit new trace markers. |
+| `knes-agent/src/main/kotlin/knes/agent/skills/GrindLoop.kt` | Modify (lines 76–78 vicinity) | Log `encounterCounter` delta per step + emit `grind_encounter_byte_dead` warning if all-zero across the loop. |
+
+**Pinned files (DO NOT touch — regression baseline per spec § Regression protection):**
+`BuyAtShop*`, `SYSTEM_SHOP_PURCHASE` prompt, `Main.kt` savestate warm-up, `OutfitBootPhase.kt` entry guards, `NameTable.stateSave` in vNES.
+
+---
+
+## Task 1: Pure helper — `GrindAnchorSelector`
+
+**Files:**
+- Create: `knes-agent/src/main/kotlin/knes/agent/runtime/GrindAnchorSelector.kt`
+- Test: `knes-agent/src/test/kotlin/knes/agent/runtime/GrindAnchorSelectorTest.kt`
+
+The selector takes a party world coordinate and an `OverworldMap`. If the party tile is `GRASS` or `FOREST`, the anchor is the party tile (no fallback). Else it scans a 5×5 box (`radius=2`) around party, finds all `GRASS`/`FOREST` tiles, and picks the closest by Manhattan distance, breaking ties by preferring south (`dy > 0`) then east (`dx > 0`). If no encounter tile is in the 5×5, the result is the party tile with `fellBack = true`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `knes-agent/src/test/kotlin/knes/agent/runtime/GrindAnchorSelectorTest.kt`:
+
+```kotlin
+package knes.agent.runtime
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import knes.agent.perception.OverworldMap
+import knes.agent.perception.TileType
+import java.lang.reflect.Constructor
+
+/**
+ * Builds a 256×256 OverworldMap from a tileId mapping. Tiles default to 0x17
+ * (WATER, impassable) so any cell not explicitly populated is non-encounter.
+ *
+ * 0x00 = GRASS (per OverworldTileClassifier)
+ * 0x03 = FOREST
+ * 0x10 = MOUNTAIN
+ * 0x17 = WATER (default fill)
+ * 0x4A = TOWN
+ */
+private fun buildMap(populated: Map<Pair<Int, Int>, Int>): OverworldMap {
+    val tiles = ByteArray(256 * 256) { 0x17.toByte() }
+    for ((xy, id) in populated) {
+        val (x, y) = xy
+        tiles[y * 256 + x] = id.toByte()
+    }
+    val ctor: Constructor<OverworldMap> =
+        OverworldMap::class.java.getDeclaredConstructor(ByteArray::class.java)
+    ctor.isAccessible = true
+    return ctor.newInstance(tiles)
+}
+
+class GrindAnchorSelectorTest : FunSpec({
+    test("party on GRASS → anchor = party, no fallback") {
+        val map = buildMap(mapOf(146 to 156 to 0x00))
+        val pick = GrindAnchorSelector.pickGrindAnchor(146 to 156, map)
+        pick.anchor shouldBe (146 to 156)
+        pick.tileClass shouldBe TileType.GRASS
+        pick.fellBack shouldBe false
+    }
+
+    test("party on FOREST → anchor = party, no fallback") {
+        val map = buildMap(mapOf(146 to 156 to 0x03))
+        val pick = GrindAnchorSelector.pickGrindAnchor(146 to 156, map)
+        pick.anchor shouldBe (146 to 156)
+        pick.tileClass shouldBe TileType.FOREST
+        pick.fellBack shouldBe false
+    }
+
+    test("party on TOWN tile, GRASS one south → anchor shifts south") {
+        val map = buildMap(mapOf(
+            147 to 155 to 0x4A,  // party tile = TOWN
+            147 to 156 to 0x00,  // south = GRASS
+            147 to 154 to 0x00,  // north = GRASS (also valid — should lose tie-break)
+        ))
+        val pick = GrindAnchorSelector.pickGrindAnchor(147 to 155, map)
+        pick.anchor shouldBe (147 to 156)
+        pick.tileClass shouldBe TileType.GRASS
+        pick.fellBack shouldBe false
+    }
+
+    test("party on TOWN tile, FOREST diagonally SE wins south+east tie-break vs NW GRASS") {
+        val map = buildMap(mapOf(
+            100 to 100 to 0x4A,                    // party = TOWN
+            99 to 99 to 0x00,                      // NW grass (Manhattan 2)
+            101 to 101 to 0x03,                    // SE forest (Manhattan 2) — should win
+        ))
+        val pick = GrindAnchorSelector.pickGrindAnchor(100 to 100, map)
+        pick.anchor shouldBe (101 to 101)
+        pick.tileClass shouldBe TileType.FOREST
+        pick.fellBack shouldBe false
+    }
+
+    test("no encounter tile within radius → fellBack=true, anchor=party") {
+        // Default fill is WATER; nothing populated near (50,50).
+        val map = buildMap(mapOf(50 to 50 to 0x17))
+        val pick = GrindAnchorSelector.pickGrindAnchor(50 to 50, map)
+        pick.anchor shouldBe (50 to 50)
+        pick.fellBack shouldBe true
+    }
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./gradlew :knes-agent:test --tests "knes.agent.runtime.GrindAnchorSelectorTest"`
+Expected: compilation failure — `GrindAnchorSelector` does not exist.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `knes-agent/src/main/kotlin/knes/agent/runtime/GrindAnchorSelector.kt`:
+
+```kotlin
+package knes.agent.runtime
+
+import knes.agent.perception.OverworldMap
+import knes.agent.perception.TileType
+import kotlin.math.abs
+
+/**
+ * Picks a grind anchor near the party using overworld tile classifications.
+ * Encounter zones are GRASS or FOREST (FF1 mechanic, user-confirmed).
+ * If the party already stands on an encounter tile, the anchor IS the party
+ * tile. Otherwise the closest encounter tile within `radius` is picked,
+ * breaking ties by preferring south (dy>0) then east (dx>0).
+ */
+object GrindAnchorSelector {
+    data class Pick(
+        val anchor: Pair<Int, Int>,
+        val tileClass: TileType,
+        val fellBack: Boolean,
+    )
+
+    fun pickGrindAnchor(
+        party: Pair<Int, Int>,
+        map: OverworldMap,
+        radius: Int = 2,
+    ): Pick {
+        val (px, py) = party
+        val partyClass = map.classifyAt(px, py)
+        if (partyClass == TileType.GRASS || partyClass == TileType.FOREST) {
+            return Pick(party, partyClass, fellBack = false)
+        }
+        var best: Pick? = null
+        var bestDist = Int.MAX_VALUE
+        var bestSouthBias = Int.MIN_VALUE
+        var bestEastBias = Int.MIN_VALUE
+        for (dy in -radius..radius) {
+            for (dx in -radius..radius) {
+                if (dx == 0 && dy == 0) continue
+                val tx = px + dx
+                val ty = py + dy
+                val klass = map.classifyAt(tx, ty)
+                if (klass != TileType.GRASS && klass != TileType.FOREST) continue
+                val dist = abs(dx) + abs(dy)
+                val southBias = if (dy > 0) dy else 0
+                val eastBias = if (dx > 0) dx else 0
+                val better = when {
+                    dist < bestDist -> true
+                    dist == bestDist && southBias > bestSouthBias -> true
+                    dist == bestDist && southBias == bestSouthBias && eastBias > bestEastBias -> true
+                    else -> false
+                }
+                if (better) {
+                    best = Pick(tx to ty, klass, fellBack = false)
+                    bestDist = dist
+                    bestSouthBias = southBias
+                    bestEastBias = eastBias
+                }
+            }
+        }
+        return best ?: Pick(party, partyClass, fellBack = true)
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `./gradlew :knes-agent:test --tests "knes.agent.runtime.GrindAnchorSelectorTest"`
+Expected: 5 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add knes-agent/src/main/kotlin/knes/agent/runtime/GrindAnchorSelector.kt \
+        knes-agent/src/test/kotlin/knes/agent/runtime/GrindAnchorSelectorTest.kt
+git commit -m "feat(grind): GrindAnchorSelector — pick GRASS/FOREST anchor from OverworldMap"
+```
+
+---
+
+## Task 2: Append user-hint paragraph to `VisionInteriorNavigator.SYSTEM_PROMPT`
+
+**Files:**
+- Modify: `knes-agent/src/main/kotlin/knes/agent/perception/VisionInteriorNavigator.kt:233-260`
+
+The existing `SYSTEM_PROMPT` already covers castles/dungeons and basic town nav. We append one paragraph encoding user hints #1 (DOWN-from-shop), #3 (overworld trees walkable). Hint #2 (green=grind target) is encoded in `GrindAnchorSelector` already, not in this prompt.
+
+- [ ] **Step 1: Make the edit**
+
+Open `knes-agent/src/main/kotlin/knes/agent/perception/VisionInteriorNavigator.kt`. Find the line ending `Output ONLY JSON: {"direction":"N|S|E|W|EXIT|STUCK","reason":"<<=80 chars"}.` (around line 260). Insert this block immediately before that final line, inside the same string concatenation:
+
+```kotlin
+                "POST-SHOP TOWN EXIT (when the screen shows a town interior with shops/houses): " +
+                "after buying weapons your goal is to leave the town to the overworld. " +
+                "Walk SOUTH out of the shop building first (counter is north, door is south); " +
+                "then keep walking SOUTH along the dirt path between buildings until the camera " +
+                "scrolls off the town onto the overworld (terrain map: grass, trees, mountains, water). " +
+                "Building doorways on LEFT/RIGHT lead INTO other shops and trap you in a dialog — " +
+                "avoid them unless SOUTH is genuinely blocked. Trees in the town overlay block " +
+                "movement; trees on the overworld do NOT — they're walkable encounter terrain. " +
+```
+
+The final concatenated line stays as-is (the `Output ONLY JSON: ...` text).
+
+- [ ] **Step 2: Build to verify the string compiles**
+
+Run: `./gradlew :knes-agent:compileKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Sanity-check the prompt rendered correctly**
+
+Run: `grep -A2 "POST-SHOP TOWN EXIT" knes-agent/src/main/kotlin/knes/agent/perception/VisionInteriorNavigator.kt`
+Expected: prints the inserted lines.
+
+- [ ] **Step 4: Run any existing navigator tests to confirm no regression**
+
+Run: `./gradlew :knes-agent:test --tests "*VisionInteriorNavigator*"` (no-op if no tests exist for this class; skip cleanly).
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add knes-agent/src/main/kotlin/knes/agent/perception/VisionInteriorNavigator.kt
+git commit -m "feat(nav): post-shop town-exit hints in VisionInteriorNavigator prompt
+
+Encode user hints #1 (DOWN-from-shop) and #3 (overworld trees walkable) so
+the model walks SOUTH out of the shop building, avoids LEFT/RIGHT building
+doorways, and doesn't return STUCK when it sees trees on the south horizon."
+```
+
+---
+
+## Task 3: GrindLoop encounterCounter delta logging
+
+**Files:**
+- Modify: `knes-agent/src/main/kotlin/knes/agent/skills/GrindLoop.kt:76-78` (the `println` line + surrounding context)
+
+We add a delta calculation against the previous step's counter, and emit a one-shot warning at the end of the loop if all 12 deltas were zero (signalling the wrong RAM byte or a peninsula dead-zone — visible in trace).
+
+- [ ] **Step 1: Make the edit**
+
+Open `knes-agent/src/main/kotlin/knes/agent/skills/GrindLoop.kt`. Two changes:
+
+a) Add a counter-tracking var at the top of `invoke`. After the line `var goingNorth = true` (around line 42), add:
+
+```kotlin
+        var prevEncCounter: Int? = null
+        var nonZeroDeltaSeen = false
+```
+
+b) In the per-step `println` block (around lines 76–78), wrap it to compute delta and update tracking. Replace:
+
+```kotlin
+            println("[grind] step=$steps world=(${ramStep["worldX"]},${ramStep["worldY"]}) " +
+                "mapflags=${ramStep["mapflags"]} encounterCounter=${ramStep["encounterCounter"]} " +
+                "screenState=0x${(ramStep["screenState"] ?: 0).toString(16)}")
+```
+
+with:
+
+```kotlin
+            val encNow = ramStep["encounterCounter"] ?: 0
+            val encDelta = prevEncCounter?.let { encNow - it } ?: 0
+            if (prevEncCounter != null && encDelta != 0) nonZeroDeltaSeen = true
+            prevEncCounter = encNow
+            println("[grind] step=$steps world=(${ramStep["worldX"]},${ramStep["worldY"]}) " +
+                "mapflags=${ramStep["mapflags"]} encounterCounter=$encNow delta=$encDelta " +
+                "screenState=0x${(ramStep["screenState"] ?: 0).toString(16)}")
+```
+
+c) Just before each of the **two** existing `return SkillResult` statements that report `NoEncounter` and the final fall-through (at the end of the function), add a one-shot warning `println` if `prevEncCounter != null && !nonZeroDeltaSeen`. The simplest way is to add it right before the fall-through `val stateAfter = toolset.getState()` outside the loop (around line 113):
+
+```kotlin
+        if (prevEncCounter != null && !nonZeroDeltaSeen) {
+            println("[grind] WARN grind_encounter_byte_dead: encounterCounter=$prevEncCounter " +
+                "stayed flat across $steps steps — wrong RAM byte or true dead-zone")
+        }
+```
+
+- [ ] **Step 2: Build to verify**
+
+Run: `./gradlew :knes-agent:compileKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Run existing GrindLoop tests if any**
+
+Run: `./gradlew :knes-agent:test --tests "*GrindLoop*" --tests "*GrindAndHeal*"`
+Expected: BUILD SUCCESSFUL with all green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add knes-agent/src/main/kotlin/knes/agent/skills/GrindLoop.kt
+git commit -m "feat(grind): log encounterCounter delta + warn on flat-counter loop
+
+Per-step delta makes encounter-byte staleness visible in stdout; one-shot
+WARN at loop end (grind_encounter_byte_dead) signals when all 12 steps
+saw zero delta, distinguishing wrong RAM byte from true peninsula dead-zone."
+```
+
+---
+
+## Task 4: Replace exit + grind block in `runOutfitBootPhase`
+
+**Files:**
+- Modify: `knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt:1465-1536` (the exit + equip + summary block)
+
+This is the largest edit. We:
+1. Drop `ExitTownEmpirical` from the hot path (kept available only when `outfitNavigator == null`).
+2. Use `WalkInteriorVision(navigator, historyHint=scratchpad.renderForLLM(), maxSteps=60)` as the primary exit.
+3. After exit success, emit `boot_phase3_exit_result`, settle 120 frames, read world coords, call `GrindAnchorSelector.pickGrindAnchor(party, outfitViewportSource as OverworldMap)`, emit `boot_phase4_grind_anchor`.
+4. Run `GrindLoop` with re-anchor (max 2 retries on `NoEncounter`); after each `GrindLoop`, emit `boot_phase4_grind_result`.
+5. On `EncounteredBattle`, emit `boot_pipeline_end {victory:pending}` — actual battle win is handled by the strategic loop's existing PostBattle handler; we mark "pending" so trace makes the boundary visible. Equip stays gated by `KNES_FF1_BOOT_EQUIP` as today.
+
+**Important:** preserve the existing scratchpad recording, the `boot_outfit_summary` event, and the equip logic. Only the exit/grind block changes.
+
+- [ ] **Step 1: Read the current block to anchor the edit**
+
+Run: `sed -n '1465,1540p' knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt`
+Expected output: the existing exit + equip + summary block, ending at `}` of `runOutfitBootPhase`.
+
+- [ ] **Step 2: Replace lines 1465–1496 (exit block) with vision-only + anchor + grind orchestration**
+
+Open `knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt`. Find the block starting at `// 5. Exit shop interior; equip on overworld.` (line 1465) and ending after the `scratchpad.record(...)` call that closes `boot_exit_interior_result` (around line 1496). Replace it with:
+
+```kotlin
+        // 5. Exit shop + town to overworld via vision-LLM (Phase 3).
+        // Per spec 2026-05-09-coneria-pipeline: vision is the sole hot-path
+        // exit. ExitTownEmpirical / tree-detour stay reachable only when the
+        // navigator is unwired (offline tests).
+        repeat(8) {
+            toolset.tap(button = "B", count = 1, pressFrames = 4, gapFrames = 8)
+            toolset.step(buttons = emptyList(), frames = 4)
+        }
+
+        val exitResult = if (outfitNavigator != null) {
+            knes.agent.skills.WalkInteriorVision(
+                toolset, outfitNavigator, toolCallLog,
+                historyHint = scratchpad.renderForLLM(),
+            ).invoke(mapOf("maxSteps" to "60"))
+        } else {
+            // Offline fallback: empirical+tree-detour, then BFS.
+            val emp = knes.agent.skills.ExitTownEmpirical(toolset, scratchpad)
+                .invoke(mapOf("maxTaps" to "120"))
+            if (emp.ok) emp
+            else ExitInterior(toolset, outfitMapSession, fog).invoke(emptyMap())
+        }
+        val exitRam = exitResult.ramAfter
+        trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
+            note = "boot_phase3_exit_result: ok=${exitResult.ok} msg=${exitResult.message} " +
+                "world=(${exitRam["worldX"] ?: "?"},${exitRam["worldY"] ?: "?"}) " +
+                "mapflags=${exitRam["mapflags"] ?: "?"} " +
+                "via=${if (outfitNavigator != null) "vision" else "fallback"}"))
+        scratchpad.record(kind = "exit",
+            summary = "phase3_exit_result: ok=${exitResult.ok}",
+            smPost = (exitRam["smPlayerX"] ?: 0) to (exitRam["smPlayerY"] ?: 0),
+            mapflagsPost = exitRam["mapflags"] ?: 0,
+            note = exitResult.message.take(120))
+
+        // Phase 4: grind anchor selection + GrindLoop with re-anchor.
+        // Only run when exit succeeded AND viewport source is an OverworldMap.
+        val owMap = outfitViewportSource as? knes.agent.perception.OverworldMap
+        if (exitResult.ok && owMap != null) {
+            // 120-frame settle so any mapflags.bit1 mid-scroll transient clears.
+            toolset.step(buttons = emptyList(), frames = 120)
+            val ramSettled = toolset.getState().ram
+            val partyXY = (ramSettled["worldX"] ?: 0) to (ramSettled["worldY"] ?: 0)
+            val triedAnchors = mutableSetOf<Pair<Int, Int>>()
+            var firstPick = GrindAnchorSelector.pickGrindAnchor(partyXY, owMap)
+            trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
+                note = "boot_phase4_grind_anchor: anchor=(${firstPick.anchor.first}," +
+                    "${firstPick.anchor.second}) tileClass=${firstPick.tileClass} " +
+                    "fellBack=${firstPick.fellBack} party=(${partyXY.first},${partyXY.second})"))
+            var grindAttempt = 0
+            val maxAttempts = 3  // 1 initial + 2 re-anchors
+            var lastResult: knes.agent.skills.SkillResult? = null
+            var currentPick = firstPick
+            while (grindAttempt < maxAttempts) {
+                triedAnchors += currentPick.anchor
+                val (ax, ay) = currentPick.anchor
+                lastResult = knes.agent.skills.GrindLoop(toolset).invoke(mapOf(
+                    "anchorX" to ax.toString(),
+                    "anchorY" to ay.toString(),
+                    "corridorRadius" to "3",
+                    "maxStepsWithoutEncounter" to "12",
+                ))
+                trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
+                    note = "boot_phase4_grind_result: attempt=${grindAttempt + 1}/$maxAttempts " +
+                        "anchor=($ax,$ay) outcome=${lastResult.message}"))
+                val msg = lastResult.message
+                val battle = msg.startsWith("EncounteredBattle")
+                if (battle) break
+                val noEnc = msg.startsWith("NoEncounter")
+                if (!noEnc) break  // WanderedOff / Blocked → don't re-anchor
+                grindAttempt++
+                if (grindAttempt >= maxAttempts) break
+                // Re-anchor: read current world coord and pick the next-best
+                // tile that we haven't tried yet. Loosen by widening radius.
+                val reRam = toolset.getState().ram
+                val reParty = (reRam["worldX"] ?: ax) to (reRam["worldY"] ?: ay)
+                val widerPicks = (1..3).asSequence().mapNotNull { r ->
+                    val p = GrindAnchorSelector.pickGrindAnchor(reParty, owMap, radius = r + 1)
+                    if (p.anchor in triedAnchors || p.fellBack) null else p
+                }
+                currentPick = widerPicks.firstOrNull() ?: break
+                trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
+                    note = "boot_phase4_grind_reanchor: attempt=${grindAttempt + 1} " +
+                        "newAnchor=(${currentPick.anchor.first},${currentPick.anchor.second}) " +
+                        "tileClass=${currentPick.tileClass}"))
+            }
+            val pipelineVictory = lastResult?.message?.startsWith("EncounteredBattle") == true
+            trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
+                note = "boot_pipeline_end: victory=$pipelineVictory " +
+                    "lastPhase=${if (pipelineVictory) "phase4_battle_pending" else "phase4_grind"}"))
+        } else if (!exitResult.ok) {
+            trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
+                note = "boot_pipeline_end: victory=false lastPhase=phase3_exit_failed"))
+        } else {
+            trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
+                note = "boot_pipeline_end: victory=false lastPhase=phase4_skipped_no_overworld_map"))
+        }
+```
+
+The existing equip block (`if (System.getenv("KNES_FF1_BOOT_EQUIP")...`) and the final summary block (`val finalGold = ... boot_outfit_summary: $summary`) stay untouched — they're after this insertion.
+
+- [ ] **Step 3: Verify imports — `GrindAnchorSelector` is in the same package, no import needed; `OverworldMap`/`SkillResult` may need explicit imports**
+
+Run: `./gradlew :knes-agent:compileKotlin`
+Expected: BUILD SUCCESSFUL. If `Unresolved reference: GrindAnchorSelector` or `SkillResult` appears, add at the top of `AgentSession.kt`:
+
+```kotlin
+import knes.agent.skills.SkillResult
+```
+
+(`GrindAnchorSelector` is in `knes.agent.runtime` — same package as `AgentSession`, no import needed.)
+
+- [ ] **Step 4: Run the full unit-test suite to verify no regression**
+
+Run: `./gradlew :knes-agent:test`
+Expected: 348 unit tests + 3 in `SavestateRoundtripDebug` + 5 new in `GrindAnchorSelectorTest` = 356 tests, all green. If `OutfitBootPhaseTest` regresses, `runOutfitBootPhase` was perturbed beyond the exit block — STOP and re-read the diff.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt
+git commit -m "feat(boot): vision-only Phase 3 exit + Phase 4 grind w/ anchor + reanchor
+
+Drops ExitTownEmpirical / tree-detour from hot path (kept as offline fallback
+when outfitNavigator==null). Post-exit settles 120 frames, picks anchor via
+GrindAnchorSelector reading OverworldMap GRASS/FOREST classifications, runs
+GrindLoop with up to 2 re-anchors on NoEncounter. New trace markers:
+boot_phase3_exit_result, boot_phase4_grind_anchor, boot_phase4_grind_result,
+boot_phase4_grind_reanchor, boot_pipeline_end."
+```
+
+---
+
+## Task 5: Smoke check #1 — savestate-loaded run (validates Phase 3+4)
+
+This is a **manual run** because Phase 3 exits a real emulator state via vision-LLM and we cannot mock the navigator faithfully in unit tests. Savestate-load is the fast path (~30s startup vs ~5min fresh).
+
+- [ ] **Step 1: Verify the savestate exists**
+
+Run: `ls -la /tmp/spec5-post-buy.savestate /tmp/spec5-post-buy.actions.json 2>&1`
+
+Expected: both files present (savestate ~12KB, actions.json with walk-in trajectory). If absent, do Smoke check #2 first (which will dump the savestate at `boot_post_buy_savestate_dumped`).
+
+- [ ] **Step 2: Run with savestate, capture trace**
+
+Run:
+```bash
+KNES_VISION=gemini-pro \
+KNES_FF1_LOAD_SAVESTATE=/tmp/spec5-post-buy.savestate \
+ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY \
+GEMINI_API_KEY=$GEMINI_API_KEY \
+./gradlew :knes-agent:run --args="--rom=$PWD/roms/ff.nes \
+  --wall-clock-cap-seconds=300 --cost-cap-usd=2.0 --max-skill-invocations=120"
+```
+
+Expected: process exits in <5min. The strategic loop may bail post-grind via `UnknownMapTrap` or `OutOfBudget` — that's OK; what matters is what landed in the trace.
+
+- [ ] **Step 3: Inspect the trace for the new markers**
+
+Run:
+```bash
+LATEST=$(ls -td ~/.knes/runs/*/ | head -1)
+grep -E 'boot_phase3_exit_result|boot_phase4_grind_anchor|boot_phase4_grind_result|boot_pipeline_end' "$LATEST/trace.jsonl"
+```
+
+Expected output:
+- `boot_phase3_exit_result` with `ok=true` and `via=vision`. If `ok=false`, vision-exit failed in 60 steps — escalate per spec § Risks (consider Approach B in a follow-up; do NOT re-introduce tree-detour).
+- `boot_phase4_grind_anchor` with `tileClass=GRASS` or `FOREST`. If `fellBack=true`, the post-exit settle position is on town/castle/water — possible coast deadlock; verify by viewing the post-exit screenshot at `/tmp/spec5-postexit-*.png`.
+- One or more `boot_phase4_grind_result` lines.
+- One `boot_pipeline_end` with either `victory=true` (EncounteredBattle) or `victory=false`.
+
+- [ ] **Step 4: Decide pass/fail**
+
+Pass criteria for this smoke: `boot_phase3_exit_result.ok=true` AND at least one `boot_phase4_grind_result` line emitted. `victory=true` is the goal but not blocking — encounter rate is probabilistic and the spec allows up to 2 re-anchors.
+
+If exit-result is `ok=false` after this commit, do NOT proceed to Smoke #2. Open a follow-up issue documenting the vision-exit failure mode (final mapflags, screenshot) and stop.
+
+- [ ] **Step 5: No commit — this is observation only**
+
+---
+
+## Task 6: Smoke check #2 — fresh-run regression (validates Phase 1+2 baseline)
+
+This validates that the rework did NOT break the 4/4 buy baseline. Runtime ~5–8 min (full advisor loop fires).
+
+- [ ] **Step 1: Clear stale state**
+
+Run:
+```bash
+rm -f ~/.knes/ff1-ow-memory.json /tmp/spec5-post-buy.savestate /tmp/spec5-post-buy.actions.json
+cat > ~/.knes/ff1-landmarks.json <<'JSON'
+{"version":1,"landmarks":[
+  {"id":"interior_entry_147_155","kind":"TOWN_ENTRY","worldX":147,"worldY":155,
+   "visited":true,"note":"coneria-town overworld waypoint","discoveredRunId":"preseed"},
+  {"id":"weapon_shopkeeper_preseed","kind":"NPC_SHOPKEEPER","visited":false,
+   "note":"kind=weapon; preseed; items=staff:5,dagger:5,nunchuck:10,rapier:10,hammer:10","discoveredRunId":"preseed"}
+]}
+JSON
+```
+
+- [ ] **Step 2: Fresh run**
+
+Run:
+```bash
+KNES_VISION=gemini-pro \
+ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY \
+GEMINI_API_KEY=$GEMINI_API_KEY \
+./gradlew :knes-agent:run --args="--rom=$PWD/roms/ff.nes \
+  --wall-clock-cap-seconds=900 --cost-cap-usd=3.0 --max-skill-invocations=120"
+```
+
+Expected: process completes within wall-clock cap.
+
+- [ ] **Step 3: Verify Phase 2 baseline (4/4 buy)**
+
+Run:
+```bash
+LATEST=$(ls -td ~/.knes/runs/*/ | head -1)
+grep -E 'BOUGHT|boot_outfit_summary|boot_post_buy_savestate' "$LATEST/trace.jsonl"
+```
+
+Expected: `boot_outfit_summary: weaponsBought=4 ...`. **If `weaponsBought < 4`, this is a regression of the pinned baseline — STOP, do NOT commit anything else; revert the rework commits and re-investigate.**
+
+- [ ] **Step 4: Verify Phase 3+4 fired on fresh state too**
+
+Run:
+```bash
+grep -E 'boot_phase3_exit_result|boot_phase4_grind_anchor|boot_pipeline_end' "$LATEST/trace.jsonl"
+```
+
+Expected: same shape as Smoke #1 — exit ok, anchor picked, pipeline_end emitted. Cost on this run will be higher (full advisor + vision-exit).
+
+- [ ] **Step 5: No commit — observation only. Capture results in HANDOFF.md update.**
+
+---
+
+## Task 7: Update HANDOFF.md with cont-4 results
+
+**Files:**
+- Modify: `HANDOFF.md` — prepend a new "TL;DR — 2026-05-09 cont 4" section.
+
+- [ ] **Step 1: Open `HANDOFF.md` and prepend a new TL;DR section above the existing cont-3 section**
+
+The new section should state, with concrete numbers from the smoke runs:
+- Final HEAD SHA after this plan's commits.
+- Smoke #1 result: exit-ok? anchor tileClass? pipeline_end victory?
+- Smoke #2 result: weaponsBought=N (must be 4 to pass), exit-ok, pipeline_end.
+- Files touched (4 files per the file structure section above).
+- Known follow-ups: e.g. if vision-exit was unreliable on certain start positions, note it; if encounter rate stayed zero across all 3 attempts in both smokes, recommend the next-session direction (pure-grass corridor further from coast, or `encounterCounter` byte audit).
+
+Template:
+
+```markdown
+# FF1 Koog Agent — Handoff (Spec 5 — Coneria pipeline rework, 2026-05-09 cont 4)
+
+**Master HEAD:** `<SHA>`.
+**Branch:** `ff1-buy-and-equip-coneria`.
+**Tests:** 356 unit + 3 in SavestateRoundtripDebug. Compiles clean.
+
+## TL;DR — 2026-05-09 cont 4 progress
+
+**Goal:** Phase 3 (exit) + Phase 4 (grind) reworked per
+`docs/superpowers/specs/2026-05-09-coneria-pipeline-design.md`.
+
+**What landed:**
+- `GrindAnchorSelector` — pure helper picks GRASS/FOREST anchor from OverworldMap.
+- `VisionInteriorNavigator.SYSTEM_PROMPT` — appended POST-SHOP TOWN EXIT paragraph.
+- `runOutfitBootPhase` — drops ExitTownEmpirical/tree-detour from hot path; Phase 3 = WalkInteriorVision(historyHint=scratchpad, maxSteps=60); Phase 4 = anchor select + GrindLoop with up to 2 re-anchors.
+- `GrindLoop` — encounterCounter delta log + grind_encounter_byte_dead WARN.
+- New trace markers: boot_phase3_exit_result, boot_phase4_grind_anchor, boot_phase4_grind_result, boot_phase4_grind_reanchor, boot_pipeline_end.
+
+**Smoke #1 (savestate):** <fill in>
+**Smoke #2 (fresh):** <fill in>
+
+**Known follow-ups:** <fill in>
+```
+
+- [ ] **Step 2: Commit the handoff**
+
+```bash
+git add HANDOFF.md
+git commit -m "docs(handoff): cont-4 — Phase 3+4 rework landed, smoke results captured"
+```
+
+---
+
+## Self-review notes (for the implementer)
+
+If the smoke runs reveal that vision-exit is still unreliable:
+- DO NOT re-enable `ExitTownEmpirical` in the hot path. The spec explicitly drops it.
+- Open a new spec for Approach B (PPU nametable read).
+
+If the smoke runs reveal `grind_encounter_byte_dead` warnings every loop:
+- Open a follow-up to audit the `encounterCounter` byte address against the FF1 disasm.
+- Do NOT widen the corridor or move the anchor outside the 5×5 in this plan — that's scope creep.
+
+If `weaponsBought < 4` in Smoke #2:
+- Revert. Re-read the diff against `runOutfitBootPhase`. The most likely culprits are an accidental edit to the lines BEFORE 1465 (Phase 2 / dialog dismiss) or AFTER 1496 (equip / summary). The only allowed change is the exit/grind block.

--- a/docs/superpowers/specs/2026-05-09-coneria-pipeline-design.md
+++ b/docs/superpowers/specs/2026-05-09-coneria-pipeline-design.md
@@ -1,0 +1,104 @@
+# Coneria End-to-End Pipeline — Design
+
+**Date:** 2026-05-09
+**Branch:** `ff1-buy-and-equip-coneria`
+**Status:** approved (brainstorming → writing-plans)
+
+## Goal
+
+Wire a reliable end-to-end pipeline from Coneria-town entry to first-random-encounter-won, in one boot phase. Today buy works (4/4); exit and grind do not.
+
+**Success = `screenState=0x68` (battle screen) fires after exit, `battleFightAll` wins, party returns to overworld with `mapflags.bit0=0`.**
+
+## Pipeline (4 phases)
+
+```
+WALK_TO_SHOP → BUY → EXIT → GRIND
+   (exists)  (exists) (rework) (rework)
+```
+
+Phases 3 (EXIT) and 4 (GRIND) are reworked. Phases 1–2 stay as-is.
+
+### Phase 1 — WALK_TO_SHOP (existing)
+
+In `runOutfitBootPhase`. Walks from world entry to shopkeeper. `AgentScratchpad` records the cardinals so Phase 3 can use the reversed trajectory as `historyHint`. When `KNES_FF1_LOAD_SAVESTATE` is set, this phase is skipped — savestate already places the party in-shop.
+
+### Phase 2 — BUY (existing)
+
+`BuyAtShop.invokeWithAdvisor` (cap=120). Achieves 4/4 weapon purchase via Gemini-Pro vision advisor. Ends at `boot_outfit_summary`; the post-buy savestate is dumped to `/tmp/spec5-post-buy.savestate` for fast iteration.
+
+### Phase 3 — EXIT (rework)
+
+Replace the brittle empirical/tree-detour stack with vision-LLM only.
+
+**Sequence:**
+1. B-spam ×8 to dismiss any lingering BUY/SELL/EXIT dialog (already in code).
+2. `WalkInteriorVision(navigator, historyHint=scratchpad.renderForLLM(), maxSteps=60)`.
+3. Success when `mapflags.bit0=0` (canonical "on overworld" per Disch). Post-success: 120-frame settle so any `mapflags.bit1` mid-scroll transient clears before Phase 4 reads world coordinates.
+4. Failure → bail; `UnknownMapTrap` safety valve fires in strategic loop.
+
+**`ExitTownEmpirical` and `ExitInterior.walkOutOfTownOverlay` stay in the codebase** but are **dropped from the hot path**. They remain reachable only when `outfitNavigator == null` (offline/test runs). No tree-detour, no hardcoded `(14,22)` approach, no `mf3-recovery` ladder.
+
+**Prompt change in `VisionInteriorNavigator.SYSTEM_PROMPT`** — append one paragraph:
+
+> When you've just bought weapons in a TOWN shop and need to leave: first walk SOUTH out of the shop building (the shopkeeper counter is north, the door is south). Then keep walking SOUTH along the dirt path between buildings until the camera scrolls off the town onto the overworld (grass, trees, mountains visible). LEFT/RIGHT during town-exit usually leads INTO another building's doorway — avoid unless SOUTH is genuinely blocked. Trees in the town overlay block movement; trees on the overworld do NOT — they're walkable encounter terrain, not obstacles.
+
+This encodes user-hint #1 (DOWN-from-shop) and primes the model for the town/overworld tree-walkability distinction (hints #2/#3) so the model doesn't return STUCK when it sees trees on the south horizon.
+
+### Phase 4 — GRIND (rework)
+
+**Anchor placement (new):** post-exit, `runOutfitBootPhase` reads `worldX/worldY` after the 120-frame settle, classifies the 5×5 tile area around party using `OverworldMap.fromRom` (already constructed in `Main.kt`), and picks an anchor:
+
+- If party stands on `forest` or `grass` → `anchor = (worldX, worldY)`.
+- Else → `anchor = nearest forest/grass tile in 5×5`, preferring south + east (FF1 Coneria peninsula has open grass to the SE).
+- Else (no walkable encounter tile in 5×5) → log warning, fall back to `anchor = (worldX, worldY)` and let `GrindLoop` report `WanderedOff` if needed.
+
+**`GrindLoop` invocation:** `corridorRadius=3, maxStepsWithoutEncounter=12`.
+
+**Encounter-rate diagnostics + retry:**
+1. Per-step log already dumps `encounterCounter`; add `delta = encounterCounterPost - encounterCounterPre`. If delta is zero across all 12 steps, log a single warning (`grind_encounter_byte_dead`) but continue — `screenState=0x68` is the authoritative battle signal regardless of the counter byte.
+2. If `GrindLoop` returns `NoEncounter`, re-anchor to the next forest/grass tile in the 5×5 area and retry. Max 2 re-anchors.
+
+**No corridor-shift logic** (the cont-3 +2E/-4N shift moved the corridor into castle territory and is removed in this design).
+
+## User-hint encoding
+
+| Hint | Where encoded |
+|---|---|
+| #1 "Po wyjściu ze sklepu — DOWN" | `VisionInteriorNavigator.SYSTEM_PROMPT` (new paragraph above) |
+| #2 "Zielone = grass = cel grindu" | Phase 4 anchor selection via `OverworldMap` tile classification |
+| #3 "Drzewa na overworld są chodzące" | Same SYSTEM_PROMPT paragraph + `GrindLoop` treats `forest` as encounter zone |
+
+## Phase boundaries / state contract
+
+- Phase 3 fails → no Phase 4. `boot_phase3_exit_result {ok:false, ...}` written to trace; `runOutfitBootPhase` returns; strategic loop takes over.
+- Phase 4 fails (`NoEncounter` after 2 re-anchors, `WanderedOff`, `Blocked`) → `boot_phase4_grind_result {ok:false, ...}`; `runOutfitBootPhase` returns; strategic loop takes over.
+- Phase 4 success (`EncounteredBattle`) → `runOutfitBootPhase` returns; the existing `PostBattle` handler in `ExecutorAgent` fires `battleFightAll`. Pipeline END marker `boot_pipeline_end {victory:true}` is written when `battleFightAll` returns and `mapflags.bit0=0`.
+
+## Trace markers (added)
+
+- `boot_phase3_exit_result {ok, finalWorldX, finalWorldY, mapflags, steps, via:"vision"}`
+- `boot_phase4_grind_anchor {anchorX, anchorY, tileClass}`
+- `boot_phase4_grind_result {outcome, anchorReanchorCount, encounterByteDead}`
+- `boot_pipeline_end {victory, lastPhase}`
+
+## Out of scope
+
+- EquipWeapon (bare-hand grind works; separate follow-up).
+- Generalization to Pravoka / Elfheim / other towns. Once the mechanism works for Coneria, the prompt paragraph + `OverworldMap`-based anchor selection should generalize without code changes; not validated in this spec.
+- PPU nametable tile-classification (Approach B — explicitly rejected; conflicts with `feedback_vision_primary.md`).
+- Loop back to town for re-buy / re-grind cycles.
+- `UnknownMapTrap` detector refactor (separate concern; current 10-obs threshold is acceptable safety valve).
+
+## Files affected
+
+- `knes-agent/src/main/kotlin/knes/agent/perception/VisionInteriorNavigator.kt` — SYSTEM_PROMPT addition.
+- `knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt` — `runOutfitBootPhase` Phase 3 (drop empirical/tree-detour from hot path) and Phase 4 (anchor selection via `OverworldMap`).
+- `knes-agent/src/main/kotlin/knes/agent/skills/GrindLoop.kt` — encounter-byte delta log; no behavior change otherwise.
+- New trace events written from `runOutfitBootPhase`.
+
+## Risks
+
+1. Vision-LLM still fails to exit Coneria reliably even with hint paragraph — mitigation: scratchpad `historyHint` is already wired and gives the model the walk-in trajectory; 60 steps is twice cont-3's failed run. If this still fails, fallback escalation is documented in HANDOFF as Approach B (PPU nametable) — separate spec.
+2. `OverworldMap` tile classification doesn't expose `forest`/`grass` distinctly — mitigation: any tile that's neither `mountain` nor `water` nor a warp counts as walkable encounter terrain. Validation: read `OverworldMap.fromRom` API at plan time; if API insufficient, plan adds a thin classifier.
+3. Encounter rate near Coneria peninsula is genuinely low — mitigation: re-anchor logic + 2 retries widen the search; if still zero encounters across all anchors, the trace makes this visible (`grind_encounter_byte_dead`) and the next session can move corridor further from coast.

--- a/docs/superpowers/specs/2026-05-09-coneria-pipeline-design.md
+++ b/docs/superpowers/specs/2026-05-09-coneria-pipeline-design.md
@@ -82,6 +82,27 @@ This encodes user-hint #1 (DOWN-from-shop) and primes the model for the town/ove
 - `boot_phase4_grind_result {outcome, anchorReanchorCount, encounterByteDead}`
 - `boot_pipeline_end {victory, lastPhase}`
 
+## Regression protection (pinned phases)
+
+Phase 1 (WALK_TO_SHOP) and Phase 2 (BUY) are **pinned** — this rework MUST NOT change their code, prompts, savestate handling, or invocation contract. Spec 5 4/4 weapon purchase (Run B2-v3) is the baseline; any drop below 4/4 in a fresh run is a regression.
+
+**Invariants the implementation plan must preserve:**
+
+- `BuyAtShop.invokeWithAdvisor` cap=120 unchanged.
+- `SYSTEM_SHOP_PURCHASE` prompt unchanged (POST-PURCHASE FLOW + ERROR_DIALOG sections that took multiple sessions to land).
+- 120-frame pre-warm + 120-frame post-pump around `loadState` unchanged (`Main.kt`).
+- `runOutfitBootPhase` savestate-skip branch (`KNES_FF1_LOAD_SAVESTATE` set → skip walk + nav advisor) unchanged.
+- `NameTable.stateSave` fix unchanged (no diff to vNES).
+- `boot_outfit_summary` trace event still emitted with `weaponsBought=N totalGoldSpent=M`.
+- Per-iter buy screenshots `/tmp/spec5-buy-advisor-iter-NN-served-XXXX.png` still dumped.
+
+**Plan must include two smoke checks before declaring done:**
+
+1. **Fresh-run smoke:** end-to-end run from clean ROM (no savestate). Expect `boot_outfit_summary: weaponsBought=4` in trace. If <4, the rework regressed buy — STOP, do not proceed.
+2. **Savestate smoke:** `KNES_FF1_LOAD_SAVESTATE=/tmp/spec5-post-buy.savestate` run. Expect Phase 3 (vision exit) and Phase 4 (grind) to fire; Phase 1+2 are skipped by the savestate-skip branch and not exercised here. This is the fast-iter loop for Phase 3+4 development.
+
+If a Phase 3/4 change requires touching shared state used by Phase 2 (e.g., `runOutfitBootPhase` boot trigger, scratchpad load path), it must be raised as an explicit risk in the plan, not folded silently.
+
 ## Out of scope
 
 - EquipWeapon (bare-hand grind works; separate follow-up).

--- a/knes-agent/src/main/kotlin/knes/agent/Main.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/Main.kt
@@ -17,6 +17,7 @@ import knes.agent.perception.AnthropicVisionOverworldNavigator
 import knes.agent.perception.AnthropicVisionPhaseClassifier
 import knes.agent.perception.RamObserver
 import java.io.File
+import knes.agent.runtime.AgentScratchpad
 import knes.agent.runtime.AgentSession
 import knes.agent.runtime.Budget
 import knes.agent.runtime.Outcome
@@ -40,6 +41,27 @@ fun main(args: Array<String>) {
     // navigation loop and go directly into the in-shop purchase advisor for
     // dev iteration on shop-side bugs without burning nav budget.
     val loadStatePath = System.getenv("KNES_FF1_LOAD_SAVESTATE")?.takeIf { it.isNotBlank() }
+
+    // 2026-05-09 cont 3: when a savestate is loaded, also try to load its
+    // sister `*.actions.json` (the agent's "where I came from" notebook).
+    // Falls back to a fresh empty scratchpad if the file is absent. The
+    // loaded notebook is injected into AgentSession so subsequent skills can
+    // read in-walk trajectory + summarize history for prompts.
+    val scratchpad: AgentScratchpad = run {
+        val loaded = loadStatePath?.let { p ->
+            try {
+                AgentScratchpad.loadSister(File(p))?.also {
+                    System.err.println("[main] loaded scratchpad from " +
+                        "${AgentScratchpad.sisterPathFor(File(p)).absolutePath} " +
+                        "(${it.all().size} entries)")
+                }
+            } catch (e: Throwable) {
+                System.err.println("[main] WARN: scratchpad load failed: ${e.message}; using fresh")
+                null
+            }
+        }
+        loaded ?: AgentScratchpad.newSession()
+    }
 
     val outcome: Outcome = runBlocking {
         AnthropicSession(key).use { anthropic ->
@@ -154,6 +176,7 @@ fun main(args: Array<String>) {
                 outfitMapSession = mapSession,
                 bridgeVision = visionBackend,
                 bridgeViewportSource = overworldMap,
+                scratchpad = scratchpad,
             ).run()
         }
     }

--- a/knes-agent/src/main/kotlin/knes/agent/perception/VisionInteriorNavigator.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/perception/VisionInteriorNavigator.kt
@@ -66,6 +66,7 @@ interface VisionInteriorNavigator {
         entryDirection: InteriorMove? = null,
         frontierHint: InteriorMove? = null,
         unvisitedReachable: Int = 0,
+        historyHint: String? = null,
     ): InteriorMove
 }
 
@@ -101,14 +102,15 @@ class AnthropicVisionInteriorNavigator(
         entryDirection: InteriorMove?,
         frontierHint: InteriorMove?,
         unvisitedReachable: Int,
+        historyHint: String?,
     ): InteriorMove {
         val key = "$frame|${hintLastBlocked?.name}|${entryDirection?.name}" +
-            "|${frontierHint?.name}|$unvisitedReachable"
+            "|${frontierHint?.name}|$unvisitedReachable|${historyHint?.hashCode()}"
         if (frame == cachedFrame && key == cachedKey && cachedMove != InteriorMove.UNCLEAR) {
             return cachedMove
         }
         val body = buildRequestBody(screenshotBase64, hintLastBlocked, entryDirection,
-            frontierHint, unvisitedReachable)
+            frontierHint, unvisitedReachable, historyHint)
         val resp = try {
             client.post(API_URL) {
                 header("x-api-key", apiKey)
@@ -137,9 +139,24 @@ class AnthropicVisionInteriorNavigator(
         entryDirection: InteriorMove?,
         frontierHint: InteriorMove?,
         unvisitedReachable: Int,
+        historyHint: String?,
     ): String {
         val userText = buildString {
             append("Pick the next direction for the party. Return JSON only.")
+            if (!historyHint.isNullOrBlank()) {
+                // 2026-05-09 cont 3: free-form context from agent scratchpad —
+                // typically a render of the walk-in trajectory ("you walked
+                // UP×9 LEFT×1 ... from town entry to the shop"). Use this to
+                // reason about the exit path; it's a HINT, not a deterministic
+                // replay — current screen + NPC positions take precedence.
+                append("\nCONTEXT (your own action history, use as reasoning hint, not literal replay):\n")
+                append(historyHint.trim())
+                append("\nThe REVERSE of the walk-in trajectory points toward the exit. ")
+                append("Use this to bias direction choice when the screen is ambiguous. ")
+                append("\nGRIND/ENCOUNTER zone after exit = solid GREEN grass tiles on the overworld ")
+                append("(NOT the gray stone Coneria walls, NOT the trees). Random battles only fire ")
+                append("on green grass tiles. After exit, the party should walk on green tiles to find encounters.")
+            }
             if (entryDirection != null) {
                 val opposite = when (entryDirection) {
                     InteriorMove.NORTH -> "S"

--- a/knes-agent/src/main/kotlin/knes/agent/perception/VisionInteriorNavigator.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/perception/VisionInteriorNavigator.kt
@@ -84,7 +84,7 @@ interface VisionInteriorNavigator {
  */
 class AnthropicVisionInteriorNavigator(
     private val apiKey: String,
-    private val model: String = "claude-opus-4-5-20251101",
+    private val model: String = "claude-sonnet-4-6",
     private val client: HttpClient = HttpClient(CIO) {
         install(HttpTimeout) { requestTimeoutMillis = 30_000 }
     },

--- a/knes-agent/src/main/kotlin/knes/agent/perception/VisionInteriorNavigator.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/perception/VisionInteriorNavigator.kt
@@ -257,6 +257,14 @@ class AnthropicVisionInteriorNavigator(
                 "unvisited, treat covering the map as your TOP priority — even above seeking the exit. " +
                 "Pick the suggested explore direction (or any direction toward unvisited area) and " +
                 "return EXIT only when no unvisited tiles remain or the party is genuinely on the overworld. " +
+                "POST-SHOP TOWN EXIT (when the screen shows a town interior with shops/houses): " +
+                "after buying weapons your goal is to leave the town to the overworld. " +
+                "Walk SOUTH out of the shop building first (counter is north, door is south); " +
+                "then keep walking SOUTH along the dirt path between buildings until the camera " +
+                "scrolls off the town onto the overworld (terrain map: grass, trees, mountains, water). " +
+                "Building doorways on LEFT/RIGHT lead INTO other shops and trap you in a dialog — " +
+                "avoid them unless SOUTH is genuinely blocked. Trees in the town overlay block " +
+                "movement; trees on the overworld do NOT — they're walkable encounter terrain. " +
                 "Output ONLY JSON: {\"direction\":\"N|S|E|W|EXIT|STUCK\",\"reason\":\"<<=80 chars\"}."
     }
 }

--- a/knes-agent/src/main/kotlin/knes/agent/perception/VisionInteriorNavigator.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/perception/VisionInteriorNavigator.kt
@@ -265,6 +265,13 @@ class AnthropicVisionInteriorNavigator(
                 "Building doorways on LEFT/RIGHT lead INTO other shops and trap you in a dialog — " +
                 "avoid them unless SOUTH is genuinely blocked. Trees in the town overlay block " +
                 "movement; trees on the overworld do NOT — they're walkable encounter terrain. " +
+                "USE RECENT MOVES (when listed in the user message): each entry shows the dir you " +
+                "picked plus smPre→smPost and moved=true|false. If the SAME direction repeats with " +
+                "moved=false 2+ times in a row, the party is blocked there — pick a PERPENDICULAR " +
+                "cardinal next (LEFT/RIGHT blocked → try DOWN or UP; DOWN blocked → try LEFT or RIGHT). " +
+                "If recent moves show party drifting WEST or NORTH without progress to overworld, " +
+                "force SOUTH or EAST. Treat RECENT MOVES as STRONGER evidence than what the still " +
+                "image suggests — the image cannot show that the last 5 cardinals were no-ops. " +
                 "Output ONLY JSON: {\"direction\":\"N|S|E|W|EXIT|STUCK\",\"reason\":\"<<=80 chars\"}."
     }
 }

--- a/knes-agent/src/main/kotlin/knes/agent/runtime/AgentScratchpad.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/runtime/AgentScratchpad.kt
@@ -1,0 +1,210 @@
+package knes.agent.runtime
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.io.File
+
+/**
+ * 2026-05-09 cont 3 — coding-agent-style action notebook persisted alongside the
+ * savestate. The agent's "where I came from" memory.
+ *
+ * Why: when a savestate is loaded, the engine state is restored but the agent's
+ * narrative history is lost. Without that history, post-buy exit becomes a
+ * blind-search problem (cont-3 #1-#6 burned ~$5 validating this). With it, the
+ * agent can reverse-walk its own in-trajectory deterministically.
+ *
+ * Lifecycle:
+ *   1. Skills (boot walk-in, BuyAtShop, EquipWeapon, ExitInterior) call
+ *      [record] for each meaningful action, capturing optional `moveDir`,
+ *      `smPlayerPre/Post`, and a one-line `summary`.
+ *   2. When the agent dumps a savestate to e.g. `/tmp/spec5-post-buy.savestate`,
+ *      it ALSO calls [save] to write the sister `*.actions.json`.
+ *   3. On a subsequent `KNES_FF1_LOAD_SAVESTATE` startup, [load] reads the
+ *      sister file. The restored scratchpad is injected into AgentSession and
+ *      becomes prompt context (via [renderForLLM]) and the source of truth for
+ *      reverse-walk via [reverseTrajectoryFromTownEntry].
+ *
+ * Storage format: simple JSON array of entries, ordered by record-time. ~few KB
+ * for a typical buy session. Human-readable for debugging.
+ */
+@Serializable
+data class ScratchpadEntry(
+    /** Monotonic record index (0,1,2,...) — not the agent's turn counter. */
+    val seq: Int,
+    /** Wall-clock millis since session start, for rough timing context. */
+    val tMs: Long,
+    /** Coarse category: "boot", "walk", "tap", "buy", "equip", "exit", "summary", "phase". */
+    val kind: String,
+    /** One-line LLM-readable description. */
+    val summary: String,
+    /** For "tap" kind: cardinal name (UP/DOWN/LEFT/RIGHT) or button (A/B/Start). */
+    val dir: String? = null,
+    /** smPlayer (X,Y) before this action. */
+    val smPre: List<Int>? = null,
+    /** smPlayer (X,Y) after this action. null if not applicable. */
+    val smPost: List<Int>? = null,
+    /** Did smPlayer actually change? (false = stuck/blocked/dialog). */
+    val moved: Boolean? = null,
+    /** mapflags after action (for transition detection). */
+    val mapflagsPost: Int? = null,
+    /** Free-form context: e.g. "char3 BOUGHT (Wooden Nunchuck, 10G)". */
+    val note: String? = null,
+)
+
+class AgentScratchpad private constructor(
+    private val sessionStartMs: Long,
+) {
+    private val entries = mutableListOf<ScratchpadEntry>()
+    private var seqCounter = 0
+
+    fun record(
+        kind: String,
+        summary: String,
+        dir: String? = null,
+        smPre: Pair<Int, Int>? = null,
+        smPost: Pair<Int, Int>? = null,
+        mapflagsPost: Int? = null,
+        note: String? = null,
+    ) {
+        val moved = if (smPre != null && smPost != null) smPre != smPost else null
+        entries.add(ScratchpadEntry(
+            seq = seqCounter++,
+            tMs = System.currentTimeMillis() - sessionStartMs,
+            kind = kind,
+            summary = summary,
+            dir = dir,
+            smPre = smPre?.let { listOf(it.first, it.second) },
+            smPost = smPost?.let { listOf(it.first, it.second) },
+            moved = moved,
+            mapflagsPost = mapflagsPost,
+            note = note,
+        ))
+    }
+
+    fun all(): List<ScratchpadEntry> = entries.toList()
+
+    /**
+     * LLM-prompt-friendly text dump. Compact, chronological, stable format.
+     * Designed to drop into a system prompt or user message verbatim.
+     */
+    fun renderForLLM(headerNote: String = ""): String = buildString {
+        appendLine("=== AGENT SCRATCHPAD (${entries.size} entries) ===")
+        if (headerNote.isNotBlank()) appendLine(headerNote)
+        for (e in entries) {
+            val moveTag = if (e.dir != null) {
+                val moveResult = when (e.moved) {
+                    true -> "→${e.smPost?.joinToString(",")}"
+                    false -> "[blocked]"
+                    null -> ""
+                }
+                " ${e.dir}${if (e.smPre != null) "@(${e.smPre.joinToString(",")})" else ""}$moveResult"
+            } else ""
+            val mfTag = e.mapflagsPost?.let { " mapflags=$it" } ?: ""
+            val noteTag = e.note?.let { " — $it" } ?: ""
+            appendLine("  [${e.seq}] +${e.tMs / 1000}s ${e.kind}:${moveTag}$mfTag ${e.summary}$noteTag")
+        }
+        appendLine("=== END SCRATCHPAD ===")
+    }
+
+    /**
+     * Returns the cardinal-direction sequence the agent used during the
+     * "town walk-in" — i.e. all "tap" entries with `kind="tap"` and
+     * dir in {UP,DOWN,LEFT,RIGHT} that successfully moved smPlayer (moved=true)
+     * BETWEEN the most recent `kind="phase"` entry whose summary contains
+     * "town_entry" and the most recent `kind="phase"` entry whose summary
+     * contains "shop_reached".
+     *
+     * Reversed (UP↔DOWN, LEFT↔RIGHT) gives a known-good exit path.
+     */
+    /**
+     * Returns the smPlayer (X,Y) tile where the FIRST cardinal-tap of the
+     * most recent walk-in started — i.e. the town/overworld warp tile where
+     * the engine placed the party when it transitioned IN. This is the
+     * exact tile to return to in order to exit (reverse the warp).
+     *
+     * Returns null if no walk-in trajectory is recorded.
+     */
+    fun walkInEntryTile(): Pair<Int, Int>? {
+        // Iterate from the LATEST walk-in pair backwards, skipping pairs that
+        // contain no actual taps (savestate-loaded skips that just emit two
+        // phase markers without a real walk).
+        val phaseIndices = entries.withIndex().filter { it.value.kind == "phase" }
+        val pairs = mutableListOf<Pair<Int, Int>>()  // (entryIdx, shopIdx)
+        var pendingEntry: Int? = null
+        for ((idx, e) in phaseIndices) {
+            if (e.summary.contains("town_entry", ignoreCase = true)) pendingEntry = idx
+            else if (e.summary.contains("shop_reached", ignoreCase = true) && pendingEntry != null) {
+                pairs.add(pendingEntry!! to idx)
+                pendingEntry = null
+            }
+        }
+        // Latest pair with actual cardinal taps wins.
+        for ((entryIdx, shopIdx) in pairs.reversed()) {
+            val firstTap = entries.subList(entryIdx, shopIdx)
+                .firstOrNull { it.kind == "tap" && it.smPre != null && it.moved == true }
+            if (firstTap != null) {
+                val sm = firstTap.smPre!!
+                return sm[0] to sm[1]
+            }
+        }
+        return null
+    }
+
+    fun reverseTrajectoryFromTownEntry(): List<String> {
+        val reverseMap = mapOf("UP" to "DOWN", "DOWN" to "UP", "LEFT" to "RIGHT", "RIGHT" to "LEFT")
+        // Find the latest walk-in pair with actual cardinal taps (skip empty
+        // savestate-load skip pairs).
+        val phaseIndices = entries.withIndex().filter { it.value.kind == "phase" }
+        val pairs = mutableListOf<Pair<Int, Int>>()
+        var pendingEntry: Int? = null
+        for ((idx, e) in phaseIndices) {
+            if (e.summary.contains("town_entry", ignoreCase = true)) pendingEntry = idx
+            else if (e.summary.contains("shop_reached", ignoreCase = true) && pendingEntry != null) {
+                pairs.add(pendingEntry!! to idx); pendingEntry = null
+            }
+        }
+        for ((entryIdx, shopIdx) in pairs.reversed()) {
+            val taps = entries.subList(entryIdx, shopIdx)
+                .filter { it.kind == "tap" && it.moved == true && it.dir in reverseMap.keys }
+            if (taps.isNotEmpty()) {
+                return taps.mapNotNull { reverseMap[it.dir] }.reversed()
+            }
+        }
+        return emptyList()
+    }
+
+    fun save(path: File) {
+        path.writeText(json.encodeToString(entries))
+    }
+
+    companion object {
+        private val json = Json { prettyPrint = true; ignoreUnknownKeys = true }
+
+        fun newSession(): AgentScratchpad =
+            AgentScratchpad(sessionStartMs = System.currentTimeMillis())
+
+        /**
+         * Loads a scratchpad from disk if present. The loaded scratchpad's
+         * `tMs` field is preserved (rebased relative to original session) but
+         * subsequent [record] calls will use the new session's clock — entries
+         * are append-only so the discontinuity is visible but not problematic.
+         *
+         * Returns null if the file doesn't exist; throws on parse error so
+         * caller knows the file was corrupted rather than missing.
+         */
+        fun loadSister(savestatePath: File): AgentScratchpad? {
+            val sister = sisterPathFor(savestatePath)
+            if (!sister.exists()) return null
+            val loaded = json.decodeFromString<List<ScratchpadEntry>>(sister.readText())
+            val pad = AgentScratchpad(sessionStartMs = System.currentTimeMillis())
+            pad.entries.addAll(loaded)
+            pad.seqCounter = (loaded.maxOfOrNull { it.seq } ?: -1) + 1
+            return pad
+        }
+
+        /** Convention: `<savestate>.actions.json` next to the savestate. */
+        fun sisterPathFor(savestatePath: File): File =
+            File(savestatePath.parentFile, savestatePath.nameWithoutExtension + ".actions.json")
+    }
+}

--- a/knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt
@@ -8,6 +8,7 @@ import knes.agent.skills.BuyAtShop
 import knes.agent.skills.EquipWeapon
 import knes.agent.skills.ExitInterior
 import knes.agent.skills.GrindLoop
+import knes.agent.skills.SkillResult
 import knes.agent.skills.WalkOverworldTo
 import knes.agent.perception.FfPhase
 import knes.agent.perception.FogOfWar
@@ -1462,38 +1463,101 @@ class AgentSession(
             roundIdx++
         }
 
-        // 5. Exit shop interior; equip on overworld.
-        // Pre-flight: dismiss any lingering dialog (BuyAtShop's 6 B-taps post-buy
-        // sometimes leave a "Welcome!" header above MAIN_MENU; mapflags.bit1=1
-        // observed in 2026-05-09 cont 3 runs). Eight B-taps at relaxed cadence
-        // pop dialog stack reliably. Cheap: ~96 frames.
+        // 5. Exit shop + town to overworld via vision-LLM (Phase 3).
+        // Per spec 2026-05-09-coneria-pipeline: vision is the sole hot-path
+        // exit. ExitTownEmpirical / tree-detour stay reachable only when the
+        // navigator is unwired (offline tests).
         repeat(8) {
             toolset.tap(button = "B", count = 1, pressFrames = 4, gapFrames = 8)
             toolset.step(buttons = emptyList(), frames = 4)
         }
 
-        // 2026-05-09 cont 3: empirical explorer with mf3-recovery (long idle
-        // waits for mid-transition state). cont-3 #8 evidence: party walks
-        // visually onto overworld grass at south edge but mapflags bit 1
-        // takes 200+ frames to clear. ExitTownEmpirical now uses 300-frame
-        // idle waits + multiple short DOWN taps to commit the transition.
-        // Vision-LLM exit (WalkInteriorVision with scratchpad historyHint)
-        // is wired but de-prioritized — its model ID needs refresh and the
-        // deterministic path is faster to validate.
-        val empResult = knes.agent.skills.ExitTownEmpirical(toolset, scratchpad)
-            .invoke(mapOf("maxTaps" to "120"))
-        val exitResult = if (empResult.ok) empResult
+        val exitResult = if (outfitNavigator != null) {
+            knes.agent.skills.WalkInteriorVision(
+                toolset, outfitNavigator, toolCallLog,
+                historyHint = scratchpad.renderForLLM(),
+            ).invoke(mapOf("maxSteps" to "60"))
+        } else {
+            // Offline fallback: empirical+tree-detour, then BFS.
+            val emp = knes.agent.skills.ExitTownEmpirical(toolset, scratchpad)
+                .invoke(mapOf("maxTaps" to "120"))
+            if (emp.ok) emp
             else ExitInterior(toolset, outfitMapSession, fog).invoke(emptyMap())
+        }
         val exitRam = exitResult.ramAfter
         trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
-            note = "boot_exit_interior_result: ok=${exitResult.ok} msg=${exitResult.message} " +
+            note = "boot_phase3_exit_result: ok=${exitResult.ok} msg=${exitResult.message} " +
                 "world=(${exitRam["worldX"] ?: "?"},${exitRam["worldY"] ?: "?"}) " +
-                "mapId=${exitRam["currentMapId"] ?: "?"} mapflags=${exitRam["mapflags"] ?: "?"}"))
+                "mapflags=${exitRam["mapflags"] ?: "?"} " +
+                "via=${if (outfitNavigator != null) "vision" else "fallback"}"))
         scratchpad.record(kind = "exit",
-            summary = "exit_interior_result: ok=${exitResult.ok}",
+            summary = "phase3_exit_result: ok=${exitResult.ok}",
             smPost = (exitRam["smPlayerX"] ?: 0) to (exitRam["smPlayerY"] ?: 0),
             mapflagsPost = exitRam["mapflags"] ?: 0,
             note = exitResult.message.take(120))
+
+        // Phase 4: grind anchor selection + GrindLoop with re-anchor.
+        // Only run when exit succeeded AND viewport source is an OverworldMap.
+        val owMap = outfitViewportSource as? knes.agent.perception.OverworldMap
+        if (exitResult.ok && owMap != null) {
+            // 120-frame settle so any mapflags.bit1 mid-scroll transient clears.
+            toolset.step(buttons = emptyList(), frames = 120)
+            val ramSettled = toolset.getState().ram
+            val partyXY = (ramSettled["worldX"] ?: 0) to (ramSettled["worldY"] ?: 0)
+            val triedAnchors = mutableSetOf<Pair<Int, Int>>()
+            val firstPick = GrindAnchorSelector.pickGrindAnchor(partyXY, owMap)
+            trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
+                note = "boot_phase4_grind_anchor: anchor=(${firstPick.anchor.first}," +
+                    "${firstPick.anchor.second}) tileClass=${firstPick.tileClass} " +
+                    "fellBack=${firstPick.fellBack} party=(${partyXY.first},${partyXY.second})"))
+            var grindAttempt = 0
+            val maxAttempts = 3  // 1 initial + 2 re-anchors
+            var lastResult: knes.agent.skills.SkillResult? = null
+            var currentPick = firstPick
+            while (grindAttempt < maxAttempts) {
+                triedAnchors += currentPick.anchor
+                val (ax, ay) = currentPick.anchor
+                lastResult = knes.agent.skills.GrindLoop(toolset).invoke(mapOf(
+                    "anchorX" to ax.toString(),
+                    "anchorY" to ay.toString(),
+                    "corridorRadius" to "3",
+                    "maxStepsWithoutEncounter" to "12",
+                ))
+                trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
+                    note = "boot_phase4_grind_result: attempt=${grindAttempt + 1}/$maxAttempts " +
+                        "anchor=($ax,$ay) outcome=${lastResult.message}"))
+                val msg = lastResult.message
+                val battle = msg.startsWith("EncounteredBattle")
+                if (battle) break
+                val noEnc = msg.startsWith("NoEncounter")
+                if (!noEnc) break  // WanderedOff / Blocked → don't re-anchor
+                grindAttempt++
+                if (grindAttempt >= maxAttempts) break
+                // Re-anchor: read current world coord and pick the next-best
+                // tile that we haven't tried yet. Loosen by widening radius.
+                val reRam = toolset.getState().ram
+                val reParty = (reRam["worldX"] ?: ax) to (reRam["worldY"] ?: ay)
+                val widerPicks = (1..3).asSequence().mapNotNull { r ->
+                    val p = GrindAnchorSelector.pickGrindAnchor(reParty, owMap, radius = r + 1)
+                    if (p.anchor in triedAnchors || p.fellBack) null else p
+                }
+                currentPick = widerPicks.firstOrNull() ?: break
+                trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
+                    note = "boot_phase4_grind_reanchor: attempt=${grindAttempt + 1} " +
+                        "newAnchor=(${currentPick.anchor.first},${currentPick.anchor.second}) " +
+                        "tileClass=${currentPick.tileClass}"))
+            }
+            val pipelineVictory = lastResult?.message?.startsWith("EncounteredBattle") == true
+            trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
+                note = "boot_pipeline_end: victory=$pipelineVictory " +
+                    "lastPhase=${if (pipelineVictory) "phase4_battle_pending" else "phase4_grind"}"))
+        } else if (!exitResult.ok) {
+            trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
+                note = "boot_pipeline_end: victory=false lastPhase=phase3_exit_failed"))
+        } else {
+            trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
+                note = "boot_pipeline_end: victory=false lastPhase=phase4_skipped_no_overworld_map"))
+        }
 
         // Per 2026-05-09 cont 2 handoff: skip equip by default. Chars can grind
         // bare-handed (lower DPS but works); equip is a separate follow-up since

--- a/knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt
@@ -85,6 +85,15 @@ class AgentSession(
      * without modifying the production goal of reaching Garland.
      */
     private val onTurnEnd: ((FfPhase, Map<String, Int>) -> Outcome?)? = null,
+    /**
+     * 2026-05-09 cont 3: persistent action notebook. Records significant agent
+     * actions (boot walk-in, BuyAtShop iters, exit attempts) and serializes
+     * alongside savestate dumps as `*.actions.json`. On savestate-load with a
+     * sister file present, the loaded scratchpad is the agent's "memory of how
+     * it got here" — usable for reverse-replay or LLM prompt context.
+     * Defaults to a fresh per-session scratchpad when no prior history exists.
+     */
+    private val scratchpad: AgentScratchpad = AgentScratchpad.newSession(),
 ) {
     private val resolvedRunDir = runDir
     private val trace = Trace(resolvedRunDir)
@@ -255,7 +264,12 @@ class AgentSession(
         // (FIGHT-normal random encounter). Require N consecutive observations
         // and require phase is NOT Battle/PostBattle (those resolve themselves).
         var consecutiveTrapObs = 0
-        val TRAP_CONFIRM_THRESHOLD = 3
+        // 2026-05-09 cont 3: bumped 3→10. Coneria south exit lands at world
+        // (147,155) on a peninsula gate tile; the adjacent overworld tile
+        // walks back into town (mapflags=1), looking like UnknownMapTrap.
+        // GrindLoop has adaptive anchor-shift (3 NoEncounter → shift +2 E -4 N
+        // toward bridge) but needs more breathing room than 3 obs to fire.
+        val TRAP_CONFIRM_THRESHOLD = 10
 
         try {
             while (true) {
@@ -378,13 +392,24 @@ class AgentSession(
                             // for 50+ grind cycles without ever triggering a battle.
                             // Larger corridor reaches into the encounter-bearing
                             // grass to the north of the safe zone.
+                            // 2026-05-09 cont 3: corridor 6→2. With anchor
+                            // captured at (145,155) post-Coneria-exit, radius=6
+                            // walks party UP to y=149 — passes through Coneria
+                            // CASTLE entry at (145,152) = warps into mapId=8.
+                            // Radius=2 keeps corridor at y=153-157 (safe grass
+                            // between Coneria town south and castle north).
+                            // maxSteps 12→24 to give encounter rate more rolls
+                            // (FF1 is ~10% per step, 24 steps ≈ 92% chance).
                             val res = GrindLoop(toolset).invoke(mapOf(
                                 "anchorX" to ax.toString(),
                                 "anchorY" to ay.toString(),
-                                "corridorRadius" to "6",
-                                "maxStepsWithoutEncounter" to "12",
+                                "corridorRadius" to "2",
+                                "maxStepsWithoutEncounter" to "24",
                             ))
                             println("[strategy:grind] ok=${res.ok} ${res.message.take(120)}")
+                            trace.record(TraceEvent(turn = 0, role = "system", phase = phase.toString(),
+                                note = "strategy_grind_result: ok=${res.ok} anchor=($ax,$ay) " +
+                                    "msg=${res.message.take(160)}"))
                             // V5.36.2: adaptive anchor. Validation run 3 evidence:
                             // spawn area (146,158) + corridor radius 6 still landed
                             // entirely in the Coneria peninsula no-encounter pocket.
@@ -407,6 +432,9 @@ class AgentSession(
                                     grindNoProgress = 0
                                     println("[strategy:grind] adaptive shift #${grindAnchorShifts}: " +
                                         "anchor ($oax,$oay) -> ($nax,$nay)")
+                                    trace.record(TraceEvent(turn = 0, role = "system", phase = phase.toString(),
+                                        note = "strategy_grind_anchor_shift: #$grindAnchorShifts " +
+                                            "($oax,$oay) -> ($nax,$nay)"))
                                 }
                             } else {
                                 grindNoProgress = 0
@@ -649,6 +677,19 @@ class AgentSession(
         )
         val pre = phase.run()
         if (pre.skipped || pre.reason == "no_town_entry") return
+
+        // Scratchpad: mark boot phase start. The kind/summary tags here are
+        // significant — `reverseTrajectoryFromTownEntry()` keys off "town_entry"
+        // to slice the cardinal-tap log when computing exit reverse.
+        run {
+            val ram = toolset.getState().ram
+            scratchpad.record(kind = "phase",
+                summary = "boot_phase_start: town_entry pending",
+                smPre = (ram["smPlayerX"] ?: 0) to (ram["smPlayerY"] ?: 0),
+                mapflagsPost = ram["mapflags"] ?: 0,
+                note = "savestateLoaded=${!System.getenv("KNES_FF1_LOAD_SAVESTATE").isNullOrBlank()} " +
+                    "world=(${ram["worldX"]},${ram["worldY"]}) mapId=${ram["currentMapId"]}")
+        }
 
         // Full orchestration requires vision + mapSession + viewportSource (all optional
         // constructor params — fall through if any missing so existing tests keep working).
@@ -1061,6 +1102,19 @@ class AgentSession(
                 }
                 actionLog.addLast(ActionLogEntry(iter, advice.action, beforeXY, afterX to afterY))
                 while (actionLog.size > actionLogMaxSize) actionLog.removeFirst()
+                // 2026-05-09 cont 3: record cardinal taps in scratchpad so the
+                // walk-in trajectory persists alongside the savestate. The
+                // ExitTownEmpirical skill (and any future reverse-replay) can
+                // mine this for known-walkable transitions.
+                if (advice.action in setOf("Up", "Down", "Left", "Right")) {
+                    scratchpad.record(kind = "tap",
+                        summary = "boot_walk_in: ${advice.action}",
+                        dir = advice.action.uppercase(),
+                        smPre = beforeXY,
+                        smPost = afterX to afterY,
+                        mapflagsPost = afterRamRead["mapflags"] ?: 0,
+                        note = if (regime == "TOWN_OVERLAY") "town_overlay" else regime)
+                }
                 // Minimap update: tag this direction as blocked-from-this-tile
                 // when the action was a cardinal that produced no movement and
                 // we stayed in the same map regime (so the block is geometric,
@@ -1324,6 +1378,39 @@ class AgentSession(
         }
         trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
             note = "boot_purchase_advisor_done: bought=$charsBought of needs=$charsNeeding"))
+        run {
+            val ram = toolset.getState().ram
+            scratchpad.record(kind = "phase",
+                summary = "shop_reached: buy_advisor_done bought=$charsBought",
+                smPre = (ram["smPlayerX"] ?: 0) to (ram["smPlayerY"] ?: 0),
+                mapflagsPost = ram["mapflags"] ?: 0)
+        }
+
+        // 2026-05-09 cont 3: dump savestate post-buy so subsequent dev runs can
+        // skip the ~5-min buy advisor and iterate on exit+grind directly. Mirror
+        // of the spec5-shop-entered.savestate pattern above. Wrapped in try/catch
+        // — failure to dump is dev-tool noise, not a session-blocking error.
+        try {
+            val bytes = toolset.session.saveState()
+            val ssFile = java.io.File("/tmp/spec5-post-buy.savestate")
+            ssFile.writeBytes(bytes)
+            // Coding-agent-style scratchpad sister file. Captures the action log
+            // up to this savestate so subsequent runs can reason about "where
+            // we came from" without burning an LLM call to figure it out.
+            val padFile = AgentScratchpad.sisterPathFor(ssFile)
+            scratchpad.record(kind = "summary",
+                summary = "post_buy_savestate_dumped",
+                note = "bought=$charsBought spent=${initialGold - StrategyContext.totalGold(toolset.getState().ram)}G")
+            scratchpad.save(padFile)
+            trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
+                note = "boot_post_buy_savestate_dumped: bytes=${bytes.size} " +
+                       "path=${ssFile.absolutePath} sister=${padFile.absolutePath} " +
+                       "scratchpad_entries=${scratchpad.all().size} " +
+                       "(set KNES_FF1_LOAD_SAVESTATE to load and skip buy)"))
+        } catch (e: Throwable) {
+            trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
+                note = "boot_post_buy_savestate_dump_failed: ${e.message}"))
+        }
 
         // Legacy stateful-batch retry path — only used if advisor served zero
         // chars (e.g., advisor immediately gave up). Kept as a safety net.
@@ -1376,26 +1463,66 @@ class AgentSession(
         }
 
         // 5. Exit shop interior; equip on overworld.
-        ExitInterior(toolset, outfitMapSession, fog).invoke(emptyMap())
+        // Pre-flight: dismiss any lingering dialog (BuyAtShop's 6 B-taps post-buy
+        // sometimes leave a "Welcome!" header above MAIN_MENU; mapflags.bit1=1
+        // observed in 2026-05-09 cont 3 runs). Eight B-taps at relaxed cadence
+        // pop dialog stack reliably. Cheap: ~96 frames.
+        repeat(8) {
+            toolset.tap(button = "B", count = 1, pressFrames = 4, gapFrames = 8)
+            toolset.step(buttons = emptyList(), frames = 4)
+        }
 
-        val equipSkill = EquipWeapon(toolset)
+        // 2026-05-09 cont 3: empirical explorer with mf3-recovery (long idle
+        // waits for mid-transition state). cont-3 #8 evidence: party walks
+        // visually onto overworld grass at south edge but mapflags bit 1
+        // takes 200+ frames to clear. ExitTownEmpirical now uses 300-frame
+        // idle waits + multiple short DOWN taps to commit the transition.
+        // Vision-LLM exit (WalkInteriorVision with scratchpad historyHint)
+        // is wired but de-prioritized — its model ID needs refresh and the
+        // deterministic path is faster to validate.
+        val empResult = knes.agent.skills.ExitTownEmpirical(toolset, scratchpad)
+            .invoke(mapOf("maxTaps" to "120"))
+        val exitResult = if (empResult.ok) empResult
+            else ExitInterior(toolset, outfitMapSession, fog).invoke(emptyMap())
+        val exitRam = exitResult.ramAfter
+        trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
+            note = "boot_exit_interior_result: ok=${exitResult.ok} msg=${exitResult.message} " +
+                "world=(${exitRam["worldX"] ?: "?"},${exitRam["worldY"] ?: "?"}) " +
+                "mapId=${exitRam["currentMapId"] ?: "?"} mapflags=${exitRam["mapflags"] ?: "?"}"))
+        scratchpad.record(kind = "exit",
+            summary = "exit_interior_result: ok=${exitResult.ok}",
+            smPost = (exitRam["smPlayerX"] ?: 0) to (exitRam["smPlayerY"] ?: 0),
+            mapflagsPost = exitRam["mapflags"] ?: 0,
+            note = exitResult.message.take(120))
+
+        // Per 2026-05-09 cont 2 handoff: skip equip by default. Chars can grind
+        // bare-handed (lower DPS but works); equip is a separate follow-up since
+        // EquipWeapon is a brittle deterministic state-machine that returned
+        // MenuStuck × 4 in Run B2-v3, costing ~240 A-taps before the strategic
+        // loop reached GRIND. Set KNES_FF1_BOOT_EQUIP=1 to re-enable.
         val charsEquipped = mutableListOf<Int>()
-        for (charSlot in 1..4) {
-            val ram = toolset.getState().ram
-            val ownedSlot = (0..3).firstOrNull {
-                StrategyContext.weaponId(StrategyContext.weaponSlot(ram, charSlot, it)) != 0
-            } ?: continue
-            if (StrategyContext.isEquipped(StrategyContext.weaponSlot(ram, charSlot, ownedSlot))) {
-                charsEquipped += charSlot
-                continue
+        if (System.getenv("KNES_FF1_BOOT_EQUIP") == "1") {
+            val equipSkill = EquipWeapon(toolset)
+            for (charSlot in 1..4) {
+                val ram = toolset.getState().ram
+                val ownedSlot = (0..3).firstOrNull {
+                    StrategyContext.weaponId(StrategyContext.weaponSlot(ram, charSlot, it)) != 0
+                } ?: continue
+                if (StrategyContext.isEquipped(StrategyContext.weaponSlot(ram, charSlot, ownedSlot))) {
+                    charsEquipped += charSlot
+                    continue
+                }
+                val r = equipSkill.invoke(mapOf(
+                    "charSlot" to charSlot.toString(),
+                    "weaponSlot" to ownedSlot.toString(),
+                ))
+                trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
+                    note = "boot_equip: char$charSlot slot=$ownedSlot result=${r.message}"))
+                if (r.ok) charsEquipped += charSlot
             }
-            val r = equipSkill.invoke(mapOf(
-                "charSlot" to charSlot.toString(),
-                "weaponSlot" to ownedSlot.toString(),
-            ))
+        } else {
             trace.record(TraceEvent(turn = 0, role = "system", phase = "BOOT",
-                note = "boot_equip: char$charSlot slot=$ownedSlot result=${r.message}"))
-            if (r.ok) charsEquipped += charSlot
+                note = "boot_outfit_equip_skipped: KNES_FF1_BOOT_EQUIP not set; bare-handed grind enabled"))
         }
 
         // 6. Summary.

--- a/knes-agent/src/main/kotlin/knes/agent/runtime/GrindAnchorSelector.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/runtime/GrindAnchorSelector.kt
@@ -1,0 +1,61 @@
+package knes.agent.runtime
+
+import knes.agent.perception.OverworldMap
+import knes.agent.perception.TileType
+import kotlin.math.abs
+
+/**
+ * Picks a grind anchor near the party using overworld tile classifications.
+ * Encounter zones are GRASS or FOREST (FF1 mechanic, user-confirmed).
+ * If the party already stands on an encounter tile, the anchor IS the party
+ * tile. Otherwise the closest encounter tile within `radius` is picked,
+ * breaking ties by preferring south (dy>0) then east (dx>0).
+ */
+object GrindAnchorSelector {
+    data class Pick(
+        val anchor: Pair<Int, Int>,
+        val tileClass: TileType,
+        val fellBack: Boolean,
+    )
+
+    fun pickGrindAnchor(
+        party: Pair<Int, Int>,
+        map: OverworldMap,
+        radius: Int = 2,
+    ): Pick {
+        val (px, py) = party
+        val partyClass = map.classifyAt(px, py)
+        if (partyClass == TileType.GRASS || partyClass == TileType.FOREST) {
+            return Pick(party, partyClass, fellBack = false)
+        }
+        var best: Pick? = null
+        var bestDist = Int.MAX_VALUE
+        var bestSouthBias = Int.MIN_VALUE
+        var bestEastBias = Int.MIN_VALUE
+        for (dy in -radius..radius) {
+            for (dx in -radius..radius) {
+                if (dx == 0 && dy == 0) continue
+                val tx = px + dx
+                val ty = py + dy
+                val klass = map.classifyAt(tx, ty)
+                if (klass != TileType.GRASS && klass != TileType.FOREST) continue
+                val dist = abs(dx) + abs(dy)
+                val southBias = if (dy > 0) dy else 0
+                val eastBias = if (dx > 0) dx else 0
+                val better = when {
+                    dist < bestDist -> true
+                    dist == bestDist && southBias > bestSouthBias -> true
+                    dist == bestDist && southBias == bestSouthBias && eastBias > bestEastBias -> true
+                    else -> false
+                }
+                if (better) {
+                    best = Pick(tx to ty, klass, fellBack = false)
+                    bestDist = dist
+                    bestSouthBias = southBias
+                    bestEastBias = eastBias
+                }
+            }
+        }
+        return best ?: Pick(party, partyClass, fellBack = true)
+    }
+}

--- a/knes-agent/src/main/kotlin/knes/agent/skills/ExitInterior.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/skills/ExitInterior.kt
@@ -66,6 +66,33 @@ class ExitInterior(
             if (mapId < 0) {
                 return SkillResult(false, "currentMapId unknown — RAM byte not configured", totalFrames, ram)
             }
+            // 2026-05-09: town-overlay fallback. Coneria town renders as
+            // mapId=0 + mapflags.bit0=1 — the overworld submap is loaded but
+            // the engine draws the town overlay on top. The standard BFS
+            // operates on mapId=0's tile data (overworld), which doesn't
+            // represent the town's actual walls / NPCs / south exit, so it
+            // emits bogus "exits" and the party walks in circles
+            // (validated: 64 iters @ Coneria, world=(147,155), never crossed
+            // mapflags=0). Bypass BFS for this case: blind-press Down with
+            // settle frames, rotate cardinals when no world-coord progress.
+            // Per memory `reference_ff1_npcs_move`, NPCs wander each frame so
+            // a tile blocked one tap may be free the next.
+            if (mapId == 0) {
+                val (cardinalFrames, exited) = walkOutOfTownOverlay(maxTaps = maxSteps - stepsTaken)
+                totalFrames += cardinalFrames
+                val ramAfter = toolset.getState().ram
+                return if (exited) {
+                    SkillResult(true,
+                        "town-overlay exit: reached overworld at (worldX=${ramAfter["worldX"] ?: 0}, " +
+                            "worldY=${ramAfter["worldY"] ?: 0})",
+                        totalFrames, ramAfter)
+                } else {
+                    SkillResult(false,
+                        "town-overlay exit: did not clear mapflags after ${maxSteps - stepsTaken} cardinal taps " +
+                            "(world=(${ramAfter["worldX"] ?: 0},${ramAfter["worldY"] ?: 0}))",
+                        totalFrames, ramAfter)
+                }
+            }
             mapSession.ensureCurrent(mapId)
             // V5.6: party tile = ($0068, $0069) = sm_player_x/y per Disch disassembly.
             // Replaces V2.6.4's static (+8, +7) offset hack on $0029/$002A scroll, which
@@ -141,5 +168,132 @@ class ExitInterior(
         } finally {
             interiorMemory?.save()
         }
+    }
+
+    /**
+     * Town-overlay blind walker: prefer DOWN (towns are entered from the south,
+     * so the south edge is the universal exit). On stuck (no world-coord change
+     * for stuckThreshold consecutive taps), rotate to next cardinal.
+     *
+     * Returns (totalFrames, exited). exited=true iff mapflags bit 0 cleared.
+     */
+    private suspend fun walkOutOfTownOverlay(maxTaps: Int): Pair<Int, Boolean> {
+        // 2026-05-09 cont 3 user-confirmed: "to exit the city you need to go down
+        // from shop". DOWN is the universal Coneria-town exit direction. Earlier
+        // runs (cont 3 #1-#3) tried rotating to LEFT/RIGHT after 3-6 stuck DOWN
+        // taps; both LEFT (10,14) and RIGHT (12,14) at the deadlock point are
+        // building doorways that open dialogs (mapflags.bit1=1) — exactly what
+        // we don't want. Stay on DOWN. When stuck (NPC blocking per
+        // `reference_ff1_npcs_move`), step idle frames to let the NPC wander
+        // off, then retry DOWN. UP only as final fallback after exhausting
+        // DOWN+wait cycles.
+        val cardinals = listOf("DOWN", "UP")  // No LEFT/RIGHT — those are doorways in Coneria.
+        var dirIdx = 0
+        var stuckCount = 0
+        val stuckThreshold = 3       // 3 stuck DOWN taps before idle-wait
+        val maxIdleWaitsAt = 5       // up to 5 wait-and-retry cycles per stuck position
+        var idleWaitsAt = 0
+        val idleFrames = 30          // ~half a second wall clock for NPC drift
+        var totalFrames = 0
+        var taps = 0
+
+        fun dump(tag: String) {
+            try {
+                val ram = toolset.getState().ram
+                val shot = toolset.getScreen().base64
+                val bytes = java.util.Base64.getDecoder().decode(shot)
+                java.io.File("/tmp/spec5-town-exit-$tag.png").writeBytes(bytes)
+                // Full watched-byte dump for dialog-signal hunt. The mid screenshot
+                // (cont-3 #5) showed shop "Welcome" dialog open while mapflags=1,
+                // so neither mapflags nor screenState toggled — need to find which
+                // byte does. Dump ALL watched values; diff entry vs stuck offline.
+                val allRam = ram.toSortedMap().entries.joinToString(" ") { "${it.key}=${it.value}" }
+                println("[exit-town] $tag: $allRam")
+            } catch (_: Throwable) { /* dev noise */ }
+        }
+
+        // Pre-flight: B-spam 8 taps to dismiss any lingering dialog (BuyAtShop's
+        // 6 B-taps may not be enough if there's a "Welcome!" header above
+        // BUY/SELL/EXIT). Then dump entry screenshot.
+        // Run-3 evidence: post-buy mapflags=1, but after cardinal taps mapflags=3.
+        // mapflags bit 1 likely = "dialog/menu active" — pressing DOWN walked
+        // into the shopkeeper sprite and re-opened the dialog.
+        repeat(8) {
+            val t = toolset.tap(button = "B", count = 1, pressFrames = 4, gapFrames = 8)
+            val s = toolset.step(buttons = emptyList(), frames = 4)
+            totalFrames += t.frame + s.frame
+        }
+        dump("entry")
+
+        while (taps < maxTaps) {
+            val ramPre = toolset.getState().ram
+            val mapflagsPre = ramPre["mapflags"] ?: 0
+            if ((mapflagsPre and 0x01) == 0) return totalFrames to true
+            // If a dialog/menu is active (bit 1), B-tap to dismiss before moving.
+            if ((mapflagsPre and 0x02) != 0) {
+                val t = toolset.tap(button = "B", count = 1, pressFrames = 4, gapFrames = 8)
+                val s = toolset.step(buttons = emptyList(), frames = 4)
+                totalFrames += t.frame + s.frame
+                taps++
+                continue
+            }
+
+            // V5.6 + 2026-05-09: in town overlay, smPlayerX/Y is the LOCAL coord
+            // that actually moves; worldX/worldY tracks the overworld entry tile
+            // and stays constant. Run-3's cardinal-taps used worldX/Y for stuck
+            // detection — flagged stuck every tap, rotating direction unhelpfully.
+            val smxPre = ramPre["smPlayerX"] ?: 0
+            val smyPre = ramPre["smPlayerY"] ?: 0
+
+            val tap = toolset.tap(button = cardinals[dirIdx], count = 1,
+                pressFrames = PRESS_FRAMES, gapFrames = GAP_FRAMES)
+            val settle = toolset.step(buttons = emptyList(), frames = SETTLE_FRAMES)
+            totalFrames += tap.frame + settle.frame
+            taps++
+
+            if (taps == maxTaps / 2) dump("mid")
+
+            val ramPost = toolset.getState().ram
+            val mapflagsPost = ramPost["mapflags"] ?: 0
+            if ((mapflagsPost and 0x01) == 0) return totalFrames to true
+
+            val smxPost = ramPost["smPlayerX"] ?: 0
+            val smyPost = ramPost["smPlayerY"] ?: 0
+            println("[exit-town] tap#$taps dir=${cardinals[dirIdx]} " +
+                "smPlayer=($smxPre,$smyPre)→($smxPost,$smyPost) " +
+                "mapflags=$mapflagsPre→$mapflagsPost stuck=$stuckCount")
+
+            if (smxPost == smxPre && smyPost == smyPre) {
+                stuckCount++
+                if (stuckCount >= stuckThreshold) {
+                    if (idleWaitsAt == 0) {
+                        // First time hitting stuckThreshold at this position — dump
+                        // full RAM to hunt for the dialog-signal byte. Compare
+                        // against the entry dump offline.
+                        dump("stuck-${cardinals[dirIdx]}-$smxPost-$smyPost")
+                    }
+                    if (idleWaitsAt < maxIdleWaitsAt && cardinals[dirIdx] == "DOWN") {
+                        // Wait for NPC to wander off the south-blocking tile.
+                        val s = toolset.step(buttons = emptyList(), frames = idleFrames)
+                        totalFrames += s.frame
+                        idleWaitsAt++
+                        stuckCount = 0
+                        println("[exit-town] idle-wait $idleWaitsAt/$maxIdleWaitsAt at " +
+                            "smPlayer=($smxPost,$smyPost) — NPC may be blocking south")
+                    } else {
+                        // Exhausted DOWN+wait budget; rotate cardinal (only UP left
+                        // in our restricted list — typically gives up next iter).
+                        dirIdx = (dirIdx + 1) % cardinals.size
+                        stuckCount = 0
+                        idleWaitsAt = 0
+                    }
+                }
+            } else {
+                stuckCount = 0
+                idleWaitsAt = 0  // moved → reset wait budget for next stuck position
+            }
+        }
+        dump("exit")
+        return totalFrames to false
     }
 }

--- a/knes-agent/src/main/kotlin/knes/agent/skills/ExitTownEmpirical.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/skills/ExitTownEmpirical.kt
@@ -1,0 +1,461 @@
+package knes.agent.skills
+
+import knes.agent.runtime.AgentScratchpad
+import knes.agent.tools.EmulatorToolset
+
+/**
+ * 2026-05-09 cont 3 — empirical Coneria-style town-overlay escape.
+ *
+ * The post-buy state has the agent inside the town overlay (mapflags.bit0=1,
+ * mapId=0). The standard ExitInterior BFS doesn't help because mapId=0 decodes
+ * to OVERWORLD tiles, not town tiles. Vision-LLM nav also failed in cont-3
+ * runs #4-#5. Cardinal walking with NPC patience failed in run #6 (RAM diff:
+ * just a wall, no dialog).
+ *
+ * This skill takes a deterministic exploration approach with scratchpad memory:
+ *   1. Build an adjacency map by experimentally tapping each cardinal at every
+ *      position the party visits. Record (smPre, dir) → smPost / blocked.
+ *   2. If a tap clears mapflags.bit0 → success, scratchpad records the path.
+ *   3. If stuck, prefer cardinals leading to NEW positions over revisits;
+ *      treat dialog-opens (any RAM byte change beyond smPlayer/localY) as
+ *      blocked — B-spam to recover, then mark that direction as "doorway".
+ *   4. Cap by maxTaps; on failure, the scratchpad still contains the partial
+ *      adjacency map + the dialog/blocked tile classifications, so the next
+ *      run inherits and continues from there.
+ *
+ * Key win over `ExitInterior.walkOutOfTownOverlay`: when DOWN deadlocks at
+ * (11,14), this skill SYSTEMATICALLY tries every other reachable position to
+ * find the exit, instead of just rotating cardinals randomly. And the
+ * scratchpad means knowledge accumulates across runs — once we find the exit
+ * once, future runs replay it directly.
+ */
+class ExitTownEmpirical(
+    private val toolset: EmulatorToolset,
+    private val scratchpad: AgentScratchpad,
+) : Skill {
+    override val id = "exit_town_empirical"
+    override val description =
+        "Empirically explore an FF1 town overlay, build an adjacency map of " +
+            "walkable tiles, and exit when mapflags.bit0 clears. Memory-backed."
+
+    private val PRESS_FRAMES = 6
+    private val GAP_FRAMES = 14
+    private val SETTLE_FRAMES = 8
+
+    private data class Edge(val from: Pair<Int, Int>, val dir: String, val to: Pair<Int, Int>)
+
+    override suspend fun invoke(args: Map<String, String>): SkillResult {
+        val maxTaps = args["maxTaps"]?.toIntOrNull() ?: 120
+        val defaultCardinals = listOf("DOWN", "RIGHT", "LEFT", "UP")
+
+        // 8 B-taps pre-flight to dismiss any lingering dialog (cont-3 cardinal
+        // walker showed shop "Welcome" can persist if BuyAtShop's 6 B-taps
+        // weren't enough). Cheap insurance.
+        var totalFrames = 0
+        repeat(8) {
+            val t = toolset.tap(button = "B", count = 1, pressFrames = 4, gapFrames = 8)
+            val s = toolset.step(buttons = emptyList(), frames = 4)
+            totalFrames += t.frame + s.frame
+        }
+
+        // 2026-05-09 cont 3: target the WARP TILE (the smPlayer where the
+        // engine placed the party when it walked into town). Pure DOWN-bias
+        // exploration leaves us at (13,22)/(14,22) — visually on overworld
+        // but mapflags stuck at 3 because we're not on the warp tile.
+        // Returning to the warp coord and pressing DOWN once should cross
+        // the transition cleanly.
+        val warpTile = scratchpad.walkInEntryTile()
+        println("[exit-town-empirical] startup: warpTile=$warpTile (target for exit)")
+
+        // Local adjacency: (x,y) → set of cardinals already attempted. Used to
+        // prefer unexplored directions over re-tries of known walls/doorways.
+        val tried = mutableMapOf<Pair<Int, Int>, MutableSet<String>>()
+        val blocked = mutableMapOf<Pair<Int, Int>, MutableSet<String>>()
+        val doorways = mutableMapOf<Pair<Int, Int>, MutableSet<String>>()
+        val edges = mutableListOf<Edge>()
+
+        var taps = 0
+        var transitionWaits = 0
+        val mf3Exhausted = mutableSetOf<Pair<Int, Int>>()  // positions where mf3-recovery already failed
+        while (taps < maxTaps) {
+            val ramPre = toolset.getState().ram
+            val mapflagsPre = ramPre["mapflags"] ?: 0
+            if ((mapflagsPre and 0x01) == 0) {
+                val msg = "exit_town_empirical: reached overworld at " +
+                    "world=(${ramPre["worldX"]},${ramPre["worldY"]}) after $taps taps"
+                scratchpad.record(kind = "exit",
+                    summary = "town_exit_success",
+                    smPost = (ramPre["smPlayerX"] ?: 0) to (ramPre["smPlayerY"] ?: 0),
+                    mapflagsPost = mapflagsPre,
+                    note = "$taps taps; ${edges.size} edges in adjacency")
+                return SkillResult(true, msg, totalFrames, ramPre)
+            }
+            // 2026-05-09 cont 3: bit 1 either = mid-scroll transition (FF1
+            // profile says "column-drawing") OR a dialog open (cont-3 #2 RIGHT
+            // (11,14)→(12,14) showed mapflags=3 with weapon-shop dialog up).
+            // Three-stage recovery:
+            //   waits 1-3: idle frames (bit 1 may clear if transition completing)
+            //   waits 4-6: B-spam (bit 1 may clear if dialog dismissable)
+            //   waits 7-8: long-hold DOWN (bit 1 may clear if engine wants
+            //              direction commitment for transition exit)
+            // After cap exhausted, fall through to normal tap logic — caller
+            // can classify the tile as doorway/transition-stuck and move on.
+            val curPosForRecovery = (ramPre["smPlayerX"] ?: 0) to (ramPre["smPlayerY"] ?: 0)
+            if ((mapflagsPre and 0x02) != 0 && transitionWaits < 8 &&
+                curPosForRecovery !in mf3Exhausted) {
+                transitionWaits++
+                val recovery = when {
+                    transitionWaits <= 3 -> "idle"
+                    transitionWaits <= 6 -> "b-spam"
+                    else -> "long-down"
+                }
+                when (recovery) {
+                    "idle" -> {
+                        // Long idle: cont-3 #8 evidence shows agent is VISUALLY
+                        // on overworld at south edge of Coneria but mapflags
+                        // bit 1 takes much longer than 30 frames to clear.
+                        // 300 frames = ~5 seconds wallclock = enough margin.
+                        val s = toolset.step(buttons = emptyList(), frames = 300)
+                        totalFrames += s.frame
+                    }
+                    "b-spam" -> {
+                        repeat(4) {
+                            val t = toolset.tap(button = "B", count = 1, pressFrames = 4, gapFrames = 8)
+                            val s = toolset.step(buttons = emptyList(), frames = 6)
+                            totalFrames += t.frame + s.frame
+                        }
+                    }
+                    "long-down" -> {
+                        // Multiple short DOWN taps + settle — maybe the engine
+                        // wants discrete commits, not held button.
+                        repeat(5) {
+                            val t = toolset.tap(button = "Down", count = 1, pressFrames = 6, gapFrames = 12)
+                            val s = toolset.step(buttons = emptyList(), frames = 60)
+                            totalFrames += t.frame + s.frame
+                        }
+                    }
+                }
+                println("[exit-town-empirical] mf3-recovery $transitionWaits/8 ($recovery) " +
+                    "mapflags=$mapflagsPre smPlayer=(${ramPre["smPlayerX"]},${ramPre["smPlayerY"]})")
+                if (transitionWaits == 8) {
+                    // Final fallback: dump screenshot so we can see what the
+                    // stuck state looks like, then mark this position as
+                    // recovery-exhausted so the next loop iteration falls
+                    // through to normal cardinal-tap logic instead of
+                    // re-entering recovery indefinitely.
+                    try {
+                        val shot = toolset.getScreen().base64
+                        val bytes = java.util.Base64.getDecoder().decode(shot)
+                        java.io.File("/tmp/spec5-mf3-stuck-${ramPre["smPlayerX"]}-${ramPre["smPlayerY"]}.png")
+                            .writeBytes(bytes)
+                        println("[exit-town-empirical] dumped /tmp/spec5-mf3-stuck-" +
+                            "${ramPre["smPlayerX"]}-${ramPre["smPlayerY"]}.png; mf3 exhausted at $curPosForRecovery")
+                    } catch (_: Throwable) {}
+                    mf3Exhausted += curPosForRecovery
+                }
+                continue
+            }
+            transitionWaits = 0  // reset for next stuck state
+            val sx = ramPre["smPlayerX"] ?: 0
+            val sy = ramPre["smPlayerY"] ?: 0
+            val pos = sx to sy
+
+            // If at warp tile (entry coord), force DOWN to commit the exit
+            // transition — this should cross the warp and clear mapflags.
+            if (warpTile != null && pos == warpTile) {
+                println("[exit-town-empirical] AT WARP TILE $warpTile — committing DOWN to cross")
+                val t = toolset.tap(button = "DOWN", count = 1,
+                    pressFrames = PRESS_FRAMES, gapFrames = GAP_FRAMES)
+                val s = toolset.step(buttons = emptyList(), frames = 60)
+                totalFrames += t.frame + s.frame
+                taps++
+                continue
+            }
+
+            // Pick cardinal:
+            //   1. Reverse-trajectory hint if available (reversed walk-in)
+            //   2. Untried frontier first, then known-walkable
+            val triedHere = tried.getOrPut(pos) { mutableSetOf() }
+            val blockedHere = blocked[pos] ?: emptySet()
+            val doorwaysHere = doorways[pos] ?: emptySet()
+            val candidates = defaultCardinals.filter {
+                it !in triedHere && it !in blockedHere && it !in doorwaysHere
+            }
+            // Manhattan-gradient pick: when warpTile is known, prefer the
+            // cardinal that REDUCES Manhattan distance to the warp tile.
+            // Falls back to default DOWN-bias when warp unknown or no
+            // gradient-improving candidate available.
+            fun gradientPick(c: List<String>): String? {
+                if (warpTile == null) return null
+                val (tx, ty) = warpTile
+                val curDist = kotlin.math.abs(sx - tx) + kotlin.math.abs(sy - ty)
+                if (curDist == 0) return null  // already at warp; default behaviour
+                return c.minByOrNull { dirCardinal ->
+                    val nsx = sx + when (dirCardinal) { "RIGHT" -> 1; "LEFT" -> -1; else -> 0 }
+                    val nsy = sy + when (dirCardinal) { "DOWN" -> 1; "UP" -> -1; else -> 0 }
+                    kotlin.math.abs(nsx - tx) + kotlin.math.abs(nsy - ty)
+                }?.takeIf { picked ->
+                    val nsx = sx + when (picked) { "RIGHT" -> 1; "LEFT" -> -1; else -> 0 }
+                    val nsy = sy + when (picked) { "DOWN" -> 1; "UP" -> -1; else -> 0 }
+                    kotlin.math.abs(nsx - tx) + kotlin.math.abs(nsy - ty) < curDist
+                }
+            }
+            val dir = when {
+                candidates.isNotEmpty() -> {
+                    // Prefer warp-gradient candidate; fall back to DOWN-bias.
+                    gradientPick(candidates) ?: candidates.first()
+                }
+                else -> {
+                    // All four already explored; the local cell is exhausted.
+                    // Try any walkable edge to leave this cell, otherwise bail.
+                    val walkable = edges.filter { it.from == pos }.map { it.dir }.distinct()
+                    if (walkable.isEmpty()) {
+                        val msg = "exit_town_empirical: all cardinals exhausted at " +
+                            "smPlayer=($sx,$sy), no walkable edges — giving up after $taps taps"
+                        scratchpad.record(kind = "exit",
+                            summary = "town_exit_giveup",
+                            smPost = pos,
+                            mapflagsPost = mapflagsPre,
+                            note = "$taps taps; all cardinals at ($sx,$sy) tried; ${edges.size} edges")
+                        return SkillResult(false, msg, totalFrames, ramPre)
+                    }
+                    walkable.random()
+                }
+            }
+            triedHere.add(dir)
+
+            // Tap + settle.
+            val tap = toolset.tap(button = dir, count = 1,
+                pressFrames = PRESS_FRAMES, gapFrames = GAP_FRAMES)
+            val settle = toolset.step(buttons = emptyList(), frames = SETTLE_FRAMES)
+            totalFrames += tap.frame + settle.frame
+            taps++
+
+            val ramPost = toolset.getState().ram
+            val mapflagsPost = ramPost["mapflags"] ?: 0
+            val sxPost = ramPost["smPlayerX"] ?: 0
+            val syPost = ramPost["smPlayerY"] ?: 0
+            val posPost = sxPost to syPost
+
+            // Detect dialog open: any byte beyond {smPlayer*, localY, facing,
+            // mapflags} flipped. cont-3 ground-truth diff confirmed normal
+            // movement only changes those four. Anything else = NPC interaction.
+            val movementBytes = setOf("smPlayerX", "smPlayerY", "localX", "localY", "facing", "mapflags")
+            val unexpectedFlips = ramPost.filter { (k, v) ->
+                k !in movementBytes && (ramPre[k] ?: 0) != v
+            }.keys
+            val dialogOpened = unexpectedFlips.isNotEmpty()
+
+            scratchpad.record(kind = "tap",
+                summary = "explore: $dir",
+                dir = dir,
+                smPre = pos,
+                smPost = posPost,
+                mapflagsPost = mapflagsPost,
+                note = if (dialogOpened) "dialog: flipped=${unexpectedFlips.take(3)}" else null)
+
+            // Classify outcome.
+            when {
+                (mapflagsPost and 0x01) == 0 -> {
+                    // Already handled top-of-loop next iteration; record edge.
+                    edges += Edge(pos, dir, posPost)
+                }
+                dialogOpened -> {
+                    // Walked into NPC/sign. B-spam to recover; mark as doorway.
+                    doorways.getOrPut(pos) { mutableSetOf() }.add(dir)
+                    repeat(8) {
+                        val t = toolset.tap(button = "B", count = 1, pressFrames = 4, gapFrames = 8)
+                        val s = toolset.step(buttons = emptyList(), frames = 4)
+                        totalFrames += t.frame + s.frame
+                    }
+                }
+                posPost == pos -> {
+                    // No move and no dialog → wall.
+                    blocked.getOrPut(pos) { mutableSetOf() }.add(dir)
+                }
+                else -> {
+                    // Successful move → record edge for backtrack.
+                    edges += Edge(pos, dir, posPost)
+                    // Allow re-trying this dir from new position later.
+                    triedHere.remove(dir)
+                }
+            }
+        }
+
+        // 2026-05-09 cont 3 user-provided exit hint after observing the
+        // /tmp/spec5-mf3-stuck-14-22.png screenshot: "blocks on a tree :)
+        // Up Right right Down Down z ostatniej pozycji". From the deadlock
+        // tile (~14,22) a tree blocks straight-south; the path AROUND the
+        // tree to reach the warp tile (16,23) is U R R D D — then one more
+        // D to commit the warp transition. Try this as a final hardcoded
+        // detour before giving up.
+        run {
+            // Pre-detour: wait for mapflags bit 1 to settle.
+            for (waitIter in 0 until 10) {
+                val r = toolset.getState().ram
+                if (((r["mapflags"] ?: 0) and 0x02) == 0) break
+                val s = toolset.step(buttons = emptyList(), frames = 60)
+                totalFrames += s.frame
+            }
+            val ramBefore = toolset.getState().ram
+            val sxBefore = ramBefore["smPlayerX"] ?: 0
+            val syBefore = ramBefore["smPlayerY"] ?: 0
+            val mfBefore = ramBefore["mapflags"] ?: 0
+            println("[exit-town-empirical] tree-detour starting from smPlayer=($sxBefore,$syBefore) mapflags=$mfBefore")
+
+            // 2026-05-09 cont 3 reliability fix: empirical exploration ends
+            // at non-deterministic positions across runs (cont-3 #N at (13,14),
+            // earlier at (14,22)). The hardcoded U R R D D D sequence was
+            // tuned for (14,22) → reaches warp tile (16,23). From other
+            // start positions it fails. Pre-navigate to (14,22) using simple
+            // delta cardinals: RIGHT (deltaX>0) / LEFT (deltaX<0) then DOWN
+            // (deltaY>0) / UP (deltaY<0). Then run the U R R D D D detour.
+            val targetX = 14
+            val targetY = 22
+            val approachSeq = mutableListOf<String>()
+            // X delta first
+            val dx = targetX - sxBefore
+            repeat(kotlin.math.abs(dx)) { approachSeq += if (dx > 0) "Right" else "Left" }
+            // Then Y delta
+            val dy = targetY - syBefore
+            repeat(kotlin.math.abs(dy)) { approachSeq += if (dy > 0) "Down" else "Up" }
+            println("[exit-town-empirical] approach to (14,22) via ${approachSeq.size} taps: $approachSeq")
+            for (apDir in approachSeq) {
+                // Pre-tap mapflags settle
+                for (w in 0 until 10) {
+                    val rW = toolset.getState().ram
+                    if (((rW["mapflags"] ?: 0) and 0x02) == 0) break
+                    val sW = toolset.step(buttons = emptyList(), frames = 30)
+                    totalFrames += sW.frame
+                }
+                val tA = toolset.tap(button = apDir, count = 1, pressFrames = 6, gapFrames = 14)
+                val sA = toolset.step(buttons = emptyList(), frames = 30)
+                totalFrames += tA.frame + sA.frame
+            }
+            val ramAtDetour = toolset.getState().ram
+            println("[exit-town-empirical] approach done; smPlayer=" +
+                "(${ramAtDetour["smPlayerX"]},${ramAtDetour["smPlayerY"]}) mapflags=${ramAtDetour["mapflags"]}")
+            val sequence = listOf("Up", "Right", "Right", "Down", "Down", "Down")
+            for ((idx, dir) in sequence.withIndex()) {
+                // Pre-tap: wait for any in-flight mid-scroll to complete
+                // (mapflags bit 1 cleared) so the tap actually registers.
+                for (w in 0 until 10) {
+                    val rW = toolset.getState().ram
+                    if (((rW["mapflags"] ?: 0) and 0x02) == 0) break
+                    val sW = toolset.step(buttons = emptyList(), frames = 30)
+                    totalFrames += sW.frame
+                }
+                // Run-9 evidence: pressFrames=18 caused 2-tile moves
+                // (overshoot past warp tile). Use the established 6-frame
+                // press / 14-frame gap pattern for reliable 1-tile-per-tap
+                // movement. Long settle between taps so any mid-scroll
+                // mapflags=3 transient resolves to 1 before next tap.
+                val t = toolset.tap(button = dir, count = 1, pressFrames = 6, gapFrames = 14)
+                val s = toolset.step(buttons = emptyList(), frames = 60)
+                totalFrames += t.frame + s.frame
+                val r = toolset.getState().ram
+                val mf = r["mapflags"] ?: 0
+                val sx2 = r["smPlayerX"] ?: 0
+                val sy2 = r["smPlayerY"] ?: 0
+                println("[exit-town-empirical] tree-detour[$idx] $dir → smPlayer=($sx2,$sy2) mapflags=$mf")
+                // Per-step visual evidence for tree-detour traversal.
+                try {
+                    val shot = toolset.getScreen().base64
+                    val pb = java.util.Base64.getDecoder().decode(shot)
+                    val fn = "/tmp/spec5-detour-%02d-%s-sm%d_%d-mf%d.png"
+                        .format(idx, dir.lowercase(), sx2, sy2, mf)
+                    java.io.File(fn).writeBytes(pb)
+                    println("[exit-town-empirical] dumped $fn")
+                } catch (_: Throwable) {}
+                scratchpad.record(kind = "tap",
+                    summary = "tree_detour: $dir",
+                    dir = dir.uppercase(),
+                    smPost = sx2 to sy2,
+                    mapflagsPost = mf,
+                    note = "user-provided detour step ${idx + 1}/${sequence.size}")
+                if ((mf and 0x01) == 0) {
+                    // Visual verification: dump screenshot at the moment of
+                    // declared exit success so we can confirm the agent really
+                    // is on overworld (not a false-positive mapflags read).
+                    try {
+                        val shot = toolset.getScreen().base64
+                        val bytes = java.util.Base64.getDecoder().decode(shot)
+                        java.io.File("/tmp/spec5-exit-success.png").writeBytes(bytes)
+                        println("[exit-town-empirical] dumped /tmp/spec5-exit-success.png — visual proof of exit")
+                    } catch (_: Throwable) {}
+                    // Post-exit safety walk: walk WEST off the gate tile.
+                    // Coneria is on a peninsula — south of (147,155) is
+                    // blocked (water), east is water, north re-enters town.
+                    // West (147→146→145…) leads onto open grass with random
+                    // encounters. cont-3 evidence: 8 DOWN taps post-exit
+                    // didn't change worldY (south blocked). LEFT should move
+                    // worldX. Walk 4 LEFT then 2 DOWN to clear gate AND
+                    // descend to encounter zone.
+                    val postSettle = toolset.step(buttons = emptyList(), frames = 120)
+                    totalFrames += postSettle.frame
+                    val rPostWarp = toolset.getState().ram
+                    println("[exit-town-empirical] post-warp: world=(${rPostWarp["worldX"]},${rPostWarp["worldY"]}) mapflags=${rPostWarp["mapflags"]}")
+                    // cont-3 evidence + user hint "trees walkable, why castle re-entry":
+                    //   - Walking UP from (145,155) reaches (145,152) = castle warp
+                    //   - Walking LEFT 2 lands at (145,155) but corridor=2 still
+                    //     extends to (145,153) → castle re-entry on shifted anchor
+                    //   - Coneria area on overworld: castle north + town south,
+                    //     grass+forest extends SOUTH of castle outer area
+                    //   - Trees ARE walkable in FF1 (encounter zone, not obstacle)
+                    //
+                    // Walk 1 LEFT (off the (147,155) gate to (146,155) grass)
+                    // then DOWN repeatedly to descend south away from castle.
+                    // Anchor will capture below castle's south edge → grind
+                    // corridor stays clear of castle warp.
+                    val postExitSequence = listOf(
+                        "Left", "Down", "Down", "Down", "Down",
+                        "Down", "Down", "Down", "Down", "Down", "Down",
+                    )
+                    for ((tapIdx, ddir) in postExitSequence.withIndex()) {
+                        val t = toolset.tap(button = ddir, count = 1, pressFrames = 5, gapFrames = 30)
+                        val s = toolset.step(buttons = emptyList(), frames = 60)
+                        totalFrames += t.frame + s.frame
+                        val rNow = toolset.getState().ram
+                        val wxNow = rNow["worldX"] ?: 0
+                        val wyNow = rNow["worldY"] ?: 0
+                        val mfNow = rNow["mapflags"] ?: 0
+                        println("[exit-town-empirical] post-exit $ddir[$tapIdx] " +
+                            "world=($wxNow,$wyNow) mapflags=$mfNow")
+                        // Per-step visual evidence: dump screenshot every tap so
+                        // we can verify the agent actually IS on overworld and
+                        // each move is real, not a false-positive RAM signal.
+                        try {
+                            val shot = toolset.getScreen().base64
+                            val pb = java.util.Base64.getDecoder().decode(shot)
+                            val fn = "/tmp/spec5-postexit-%02d-%s-w%d_%d-mf%d.png"
+                                .format(tapIdx, ddir.lowercase(), wxNow, wyNow, mfNow)
+                            java.io.File(fn).writeBytes(pb)
+                            println("[exit-town-empirical] dumped $fn")
+                        } catch (_: Throwable) {}
+                    }
+                    val rFinal = toolset.getState().ram
+                    val msg = "exit_town_empirical: tree-detour SUCCESS at " +
+                        "world=(${rFinal["worldX"]},${rFinal["worldY"]}) after step ${idx + 1} " +
+                        "+ 3 post-exit DOWN taps for grind-anchor distancing"
+                    scratchpad.record(kind = "exit",
+                        summary = "town_exit_success_via_tree_detour",
+                        smPost = (rFinal["smPlayerX"] ?: 0) to (rFinal["smPlayerY"] ?: 0),
+                        mapflagsPost = rFinal["mapflags"] ?: 0,
+                        note = "step ${idx + 1}/${sequence.size} + post-exit south walk")
+                    return SkillResult(true, msg, totalFrames, rFinal)
+                }
+            }
+        }
+
+        val ramFinal = toolset.getState().ram
+        val msg = "exit_town_empirical: did not exit in $maxTaps taps + tree-detour " +
+            "(visited ${tried.size} positions, ${blocked.values.sumOf { it.size }} walls, " +
+            "${doorways.values.sumOf { it.size }} doorways, ${edges.size} walkable edges)"
+        scratchpad.record(kind = "exit",
+            summary = "town_exit_timeout",
+            smPost = (ramFinal["smPlayerX"] ?: 0) to (ramFinal["smPlayerY"] ?: 0),
+            mapflagsPost = ramFinal["mapflags"] ?: 0,
+            note = "${tried.size} positions ${edges.size} edges; tree-detour also failed")
+        return SkillResult(false, msg, totalFrames, ramFinal)
+    }
+}

--- a/knes-agent/src/main/kotlin/knes/agent/skills/GrindLoop.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/skills/GrindLoop.kt
@@ -8,6 +8,15 @@ import kotlin.math.absoluteValue
  * is exhausted, or party drifts outside the corridor. Deterministic — no LLM
  * inside; AgentSession's PostBattle handler handles the resulting battle.
  *
+ * IMPORTANT (FF1 mechanics, user-confirmed 2026-05-09):
+ *   - Random encounters fire on GREEN GRASS and FOREST (tree) overworld tiles
+ *     — trees are walkable, not obstacles.
+ *   - Mountain and water tiles block movement (no encounters).
+ *   - Town/castle entry tiles are WARP TILES — walking onto them transitions
+ *     into the standard map (mapflags.bit0=1) and breaks the grind corridor.
+ *   - The grind corridor anchor must be placed such that the entire walked
+ *     range stays clear of warp tiles.
+ *
  * Outcome encoded in [SkillResult.message] prefix:
  *   - "EncounteredBattle: ..."   ok=true
  *   - "NoEncounter: ..."         ok=true
@@ -32,6 +41,16 @@ class GrindLoop(private val toolset: EmulatorToolset) : Skill {
         var steps = 0
         var goingNorth = true
 
+        // Per-step screenshot evidence for grind walk — confirms the agent is
+        // actually traversing GREEN grass tiles where encounters fire (per
+        // user-confirmed FF1 mechanic). Dump entry frame.
+        try {
+            val ramEntry = toolset.getState().ram
+            val shotEntry = toolset.getScreen().base64
+            java.io.File("/tmp/spec5-grind-entry-w${ramEntry["worldX"]}_${ramEntry["worldY"]}-mf${ramEntry["mapflags"]}.png")
+                .writeBytes(java.util.Base64.getDecoder().decode(shotEntry))
+        } catch (_: Throwable) {}
+
         while (steps < maxStepsWithoutEncounter) {
             val targetY = if (goingNorth) anchorY - corridorRadius else anchorY + corridorRadius
             toolset.tap(
@@ -39,6 +58,24 @@ class GrindLoop(private val toolset: EmulatorToolset) : Skill {
                 count = 1, pressFrames = 5, gapFrames = 30
             )
             steps++
+
+            // Per-step screenshot for the first few steps (visual proof we are
+            // walking on grass, not stuck in stone-walled town overlay).
+            // Also log encounterCounter to verify FF1's step-based encounter
+            // timer is actually decrementing (if not, encounters won't fire
+            // regardless of how many steps we walk).
+            val ramStep = toolset.getState().ram
+            if (steps <= 6) {
+                try {
+                    val shotN = toolset.getScreen().base64
+                    java.io.File("/tmp/spec5-grind-step%02d-w%d_%d-mf%d.png".format(
+                        steps, ramStep["worldX"] ?: 0, ramStep["worldY"] ?: 0, ramStep["mapflags"] ?: 0))
+                        .writeBytes(java.util.Base64.getDecoder().decode(shotN))
+                } catch (_: Throwable) {}
+            }
+            println("[grind] step=$steps world=(${ramStep["worldX"]},${ramStep["worldY"]}) " +
+                "mapflags=${ramStep["mapflags"]} encounterCounter=${ramStep["encounterCounter"]} " +
+                "screenState=0x${(ramStep["screenState"] ?: 0).toString(16)}")
 
             val stateAfter = toolset.getState()
             val ram = stateAfter.ram

--- a/knes-agent/src/main/kotlin/knes/agent/skills/GrindLoop.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/skills/GrindLoop.kt
@@ -40,6 +40,8 @@ class GrindLoop(private val toolset: EmulatorToolset) : Skill {
         val startFrame = toolset.getState().frame
         var steps = 0
         var goingNorth = true
+        var prevEncCounter: Int? = null
+        var nonZeroDeltaSeen = false
 
         // Per-step screenshot evidence for grind walk — confirms the agent is
         // actually traversing GREEN grass tiles where encounters fire (per
@@ -73,8 +75,12 @@ class GrindLoop(private val toolset: EmulatorToolset) : Skill {
                         .writeBytes(java.util.Base64.getDecoder().decode(shotN))
                 } catch (_: Throwable) {}
             }
+            val encNow = ramStep["encounterCounter"] ?: 0
+            val encDelta = prevEncCounter?.let { encNow - it } ?: 0
+            if (prevEncCounter != null && encDelta != 0) nonZeroDeltaSeen = true
+            prevEncCounter = encNow
             println("[grind] step=$steps world=(${ramStep["worldX"]},${ramStep["worldY"]}) " +
-                "mapflags=${ramStep["mapflags"]} encounterCounter=${ramStep["encounterCounter"]} " +
+                "mapflags=${ramStep["mapflags"]} encounterCounter=$encNow delta=$encDelta " +
                 "screenState=0x${(ramStep["screenState"] ?: 0).toString(16)}")
 
             val stateAfter = toolset.getState()
@@ -111,6 +117,10 @@ class GrindLoop(private val toolset: EmulatorToolset) : Skill {
             }
         }
 
+        if (prevEncCounter != null && !nonZeroDeltaSeen) {
+            println("[grind] WARN grind_encounter_byte_dead: encounterCounter=$prevEncCounter " +
+                "stayed flat across $steps steps — wrong RAM byte or true dead-zone")
+        }
         val stateAfter = toolset.getState()
         val ram = stateAfter.ram
         return SkillResult(

--- a/knes-agent/src/main/kotlin/knes/agent/skills/WalkInteriorVision.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/skills/WalkInteriorVision.kt
@@ -45,6 +45,12 @@ class WalkInteriorVision(
         var stepsTaken = 0
         var lastBlocked: InteriorMove? = null
         var consecutiveStuck = 0
+        // 2026-05-10 cont 5: rolling buffer of recent decisions + outcomes.
+        // Without this the model picks LEFT 8 times in a row at the same
+        // smPlayer because each call is stateless (lastBlocked is only the
+        // most-recent failed cardinal). Per `feedback_locate_party_first`
+        // and the cont-4 sm(2,14) deadlock evidence.
+        val recentMoves = ArrayDeque<String>()
         try {
         // V3.2: when navigator says STUCK on step 0 with no movement evidence, the
         // skill should not yet trust it. Default to SOUTH (FF1 castle/town entries
@@ -103,11 +109,20 @@ class WalkInteriorVision(
                     unvisitedReachable = 1
                 }
             }
+            val extendedHint: String? = run {
+                val parts = mutableListOf<String>()
+                if (!historyHint.isNullOrBlank()) parts += historyHint
+                if (recentMoves.isNotEmpty()) {
+                    parts += "RECENT MOVES (most recent last):\n" +
+                        recentMoves.joinToString("\n")
+                }
+                parts.takeIf { it.isNotEmpty() }?.joinToString("\n\n")
+            }
             val dir = navigator.nextDirection(
                 shotB64, frame, lastBlocked,
                 frontierHint = frontierHint,
                 unvisitedReachable = unvisitedReachable,
-                historyHint = historyHint,
+                historyHint = extendedHint,
             )
             toolCallLog?.append("walkInteriorVision.dir",
                 "step=$stepsTaken dir=${dir.name}" +
@@ -157,6 +172,11 @@ class WalkInteriorVision(
                     "moved=$moved transitioned=$transitioned")
 
             lastBlocked = if (!moved && !transitioned) effectiveDir else null
+            recentMoves.addLast("step=$stepsTaken dir=${effectiveDir.name} " +
+                "smPre=(${ramPre["smPlayerX"]},${ramPre["smPlayerY"]}) " +
+                "smPost=(${ramPost["smPlayerX"]},${ramPost["smPlayerY"]}) " +
+                "moved=$moved")
+            while (recentMoves.size > 8) recentMoves.removeFirst()
             if (transitioned) {
                 // V5.9: record exit-confirmed at the pre-step tile + direction.
                 if (mapIdPre >= 0) {

--- a/knes-agent/src/main/kotlin/knes/agent/skills/WalkInteriorVision.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/skills/WalkInteriorVision.kt
@@ -76,6 +76,16 @@ class WalkInteriorVision(
 
             val frame = toolset.getState().frame
             val shotB64 = toolset.getScreen().base64
+            // 2026-05-09 cont 4: per-iter PNG for offline diagnosis. Without
+            // these, a 60-step vision drift leaves zero visual evidence of
+            // what the model saw or whether the party moved tile-to-tile.
+            // Per `feedback_per_iter_screenshots.md`.
+            try {
+                val mfPre = ramPre["mapflags"] ?: 0
+                val fn = "/tmp/spec5-vision-exit-iter-%02d-sm%d_%d-mf%d.png".format(
+                    stepsTaken, partyXPre, partyYPre, mfPre)
+                java.io.File(fn).writeBytes(java.util.Base64.getDecoder().decode(shotB64))
+            } catch (_: Throwable) { /* dev noise */ }
             // V5.11: compute frontier hint when memory + mapSession are available.
             var frontierHint: InteriorMove? = null
             var unvisitedReachable = 0

--- a/knes-agent/src/main/kotlin/knes/agent/skills/WalkInteriorVision.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/skills/WalkInteriorVision.kt
@@ -28,6 +28,12 @@ class WalkInteriorVision(
     private val interiorMemory: InteriorMemory? = null,
     private val mapSession: MapSession? = null,
     private val framesPerTile: Int = 48,  // matches V2.4.5 ExitInterior tuning
+    /**
+     * 2026-05-09 cont 3: free-form context passed verbatim to the navigator's
+     * prompt. Typically AgentScratchpad.renderForLLM() — the walk-in
+     * trajectory used as a reasoning hint for finding the exit.
+     */
+    private val historyHint: String? = null,
 ) : Skill {
     override val id = "walk_interior_vision"
     override val description =
@@ -91,6 +97,7 @@ class WalkInteriorVision(
                 shotB64, frame, lastBlocked,
                 frontierHint = frontierHint,
                 unvisitedReachable = unvisitedReachable,
+                historyHint = historyHint,
             )
             toolCallLog?.append("walkInteriorVision.dir",
                 "step=$stepsTaken dir=${dir.name}" +

--- a/knes-agent/src/test/kotlin/knes/agent/runtime/GrindAnchorSelectorTest.kt
+++ b/knes-agent/src/test/kotlin/knes/agent/runtime/GrindAnchorSelectorTest.kt
@@ -1,0 +1,79 @@
+package knes.agent.runtime
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import knes.agent.perception.OverworldMap
+import knes.agent.perception.TileType
+import java.lang.reflect.Constructor
+
+/**
+ * Builds a 256×256 OverworldMap from a tileId mapping. Tiles default to 0x17
+ * (WATER, impassable) so any cell not explicitly populated is non-encounter.
+ *
+ * 0x00 = GRASS (per OverworldTileClassifier)
+ * 0x03 = FOREST
+ * 0x10 = MOUNTAIN
+ * 0x17 = WATER (default fill)
+ * 0x4A = TOWN
+ */
+private fun buildMap(populated: Map<Pair<Int, Int>, Int>): OverworldMap {
+    val tiles = ByteArray(256 * 256) { 0x17.toByte() }
+    for ((xy, id) in populated) {
+        val (x, y) = xy
+        tiles[y * 256 + x] = id.toByte()
+    }
+    val ctor: Constructor<OverworldMap> =
+        OverworldMap::class.java.getDeclaredConstructor(ByteArray::class.java)
+    ctor.isAccessible = true
+    return ctor.newInstance(tiles)
+}
+
+class GrindAnchorSelectorTest : FunSpec({
+    test("party on GRASS → anchor = party, no fallback") {
+        val map = buildMap(mapOf(146 to 156 to 0x00))
+        val pick = GrindAnchorSelector.pickGrindAnchor(146 to 156, map)
+        pick.anchor shouldBe (146 to 156)
+        pick.tileClass shouldBe TileType.GRASS
+        pick.fellBack shouldBe false
+    }
+
+    test("party on FOREST → anchor = party, no fallback") {
+        val map = buildMap(mapOf(146 to 156 to 0x03))
+        val pick = GrindAnchorSelector.pickGrindAnchor(146 to 156, map)
+        pick.anchor shouldBe (146 to 156)
+        pick.tileClass shouldBe TileType.FOREST
+        pick.fellBack shouldBe false
+    }
+
+    test("party on TOWN tile, GRASS one south → anchor shifts south") {
+        val map = buildMap(mapOf(
+            147 to 155 to 0x4A,  // party tile = TOWN
+            147 to 156 to 0x00,  // south = GRASS
+            147 to 154 to 0x00,  // north = GRASS (also valid — should lose tie-break)
+        ))
+        val pick = GrindAnchorSelector.pickGrindAnchor(147 to 155, map)
+        pick.anchor shouldBe (147 to 156)
+        pick.tileClass shouldBe TileType.GRASS
+        pick.fellBack shouldBe false
+    }
+
+    test("party on TOWN tile, FOREST diagonally SE wins south+east tie-break vs NW GRASS") {
+        val map = buildMap(mapOf(
+            100 to 100 to 0x4A,                    // party = TOWN
+            99 to 99 to 0x00,                      // NW grass (Manhattan 2)
+            101 to 101 to 0x03,                    // SE forest (Manhattan 2) — should win
+        ))
+        val pick = GrindAnchorSelector.pickGrindAnchor(100 to 100, map)
+        pick.anchor shouldBe (101 to 101)
+        pick.tileClass shouldBe TileType.FOREST
+        pick.fellBack shouldBe false
+    }
+
+    test("no encounter tile within radius → fellBack=true, anchor=party") {
+        // Default fill is WATER; nothing populated near (50,50).
+        val map = buildMap(mapOf(50 to 50 to 0x17))
+        val pick = GrindAnchorSelector.pickGrindAnchor(50 to 50, map)
+        pick.anchor shouldBe (50 to 50)
+        pick.fellBack shouldBe true
+    }
+})


### PR DESCRIPTION
## Summary

- **Phase 3 (exit) + Phase 4 (grind) pipeline rework** post-buy in Coneria, per [`docs/superpowers/specs/2026-05-09-coneria-pipeline-design.md`](docs/superpowers/specs/2026-05-09-coneria-pipeline-design.md). Vision-LLM (`WalkInteriorVision`, Sonnet 4.6) is the sole hot-path exit; `ExitTownEmpirical`/tree-detour kept only as offline fallback when `outfitNavigator==null`. Phase 4 picks a `GrindAnchorSelector` anchor on the closest `GRASS`/`FOREST` overworld tile (south+east tie-break) and runs `GrindLoop` with up to 2 re-anchors on `NoEncounter`.
- **Phase 1+2 (4/4 weapon buy) regression baseline preserved** — empirically validated this PR's HEAD with a fresh-run smoke (`weaponsBought=4 totalGoldSpent=25` at `boot_outfit_summary`). The spec § Regression protection invariants (`BuyAtShop` cap=120, `SYSTEM_SHOP_PURCHASE` prompt, savestate warm-up, `OutfitBootPhase` entry guards, `NameTable.stateSave`) are all untouched. `OutfitBootPhaseTest` green throughout.
- **Phase 3 still fails empirically per documented Risk #1** — vision-LLM consistently bails on the cont-3 `sm(14,22)` Coneria south-edge deadlock with `UNCLEAR x2` after 12–14 steps. Recent-moves history (cont-5) broke the LEFT-LEFT-LEFT loop from cont-4 (60-step drift west → 9-step reach to south edge), but the model still drifts west past the warp tile. Approach B (PPU nametable read for town overlay tile data) is the cont-6 direction.

## Files changed

| File | What |
|---|---|
| `docs/superpowers/specs/2026-05-09-coneria-pipeline-design.md` | New design doc + § Regression protection |
| `docs/superpowers/plans/2026-05-09-coneria-pipeline.md` | 7-task TDD-shaped implementation plan |
| `HANDOFF.md` | cont-4 + cont-5 progress notes |
| `knes-agent/src/main/kotlin/knes/agent/runtime/GrindAnchorSelector.kt` (+test) | Pure helper, 5 unit tests |
| `knes-agent/src/main/kotlin/knes/agent/runtime/AgentSession.kt` | `runOutfitBootPhase` Phase 3+4 rework, 5 new trace markers |
| `knes-agent/src/main/kotlin/knes/agent/perception/VisionInteriorNavigator.kt` | POST-SHOP TOWN EXIT prompt, RECENT MOVES instruction, model-ID fix (claude-sonnet-4-6) |
| `knes-agent/src/main/kotlin/knes/agent/skills/WalkInteriorVision.kt` | Per-iter PNG dump + 8-entry recent-moves rolling buffer |
| `knes-agent/src/main/kotlin/knes/agent/skills/GrindLoop.kt` | encounterCounter delta log + `grind_encounter_byte_dead` WARN |
| `knes-agent/src/main/kotlin/knes/agent/runtime/AgentScratchpad.kt` (new) + `Main.kt` | Sister-file scratchpad load/persist alongside savestate (cont-3 checkpoint) |
| `knes-agent/src/main/kotlin/knes/agent/skills/ExitInterior.kt` + `ExitTownEmpirical.kt` (new) | Offline fallback path (cont-3 checkpoint), no longer on hot path |

## Test plan

- [x] `./gradlew :knes-agent:test` — 353 unit + 3 in `SavestateRoundtripDebug`. 5 new tests in `GrindAnchorSelectorTest`, all green. 3 pre-existing failures (`Coneria8VisualDiffTest`, `ConeriaTownEmpiricalDiscoveryTest`, `ExploreOverworldFrontierTest`) unchanged from baseline — out of scope.
- [x] `./gradlew :knes-agent:compileKotlin` — BUILD SUCCESSFUL.
- [x] `OutfitBootPhaseTest` green — Phase 2 entry-guard regression baseline preserved.
- [x] **Smoke #2 fresh-run** (this PR's HEAD `3311a4b`, full pipeline): `KNES_VISION=gemini-pro ./gradlew :knes-agent:run --args="--rom=$PWD/roms/ff.nes --wall-clock-cap-seconds=900 --cost-cap-usd=3.0"`. Result: `weaponsBought=4 totalGoldSpent=25`, char1 BOUGHT iter=8, char2 BOUGHT iter=20, char3 BOUGHT iter=33, char4 BOUGHT iter=45. `boot_post_buy_savestate_dumped` 401665 bytes. **Phase 1+2 baseline ✅.**
- [x] Smoke #1 savestate-load (HEAD `2371e6e` and `3311a4b`, both runs): `boot_phase3_exit_result: ok=false msg=vision returned UNCLEAR 2x in a row after 12–14 steps`. Phase 3 fails per documented Risk #1 — reproducible, deterministic. Per-iter PNGs at `/tmp/spec5-vision-exit-iter-NN-smX_Y-mfM.png` show trajectory: shop counter → `sm(14,22)` south edge → drift west past warp → bail. **Phase 4 not exercised.**
- [ ] Phase 3 reliable exit — out of scope, cont-6 (Approach B: PPU nametable read for town overlay).
- [ ] Phase 4 grind battle empirically validated — blocked on Phase 3.
- [ ] Savestate-dump regression: `runOutfitBootPhase` overwrites `/tmp/spec5-post-buy.savestate` regardless of `bought=N`. Quick fix proposed for cont-6 (gate on `charsBought.size == expected`).

## Honest assessment

This PR is **mergeable for the regression-baseline reason**: 4/4 buy is empirically preserved and all unit tests are green. It does NOT deliver a working end-to-end Coneria pipeline — that requires cont-6 (Approach B). The architectural work (vision-only hot path, anchor selection, re-anchor, trace markers, per-iter diagnostics, recent-moves history) is the foundation cont-6 will build on. The cont-3 sm(14,22) deadlock is genuinely beyond pure vision-LLM reach without map-aware navigation.