### PR TITLE
knes-agent v2: PDF architecture scaffold — smoke pending

### DIFF
--- a/knes-agent/build.gradle
+++ b/knes-agent/build.gradle
@@ -69,7 +69,7 @@ tasks.register('runExplorer', JavaExec) {
 
 tasks.register('runV2', JavaExec) {
     group = 'application'
-    description = 'Run knes-agent v2 (PDF architecture)'
+    description = 'Run knes-agent v2 (Cartographer/Advisor/Executor/Reviewer)'
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'knes.agent.v2.MainKt'
     standardInput = System.in

--- a/knes-agent/build.gradle
+++ b/knes-agent/build.gradle
@@ -66,3 +66,14 @@ tasks.register('runExplorer', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     standardInput = System.in
 }
+
+tasks.register('runV2', JavaExec) {
+    group = 'application'
+    description = 'Run knes-agent v2 (PDF architecture)'
+    classpath = sourceSets.main.runtimeClasspath
+    mainClass = 'knes.agent.v2.MainKt'
+    standardInput = System.in
+    if (project.hasProperty('appArgs')) {
+        args(project.property('appArgs').toString().split(' '))
+    }
+}

--- a/knes-agent/src/main/kotlin/knes/agent/perception/FogOfWar.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/perception/FogOfWar.kt
@@ -42,4 +42,11 @@ class FogOfWar {
         val ys = seen.keys.map { it.second }
         return (xs.min() to ys.min()) to (xs.max() to ys.max())
     }
+
+    /**
+     * V2 Cartographer frontier check. First-cut stub returns false — forces
+     * Cartographer to continue exploring until its time/vision-call budget
+     * is exhausted. Refine with a fog-coverage heuristic in follow-up.
+     */
+    fun allReachableKnown(from: Pair<Int, Int>): Boolean = false
 }

--- a/knes-agent/src/main/kotlin/knes/agent/v2/Main.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/Main.kt
@@ -2,6 +2,7 @@ package knes.agent.v2
 
 fun main(args: Array<String>) {
     val cfg = V2Config.parse(args)
+    // TODO(C1): redact key fields from this log line once GeminiPro31Client config lands.
     System.err.println("[v2.main] config=$cfg")
     System.err.println("[v2.main] not yet implemented")
 }

--- a/knes-agent/src/main/kotlin/knes/agent/v2/Main.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/Main.kt
@@ -1,0 +1,7 @@
+package knes.agent.v2
+
+fun main(args: Array<String>) {
+    val cfg = V2Config.parse(args)
+    System.err.println("[v2.main] config=$cfg")
+    System.err.println("[v2.main] not yet implemented")
+}

--- a/knes-agent/src/main/kotlin/knes/agent/v2/Main.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/Main.kt
@@ -1,12 +1,94 @@
 package knes.agent.v2
 
+import knes.agent.llm.AnthropicSession
+import knes.agent.perception.FogOfWar
+import knes.agent.perception.InteriorMapLoader
+import knes.agent.perception.LandmarkMemory
+import knes.agent.perception.MapSession
+import knes.agent.perception.OverworldMap
+import knes.agent.skills.BuyAtShop
+import knes.agent.skills.EquipWeapon
+import knes.agent.skills.ExitInterior
+import knes.agent.skills.RestAtInn
+import knes.agent.skills.WalkOverworldTo
+import knes.agent.tools.EmulatorToolset
+import knes.agent.v2.agents.AdvisorAgent
+import knes.agent.v2.agents.CartographerAgent
+import knes.agent.v2.agents.ExecutorAgent
+import knes.agent.v2.agents.ReviewerAgent
+import knes.agent.v2.llm.GeminiPro31Client
+import knes.agent.v2.llm.HaikuClient
+import knes.agent.v2.llm.SonnetClient
+import knes.agent.v2.runtime.SnapshotDumper
+import knes.agent.v2.runtime.V2Memory
 import knes.agent.v2.runtime.V2RunDirectory
+import knes.agent.v2.runtime.Watchdog
+import knes.agent.v2.tools.DefaultToolSurface
+import knes.api.EmulatorSession
+import kotlinx.coroutines.runBlocking
+import java.io.File
 
 fun main(args: Array<String>) {
     val cfg = V2Config.parse(args)
     // TODO(C1): redact key fields from this log line once GeminiPro31Client config lands.
     System.err.println("[v2.main] config=$cfg")
+    val anthropicKey = System.getenv("ANTHROPIC_API_KEY")?.takeIf { it.isNotBlank() }
+        ?: error("ANTHROPIC_API_KEY not set")
+    val geminiKey = System.getenv("GEMINI_API_KEY")?.takeIf { it.isNotBlank() }
+        ?: error("GEMINI_API_KEY not set (Gemini 3.1 Pro required for v2)")
+
     val run = if (cfg.resumeDir != null) V2RunDirectory.resume(cfg.resumeDir)
              else V2RunDirectory.freshRun()
     System.err.println("[v2.main] run dir: ${run.root}")
+
+    runBlocking {
+        AnthropicSession(anthropicKey).use { anthropic ->
+            GeminiPro31Client(geminiKey).use { gemini ->
+                val session = EmulatorSession()
+                val toolset = EmulatorToolset(session)
+                require(toolset.loadRom(cfg.rom).ok) { "Failed to load ROM: ${cfg.rom}" }
+                require(toolset.applyProfile(cfg.profile).ok) { "Failed to apply profile: ${cfg.profile}" }
+
+                // Perception (shared with v1)
+                val overworldMap = OverworldMap.fromRom(File(cfg.rom))
+                val fog = FogOfWar()
+                val mapSession = MapSession(InteriorMapLoader(File(cfg.rom).readBytes()), fog)
+                val landmarks = LandmarkMemory()
+
+                // v2 runtime
+                val memory = V2Memory(run)
+                val snapshotDumper = SnapshotDumper(toolset, run)
+                val watchdog = Watchdog()
+
+                // Wire macros (v1 skills) — wired as plain instances, see v1 Main for full constructor args
+                val walkOverworld = WalkOverworldTo(toolset, overworldMap, fog, knes.agent.pathfinding.ViewportPathfinder(), knes.agent.runtime.ToolCallLog())
+                val exitInterior = ExitInterior(toolset, mapSession, fog,
+                    knes.agent.pathfinding.InteriorPathfinder(memory = knes.agent.perception.InteriorMemory(), mapIdProvider = { toolset.getState().ram["currentMapId"] ?: -1 }),
+                    knes.agent.runtime.ToolCallLog(), knes.agent.perception.InteriorMemory())
+                // BuyAtShop / EquipWeapon / RestAtInn full constructor args mirror v1 Main wiring — for first
+                // cut leave as null guards; ToolSurface placeholder paths still return Reject. Promote to
+                // real wiring in D3 after Smoke 0 confirms baseline.
+                val tools = DefaultToolSurface(
+                    toolset = toolset,
+                    phaseProvider = { knes.agent.v2.runtime.Phase.fromRam(toolset.getState().ram) },
+                    walkOverworld = walkOverworld,
+                    exitInterior = exitInterior,
+                    buyAtShopSkill = TODO("wire in D3"),
+                    equipWeaponSkill = TODO("wire in D3"),
+                    restAtInnSkill = TODO("wire in D3"),
+                )
+
+                // Agents
+                val advisor = AdvisorAgent(gemini, memory, run)
+                val executor = ExecutorAgent(anthropic, SonnetClient(anthropic), tools, memory)
+                val reviewer = ReviewerAgent(HaikuClient(anthropic), memory)
+                val cartographer = CartographerAgent(
+                    gemini, toolset, memory, snapshotDumper, overworldMap, fog, landmarks,
+                    cfg.cartographerBudgetSeconds, cfg.cartographerMaxVisionCalls,
+                )
+
+                System.err.println("[v2.main] bootstrap complete — campaign loop in D2")
+            }
+        }
+    }
 }

--- a/knes-agent/src/main/kotlin/knes/agent/v2/Main.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/Main.kt
@@ -1,8 +1,12 @@
 package knes.agent.v2
 
+import knes.agent.v2.runtime.V2RunDirectory
+
 fun main(args: Array<String>) {
     val cfg = V2Config.parse(args)
     // TODO(C1): redact key fields from this log line once GeminiPro31Client config lands.
     System.err.println("[v2.main] config=$cfg")
-    System.err.println("[v2.main] not yet implemented")
+    val run = if (cfg.resumeDir != null) V2RunDirectory.resume(cfg.resumeDir)
+             else V2RunDirectory.freshRun()
+    System.err.println("[v2.main] run dir: ${run.root}")
 }

--- a/knes-agent/src/main/kotlin/knes/agent/v2/Main.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/Main.kt
@@ -91,6 +91,13 @@ fun main(args: Array<String>) {
                 // Phase 0: bootstrap
                 val firstTurn = memory.campaign.lastTurn + 1
                 if (cfg.fresh) {
+                    // Pre-cartographer: deterministically press through title → party creation → overworld.
+                    // Cartographer needs a party sprite on-screen to do locate-party-first vision.
+                    System.err.println("[v2.main] pressStartUntilOverworld …")
+                    val bootResult = knes.agent.skills.PressStartUntilOverworld(toolset)
+                        .invoke(mapOf("maxAttempts" to "60"))
+                    System.err.println("[v2.main] boot → ${bootResult.message}")
+                    require(bootResult.ok) { "PressStartUntilOverworld failed: ${bootResult.message}" }
                     cartographer.exploreInitialOverworld()
                     snapshotDumper.dump(0)
                     val snap0 = toolset.getScreen().base64

--- a/knes-agent/src/main/kotlin/knes/agent/v2/Main.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/Main.kt
@@ -19,6 +19,7 @@ import knes.agent.v2.agents.ReviewerAgent
 import knes.agent.v2.llm.GeminiPro31Client
 import knes.agent.v2.llm.HaikuClient
 import knes.agent.v2.llm.SonnetClient
+import knes.agent.v2.runtime.Resumer
 import knes.agent.v2.runtime.SnapshotDumper
 import knes.agent.v2.runtime.V2Memory
 import knes.agent.v2.runtime.V2RunDirectory
@@ -57,6 +58,7 @@ fun main(args: Array<String>) {
 
                 // v2 runtime
                 val memory = V2Memory(run)
+                if (cfg.resumeDir != null) Resumer(session, run, memory).resume()
                 val snapshotDumper = SnapshotDumper(toolset, run)
                 val watchdog = Watchdog()
 

--- a/knes-agent/src/main/kotlin/knes/agent/v2/Main.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/Main.kt
@@ -67,17 +67,16 @@ fun main(args: Array<String>) {
                 val exitInterior = ExitInterior(toolset, mapSession, fog,
                     knes.agent.pathfinding.InteriorPathfinder(memory = knes.agent.perception.InteriorMemory(), mapIdProvider = { toolset.getState().ram["currentMapId"] ?: -1 }),
                     knes.agent.runtime.ToolCallLog(), knes.agent.perception.InteriorMemory())
-                // BuyAtShop / EquipWeapon / RestAtInn full constructor args mirror v1 Main wiring — for first
-                // cut leave as null guards; ToolSurface placeholder paths still return Reject. Promote to
-                // real wiring in D3 after Smoke 0 confirms baseline.
+                // Macros: v1 skills (BuyAtShop V5.45 vision-advisor, EquipWeapon, RestAtInn).
+                // EquipWeapon has a known MenuStuck bug — see spec section 13.
                 val tools = DefaultToolSurface(
                     toolset = toolset,
                     phaseProvider = { knes.agent.v2.runtime.Phase.fromRam(toolset.getState().ram) },
                     walkOverworld = walkOverworld,
                     exitInterior = exitInterior,
-                    buyAtShopSkill = TODO("wire in D3"),
-                    equipWeaponSkill = TODO("wire in D3"),
-                    restAtInnSkill = TODO("wire in D3"),
+                    buyAtShopSkill = BuyAtShop(toolset, landmarks),
+                    equipWeaponSkill = EquipWeapon(toolset),
+                    restAtInnSkill = RestAtInn(toolset),
                 )
 
                 // Agents

--- a/knes-agent/src/main/kotlin/knes/agent/v2/Main.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/Main.kt
@@ -88,7 +88,86 @@ fun main(args: Array<String>) {
                     cfg.cartographerBudgetSeconds, cfg.cartographerMaxVisionCalls,
                 )
 
-                System.err.println("[v2.main] bootstrap complete — campaign loop in D2")
+                // Phase 0: bootstrap
+                val firstTurn = memory.campaign.lastTurn + 1
+                if (cfg.fresh) {
+                    cartographer.exploreInitialOverworld()
+                    snapshotDumper.dump(0)
+                    val snap0 = toolset.getScreen().base64
+                    advisor.plan(reason = "T0 fresh campaign", screenshotB64 = snap0, turn = firstTurn)
+                } else {
+                    val snap = toolset.getScreen().base64
+                    advisor.plan(reason = "resume context", screenshotB64 = snap, turn = firstTurn)
+                }
+
+                // Phase 1: campaign loop
+                val recentExecutorOutcomes = ArrayDeque<String>(4)
+                var turn = firstTurn
+                while (turn <= cfg.maxTurns && !memory.campaign.done) {
+                    val snap = toolset.getScreen().base64
+                    snapshotDumper.dump(turn)
+                    val state = toolset.getState()
+                    val phase = knes.agent.v2.runtime.Phase.fromRam(state.ram)
+                    val ramDigest = state.ram.entries.joinToString(",") { "${it.key}=${it.value}" }
+
+                    val decision = executor.act(screenshotB64 = snap, ramDigest = ramDigest)
+
+                    val outcomeLabel = decision.outcome.javaClass.simpleName
+                    recentExecutorOutcomes.addLast(outcomeLabel)
+                    if (recentExecutorOutcomes.size > 4) recentExecutorOutcomes.removeFirst()
+
+                    val ramHash = state.ram.values.fold(0) { acc, v -> 31 * acc + v }
+                    val skillProgress = decision.outcome is knes.agent.v2.tools.ToolOutcome.Ok
+                    watchdog.observe(phase, ramHash, skillProgress)
+
+                    memory.appendTurn(
+                        knes.agent.v2.runtime.TurnLog(
+                            turn = turn,
+                            frame = state.frame.toLong(),
+                            phase = phase.name,
+                            ram = state.ram,
+                            snapshot = "snapshots/turn-%05d.png".format(turn),
+                            executor = knes.agent.v2.runtime.ExecutorTrace(
+                                model = SonnetClient(anthropic).modelId,
+                                tool = decision.tool,
+                                args = decision.args,
+                                reasoningSummary = decision.reasoning,
+                                outcome = outcomeLabel.lowercase(),
+                                message = (decision.outcome as? knes.agent.v2.tools.ToolOutcome.Ok)?.message
+                                    ?: (decision.outcome as? knes.agent.v2.tools.ToolOutcome.Fail)?.message
+                                    ?: (decision.outcome as? knes.agent.v2.tools.ToolOutcome.Reject)?.reason,
+                                ms = decision.ms,
+                            ),
+                            watchdog = knes.agent.v2.runtime.WatchdogTrace(
+                                stuckCounter = watchdog.counter(),
+                                threshold = watchdog.threshold(phase),
+                            ),
+                        )
+                    )
+
+                    if (watchdog.stuckSignal(phase)) {
+                        System.err.println("[v2.main] stuck-signal — ${watchdog.diagnose(phase, recentExecutorOutcomes.toList())}")
+                        advisor.plan(
+                            reason = "stuck: ${watchdog.diagnose(phase, recentExecutorOutcomes.toList())}",
+                            screenshotB64 = snap, turn = turn,
+                        )
+                        watchdog.reset()
+                    }
+
+                    if (turn % 50 == 0) {
+                        reviewer.audit(turn)
+                    }
+
+                    if (turn % 100 == 0) {
+                        val saveBytes = session.saveState()
+                        java.nio.file.Files.write(run.savestate(turn), saveBytes)
+                        System.err.println("[v2.main] checkpoint saved at T$turn (${saveBytes.size} bytes)")
+                    }
+
+                    turn++
+                }
+
+                System.err.println("[v2.main] done. last_turn=${memory.campaign.lastTurn}")
             }
         }
     }

--- a/knes-agent/src/main/kotlin/knes/agent/v2/V2Config.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/V2Config.kt
@@ -2,6 +2,7 @@ package knes.agent.v2
 
 import java.nio.file.Path
 
+/** CLI config for runV2. API keys (ANTHROPIC_API_KEY, GEMINI_API_KEY) are read from env in Main, not parsed here. */
 data class V2Config(
     val rom: String,
     val profile: String,

--- a/knes-agent/src/main/kotlin/knes/agent/v2/V2Config.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/V2Config.kt
@@ -1,0 +1,30 @@
+package knes.agent.v2
+
+import java.nio.file.Path
+
+data class V2Config(
+    val rom: String,
+    val profile: String,
+    val resumeDir: Path?,
+    val fresh: Boolean,
+    val maxTurns: Int,
+    val cartographerBudgetSeconds: Int,
+    val cartographerMaxVisionCalls: Int,
+) {
+    companion object {
+        fun parse(args: Array<String>): V2Config {
+            fun arg(prefix: String) = args.firstOrNull { it.startsWith(prefix) }?.removePrefix(prefix)
+            val resume = arg("--resume=")?.let(Path::of)
+            val fresh = args.contains("--fresh") || resume == null
+            return V2Config(
+                rom = arg("--rom=") ?: "roms/ff.nes",
+                profile = arg("--profile=") ?: "ff1",
+                resumeDir = resume,
+                fresh = fresh,
+                maxTurns = arg("--max-turns=")?.toInt() ?: 5000,
+                cartographerBudgetSeconds = arg("--cart-seconds=")?.toInt() ?: 600,
+                cartographerMaxVisionCalls = arg("--cart-vision-calls=")?.toInt() ?: 60,
+            )
+        }
+    }
+}

--- a/knes-agent/src/main/kotlin/knes/agent/v2/agents/AdvisorAgent.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/agents/AdvisorAgent.kt
@@ -57,9 +57,25 @@ class AdvisorAgent(
     """.trimIndent()
 
     private fun parsePlan(raw: String, milestone: String, turn: Int): Plan {
-        val jsonText = raw.substringAfter("{").let { "{$it" }.substringBeforeLast("}") + "}"
-        val parsed = kotlinx.serialization.json.Json { ignoreUnknownKeys = true }
-            .decodeFromString(PlanWire.serializer(), jsonText)
+        // Gemini often wraps JSON in ```json ... ``` fences or includes preamble text.
+        // Robust extraction: strip fences, then take substring between first `{` and last `}`.
+        val stripped = raw
+            .replace(Regex("```(?:json)?\\s*", RegexOption.IGNORE_CASE), "")
+            .replace("```", "")
+        val firstBrace = stripped.indexOf('{')
+        val lastBrace = stripped.lastIndexOf('}')
+        if (firstBrace < 0 || lastBrace < firstBrace) {
+            System.err.println("[v2.advisor] no JSON braces in response (first 300 chars): ${raw.take(300)}")
+            throw IllegalStateException("Advisor: no JSON object in Gemini response")
+        }
+        val jsonText = stripped.substring(firstBrace, lastBrace + 1)
+        val parsed = try {
+            kotlinx.serialization.json.Json { ignoreUnknownKeys = true }
+                .decodeFromString(PlanWire.serializer(), jsonText)
+        } catch (e: Exception) {
+            System.err.println("[v2.advisor] JSON parse failed; extracted=${jsonText.take(500)}")
+            throw e
+        }
         return Plan(
             createdAtTurn = turn,
             milestone = milestone,

--- a/knes-agent/src/main/kotlin/knes/agent/v2/agents/AdvisorAgent.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/agents/AdvisorAgent.kt
@@ -1,0 +1,80 @@
+package knes.agent.v2.agents
+
+import knes.agent.v2.llm.GeminiPro31Client
+import knes.agent.v2.runtime.Plan
+import knes.agent.v2.runtime.PlanEntry
+import knes.agent.v2.runtime.PlanStep
+import knes.agent.v2.runtime.V2Memory
+import knes.agent.v2.runtime.V2RunDirectory
+
+/**
+ * Advisor writes a numbered plan into current_plan.json and appends a
+ * PlanEntry to campaign.json. Called on T=0, stuck-signal, and phase
+ * boundaries. ~2% of total LLM calls.
+ */
+class AdvisorAgent(
+    private val gemini: GeminiPro31Client,
+    private val memory: V2Memory,
+    private val run: V2RunDirectory,
+) {
+    suspend fun plan(reason: String, screenshotB64: String, turn: Int) {
+        val prompt = buildPrompt(reason)
+        val raw = gemini.generate(prompt, imageB64 = screenshotB64)
+        val plan = parsePlan(raw, milestone = currentMilestone(), turn = turn)
+        memory.setPlan(plan)
+        memory.campaign.plans += PlanEntry(
+            turn = turn, by = "advisor",
+            summary = plan.steps.firstOrNull()?.description ?: "(no steps)",
+            snapshot = "snapshots/turn-%05d.png".format(turn),
+            reason = reason,
+        )
+        memory.saveCampaign()
+        System.err.println("[v2.advisor] turn=$turn reason=$reason steps=${plan.steps.size}")
+    }
+
+    private fun currentMilestone(): String =
+        memory.campaign.milestones.firstOrNull { it.status == "in_progress" }?.id
+            ?: memory.campaign.milestones.firstOrNull { it.status == "pending" }?.id
+            ?: "boot"
+
+    private fun buildPrompt(reason: String): String = """
+        You are the FF1 strategic advisor. Produce a NUMBERED plan (max 8 steps)
+        to advance the current milestone. Respond ONLY with JSON.
+
+        Current milestone: ${currentMilestone()}
+        Trigger reason: $reason
+        Campaign so far: ${memory.campaign.milestones.joinToString { "${it.id}=${it.status}" }}
+        Recent plans: ${memory.campaign.plans.takeLast(3).joinToString("\n") { "T${it.turn}: ${it.summary}" }}
+
+        Output schema:
+        {"steps":[
+          {"index":0,"description":"...","intentTool":"walkTo|interactAt|useMenu|buyAtShop|equipWeapon|restAtInn|battleFightAll","intentArgs":{"x":"15","y":"22"}},
+          ...
+        ]}
+
+        Available tools: walkTo(x,y), interactAt(x,y), useMenu(path), buyAtShop(items,charSlots),
+        equipWeapon(charSlot,weaponSlot), restAtInn(innMapId), battleFightAll().
+    """.trimIndent()
+
+    private fun parsePlan(raw: String, milestone: String, turn: Int): Plan {
+        val jsonText = raw.substringAfter("{").let { "{$it" }.substringBeforeLast("}") + "}"
+        val parsed = kotlinx.serialization.json.Json { ignoreUnknownKeys = true }
+            .decodeFromString(PlanWire.serializer(), jsonText)
+        return Plan(
+            createdAtTurn = turn,
+            milestone = milestone,
+            steps = parsed.steps.mapIndexed { i, s ->
+                PlanStep(i, s.description, s.intentTool, s.intentArgs)
+            },
+        )
+    }
+
+    @kotlinx.serialization.Serializable
+    private data class PlanWire(val steps: List<StepWire>)
+    @kotlinx.serialization.Serializable
+    private data class StepWire(
+        val description: String,
+        val intentTool: String? = null,
+        val intentArgs: Map<String, String>? = null,
+    )
+}

--- a/knes-agent/src/main/kotlin/knes/agent/v2/agents/CartographerAgent.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/agents/CartographerAgent.kt
@@ -1,0 +1,102 @@
+package knes.agent.v2.agents
+
+import knes.agent.perception.FogOfWar
+import knes.agent.perception.LandmarkMemory
+import knes.agent.perception.OverworldMap
+import knes.agent.tools.EmulatorToolset
+import knes.agent.v2.llm.GeminiPro31Client
+import knes.agent.v2.runtime.SnapshotDumper
+import knes.agent.v2.runtime.V2Memory
+
+/**
+ * Online vision exploration phase. Pushes party around spawn using vision-LLM
+ * cardinal hints to fill fog and identify landmarks (innkeeper / weapon shop /
+ * armor shop in Coneria).
+ *
+ * Budget: time + vision-call cap from V2Config. If exceeded, falls back to
+ * static ROM-decoder map only.
+ *
+ * IMPORTANT: vision prompts MUST enforce locate-party → locate-target →
+ * derive-direction (per repo's feedback_locate_party_first.md).
+ */
+class CartographerAgent(
+    private val gemini: GeminiPro31Client,
+    private val toolset: EmulatorToolset,
+    private val memory: V2Memory,
+    private val snapshotDumper: SnapshotDumper,
+    private val overworldMap: OverworldMap,
+    private val fog: FogOfWar,
+    private val landmarks: LandmarkMemory,
+    private val budgetSeconds: Int,
+    private val maxVisionCalls: Int,
+) {
+    suspend fun exploreInitialOverworld() {
+        val started = System.currentTimeMillis()
+        var visionCalls = 0
+        var turnCounter = 0   // Cartographer turns (not yet entered campaign loop)
+
+        System.err.println("[v2.cartographer] start: budget=${budgetSeconds}s maxCalls=$maxVisionCalls")
+
+        while (true) {
+            val elapsed = (System.currentTimeMillis() - started) / 1000
+            if (elapsed > budgetSeconds) { System.err.println("[v2.cartographer] time budget exceeded ($elapsed s)"); break }
+            if (visionCalls >= maxVisionCalls) { System.err.println("[v2.cartographer] vision call cap reached"); break }
+
+            val ram = toolset.getState().ram
+            val worldX = ram["worldX"] ?: 0
+            val worldY = ram["worldY"] ?: 0
+
+            // Fog merge with current viewport (cheap, no LLM).
+            val viewport = overworldMap.readFullMapView(worldX to worldY)
+            fog.merge(viewport)
+
+            // Stop condition: all reachable adjacent tiles known.
+            if (fog.allReachableKnown(worldX to worldY)) {
+                System.err.println("[v2.cartographer] frontier exhausted at ($worldX,$worldY)")
+                break
+            }
+
+            // Ask Gemini for next direction. Enforce locate-party-first contract.
+            val snap = toolset.getScreen().base64
+            val direction = askGeminiNextDirection(snap, worldX, worldY)
+            visionCalls++
+            when (direction.uppercase()) {
+                "N" -> toolset.tap("UP", 1)
+                "S" -> toolset.tap("DOWN", 1)
+                "E" -> toolset.tap("RIGHT", 1)
+                "W" -> toolset.tap("LEFT", 1)
+                "DONE" -> break
+                else -> System.err.println("[v2.cartographer] unexpected dir: $direction")
+            }
+
+            turnCounter++
+            snapshotDumper.dump(-turnCounter)  // negative turns reserved for pre-campaign Cartographer iters
+        }
+
+        // Landmark scans: weapon/armor/inn discovery in Coneria.
+        // For first cut, defer to v1 DiscoverShop/DiscoverInn skills wired in Main.
+        // This method just builds overworld fog. Indoor scans happen lazily during
+        // first Executor visit to each building.
+
+        System.err.println("[v2.cartographer] done: ${visionCalls} vision calls, ${turnCounter} steps")
+    }
+
+    suspend fun targetedRepass(flags: List<String>) {
+        // Triggered by Reviewer when ≥3 inconsistencies flagged. For each flag,
+        // walk to the flagged tile and re-classify with vision.
+        System.err.println("[v2.cartographer] targetedRepass: ${flags.size} flags (stub)")
+    }
+
+    private suspend fun askGeminiNextDirection(snap: String, x: Int, y: Int): String {
+        val prompt = """
+            You are looking at the FF1 NES overworld viewport.
+            Step 1: LOCATE the party sprite on the screen — DO NOT use prior knowledge of FF1 geography.
+            Step 2: From that visual position, identify which cardinal direction (N/S/E/W) leads to the most UNEXPLORED area.
+            Step 3: Return that direction.
+
+            Party world-coords: ($x, $y).
+            Return ONLY the letter: N or S or E or W, or DONE if no unexplored frontier.
+        """.trimIndent()
+        return gemini.generate(prompt, imageB64 = snap).trim().take(4)
+    }
+}

--- a/knes-agent/src/main/kotlin/knes/agent/v2/agents/ExecutorAgent.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/agents/ExecutorAgent.kt
@@ -1,0 +1,88 @@
+package knes.agent.v2.agents
+
+import knes.agent.llm.AnthropicSession
+import knes.agent.v2.llm.SonnetClient
+import knes.agent.v2.runtime.Plan
+import knes.agent.v2.runtime.V2Memory
+import knes.agent.v2.tools.ToolOutcome
+import knes.agent.v2.tools.ToolSurface
+
+data class ExecutorDecision(
+    val tool: String,
+    val args: Map<String, String>,
+    val reasoning: String,
+    val outcome: ToolOutcome,
+    val ms: Long,
+)
+
+/**
+ * Per-turn tool picker. Given current plan + observation (screenshot + RAM
+ * digest), Sonnet 4.6 picks the next tool and arguments. ToolSurface invokes
+ * it; we return the outcome for memory.appendTurn.
+ *
+ * Implementation: for the first cut, prefer the plan's intentTool/intentArgs
+ * verbatim (i.e. trust Advisor). If plan cursor exhausted OR intentTool null
+ * OR last 2 outcomes were Fail/Reject, ask Sonnet via a structured prompt.
+ */
+class ExecutorAgent(
+    private val anthropic: AnthropicSession,
+    private val sonnet: SonnetClient,
+    private val tools: ToolSurface,
+    private val memory: V2Memory,
+) {
+    private val recentOutcomes = ArrayDeque<String>(4)
+
+    suspend fun act(screenshotB64: String, ramDigest: String): ExecutorDecision {
+        val started = System.currentTimeMillis()
+        val plan = memory.currentPlan
+        val step = plan?.steps?.getOrNull(plan.cursor)
+
+        val (tool, args, reasoning) =
+            if (shouldUsePlanHint(step)) {
+                Triple(step!!.intentTool!!, step.intentArgs ?: emptyMap(), "plan step ${step.index}: ${step.description}")
+            } else {
+                askLlm(plan, screenshotB64, ramDigest)
+            }
+
+        val outcome = dispatch(tool, args)
+        recentOutcomes.addLast(outcome.javaClass.simpleName); if (recentOutcomes.size > 4) recentOutcomes.removeFirst()
+        if (outcome is ToolOutcome.Ok && plan != null) advancePlan(plan)
+
+        return ExecutorDecision(tool, args, reasoning, outcome, System.currentTimeMillis() - started)
+    }
+
+    private fun shouldUsePlanHint(step: knes.agent.v2.runtime.PlanStep?): Boolean {
+        if (step == null || step.intentTool == null) return false
+        val recentFails = recentOutcomes.takeLast(2).count { it != "Ok" }
+        return recentFails < 2
+    }
+
+    private suspend fun askLlm(plan: Plan?, screenshotB64: String, ramDigest: String): Triple<String, Map<String, String>, String> {
+        // For first cut, ask anthropic.chat with a structured prompt — wire to the
+        // same channel v1 ExecutorAgent uses. If v1 API is too coupled, fall back
+        // to picking from plan tail or to no-op `useMenu("main/exit")`.
+        // TODO(C3-followup): plug a Koog tool registry so Sonnet can call tools natively.
+        val tail = plan?.steps?.lastOrNull()
+        if (tail?.intentTool != null) return Triple(tail.intentTool, tail.intentArgs ?: emptyMap(), "fallback to plan tail")
+        return Triple("useMenu", mapOf("path" to "main/exit"), "no plan + no LLM wired yet — safe no-op")
+    }
+
+    private suspend fun dispatch(tool: String, args: Map<String, String>): ToolOutcome = when (tool) {
+        "walkTo"          -> tools.walkTo(args.getValue("x").toInt(), args.getValue("y").toInt())
+        "interactAt"      -> tools.interactAt(args.getValue("x").toInt(), args.getValue("y").toInt())
+        "useMenu"         -> tools.useMenu(args.getValue("path"))
+        "buyAtShop"       -> tools.buyAtShop(
+            args.getValue("items").split(",").map { it.toInt() },
+            args.getValue("charSlots").split(",").map { it.toInt() },
+        )
+        "equipWeapon"     -> tools.equipWeapon(args.getValue("charSlot").toInt(), args.getValue("weaponSlot").toInt())
+        "restAtInn"       -> tools.restAtInn(args.getValue("innMapId"))
+        "battleFightAll"  -> tools.battleFightAll()
+        else              -> ToolOutcome.Reject("unknown tool: $tool")
+    }
+
+    private fun advancePlan(plan: Plan) {
+        val advanced = plan.copy(cursor = (plan.cursor + 1).coerceAtMost(plan.steps.size))
+        memory.setPlan(advanced)
+    }
+}

--- a/knes-agent/src/main/kotlin/knes/agent/v2/agents/ReviewerAgent.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/agents/ReviewerAgent.kt
@@ -1,0 +1,106 @@
+package knes.agent.v2.agents
+
+import knes.agent.v2.llm.HaikuClient
+import knes.agent.v2.runtime.ReviewEntry
+import knes.agent.v2.runtime.V2Memory
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.nio.file.Files
+
+class ReviewerAgent(
+    private val haiku: HaikuClient,
+    private val memory: V2Memory,
+) {
+    private val json = Json { ignoreUnknownKeys = true; prettyPrint = false }
+
+    /**
+     * Read entire Memory (Campaign + on-disk landmarks/warps/blockages),
+     * ask Haiku for audit issues, parse JSON, apply REMOVE actions, append
+     * FLAG actions to cartographer-flags.json.
+     *
+     * Safety:
+     *   - Every action appended to review.jsonl BEFORE mutation.
+     *   - Only `remove_stale` mutates Memory files.
+     *   - `flag_for_cartographer` only writes to cartographer-flags.json.
+     */
+    suspend fun audit(turn: Int) {
+        val memoryDigest = digestMemory()
+        val prompt = """
+            You are the FF1 Memory auditor. Identify issues with the following game memory.
+            Return ONLY JSON: {"actions":[{"kind":"remove_stale|flag_for_cartographer","entry":"...","reason":"..."}]}
+
+            Memory digest:
+            $memoryDigest
+
+            Rules:
+            - remove_stale: entry hasn't been referenced in plans/recent decisions OR is older than 50 turns OR contradicts ground truth
+            - flag_for_cartographer: inconsistency between two ground-truth artifacts (e.g. blockage at a tile that terrain says walkable)
+            - Never invent entries. Only reference what's in the digest.
+            - Empty actions list is fine if Memory is clean.
+        """.trimIndent()
+
+        // For first cut, use a simple chat invocation through v1 AnthropicSession
+        // (HaikuClient currently only holds the modelId; full integration in followup task)
+        val response = invokeHaiku(prompt)
+        val parsed = json.decodeFromString(AuditWire.serializer(), extractJson(response))
+
+        val removed = mutableListOf<String>()
+        val flagged = mutableListOf<String>()
+        for (a in parsed.actions) {
+            val line = json.encodeToString(AuditAction.serializer(),
+                AuditAction(turn = turn, kind = a.kind, entry = a.entry, reason = a.reason))
+            memory.appendReviewLine(line)
+            when (a.kind) {
+                "remove_stale" -> { applyRemove(a.entry); removed += a.entry }
+                "flag_for_cartographer" -> { appendCartographerFlag(a.entry, a.reason); flagged += a.entry }
+                else -> System.err.println("[v2.reviewer] unknown action kind: ${a.kind}")
+            }
+        }
+
+        memory.campaign.reviews += ReviewEntry(turn = turn, removed = removed, flagged = flagged)
+        memory.saveCampaign()
+        System.err.println("[v2.reviewer] turn=$turn removed=${removed.size} flagged=${flagged.size}")
+    }
+
+    private fun digestMemory(): String {
+        val campaignJson = Files.readString(memory.run.campaignJson)
+        val landmarks = if (memory.run.landmarksJson.toFile().exists()) Files.readString(memory.run.landmarksJson) else "{}"
+        val warps = if (memory.run.warpsJson.toFile().exists()) Files.readString(memory.run.warpsJson) else "{}"
+        val blockages = if (memory.run.blockagesJson.toFile().exists()) Files.readString(memory.run.blockagesJson) else "{}"
+        return "campaign:$campaignJson\nlandmarks:$landmarks\nwarps:$warps\nblockages:$blockages"
+    }
+
+    private fun applyRemove(entry: String) {
+        // entry format: "landmarks:KEY" | "warps:KEY" | "blockages:(x,y)"
+        // For first cut just log — full mutation wired in followup once landmark
+        // JSON schemas are stable.
+        System.err.println("[v2.reviewer] would remove: $entry")
+    }
+
+    private fun appendCartographerFlag(entry: String, reason: String) {
+        val path = memory.run.cartographerFlagsJson
+        val existing = if (path.toFile().exists()) Files.readString(path) else "[]"
+        val list = json.parseToJsonElement(existing).toString().trimEnd(']') +
+                   (if (existing.trim() == "[]") "" else ",") +
+                   """{"entry":"$entry","reason":"$reason"}]"""
+        Files.writeString(path, list)
+    }
+
+    private suspend fun invokeHaiku(prompt: String): String {
+        // Placeholder — Wire AnthropicSession.send with model=haiku in Task D2.
+        return """{"actions":[]}"""
+    }
+
+    private fun extractJson(raw: String): String =
+        raw.substringAfter("{").let { "{$it" }.substringBeforeLast("}") + "}"
+
+    @Serializable
+    private data class AuditWire(val actions: List<AuditAction>)
+    @Serializable
+    private data class AuditAction(
+        val turn: Int = 0,
+        val kind: String,
+        val entry: String,
+        val reason: String,
+    )
+}

--- a/knes-agent/src/main/kotlin/knes/agent/v2/llm/GeminiPro31Client.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/llm/GeminiPro31Client.kt
@@ -1,0 +1,55 @@
+package knes.agent.v2.llm
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Minimal Gemini 3.1 Pro client for v2 agents. Sends a text+image prompt,
+ * returns model text. Reuses HTTP wiring style from v1 GeminiVisionConsult.
+ */
+class GeminiPro31Client(private val apiKey: String) : AutoCloseable {
+    private val http = HttpClient(CIO)
+    private val json = Json { ignoreUnknownKeys = true }
+    private val model = "gemini-3.1-pro"
+
+    suspend fun generate(prompt: String, imageB64: String? = null): String {
+        val parts = buildList<JsonObject> {
+            add(JsonObject(mapOf("text" to kotlinx.serialization.json.JsonPrimitive(prompt))))
+            if (imageB64 != null) {
+                add(JsonObject(mapOf("inline_data" to JsonObject(mapOf(
+                    "mime_type" to kotlinx.serialization.json.JsonPrimitive("image/png"),
+                    "data" to kotlinx.serialization.json.JsonPrimitive(imageB64),
+                )))))
+            }
+        }
+        val body = buildString {
+            append("""{"contents":[{"parts":""")
+            append(json.encodeToString(kotlinx.serialization.builtins.ListSerializer(JsonObject.serializer()), parts))
+            append("}]}")
+        }
+        val url = "https://generativelanguage.googleapis.com/v1beta/models/$model:generateContent?key=$apiKey"
+        val resp = http.post(url) {
+            contentType(ContentType.Application.Json)
+            setBody(body)
+        }.bodyAsText()
+        val candidates = json.parseToJsonElement(resp).jsonObject["candidates"]?.jsonArray
+        return candidates?.firstOrNull()?.jsonObject
+            ?.get("content")?.jsonObject
+            ?.get("parts")?.jsonArray
+            ?.firstOrNull()?.jsonObject
+            ?.get("text")?.jsonPrimitive?.content
+            ?: throw RuntimeException("Gemini response unparseable: ${resp.take(500)}")
+    }
+
+    override fun close() { http.close() }
+}

--- a/knes-agent/src/main/kotlin/knes/agent/v2/llm/GeminiPro31Client.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/llm/GeminiPro31Client.kt
@@ -23,7 +23,9 @@ class GeminiPro31Client(private val apiKey: String) : AutoCloseable {
         install(HttpTimeout) { requestTimeoutMillis = 120_000 }
     }
     private val json = Json { ignoreUnknownKeys = true }
-    private val model = "gemini-3.1-pro-preview"
+    // 2026-05-12: switched from gemini-3.1-pro-preview → gemini-2.5-pro after Smoke 0 timeouts.
+    // Preview model >2min latency on vision calls; 2.5 Pro is what v1 uses with 60s timeout reliably.
+    private val model = "gemini-2.5-pro"
 
     suspend fun generate(prompt: String, imageB64: String? = null): String {
         val parts = buildList<JsonObject> {

--- a/knes-agent/src/main/kotlin/knes/agent/v2/llm/GeminiPro31Client.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/llm/GeminiPro31Client.kt
@@ -20,7 +20,7 @@ import kotlinx.serialization.json.jsonPrimitive
 class GeminiPro31Client(private val apiKey: String) : AutoCloseable {
     private val http = HttpClient(CIO)
     private val json = Json { ignoreUnknownKeys = true }
-    private val model = "gemini-3.1-pro"
+    private val model = "gemini-3.1-pro-preview"
 
     suspend fun generate(prompt: String, imageB64: String? = null): String {
         val parts = buildList<JsonObject> {

--- a/knes-agent/src/main/kotlin/knes/agent/v2/llm/GeminiPro31Client.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/llm/GeminiPro31Client.kt
@@ -2,6 +2,7 @@ package knes.agent.v2.llm
 
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
@@ -18,7 +19,9 @@ import kotlinx.serialization.json.jsonPrimitive
  * returns model text. Reuses HTTP wiring style from v1 GeminiVisionConsult.
  */
 class GeminiPro31Client(private val apiKey: String) : AutoCloseable {
-    private val http = HttpClient(CIO)
+    private val http = HttpClient(CIO) {
+        install(HttpTimeout) { requestTimeoutMillis = 120_000 }
+    }
     private val json = Json { ignoreUnknownKeys = true }
     private val model = "gemini-3.1-pro-preview"
 

--- a/knes-agent/src/main/kotlin/knes/agent/v2/llm/HaikuClient.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/llm/HaikuClient.kt
@@ -1,0 +1,7 @@
+package knes.agent.v2.llm
+
+import knes.agent.llm.AnthropicSession
+
+class HaikuClient(private val anthropic: AnthropicSession) {
+    val modelId = "claude-haiku-4-5-20251001"
+}

--- a/knes-agent/src/main/kotlin/knes/agent/v2/llm/SonnetClient.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/llm/SonnetClient.kt
@@ -1,0 +1,12 @@
+package knes.agent.v2.llm
+
+import knes.agent.llm.AnthropicSession
+
+class SonnetClient(private val anthropic: AnthropicSession) {
+    val modelId = "claude-sonnet-4-6"
+    /**
+     * Thin call site. The real agent loop in ExecutorAgent will use Koog's
+     * tool calling on this model. For simple ask/answer fall through to
+     * anthropic.chat() (whatever the v1 API exposes) — wired in Task C3.
+     */
+}

--- a/knes-agent/src/main/kotlin/knes/agent/v2/runtime/Campaign.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/runtime/Campaign.kt
@@ -1,0 +1,39 @@
+package knes.agent.v2.runtime
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Campaign(
+    val startedAt: String,
+    val scope: String,
+    val milestones: MutableList<Milestone> = mutableListOf(),
+    val plans: MutableList<PlanEntry> = mutableListOf(),
+    val reviews: MutableList<ReviewEntry> = mutableListOf(),
+    var lastTurn: Int = 0,
+    var done: Boolean = false,
+)
+
+@Serializable
+data class Milestone(
+    val id: String,
+    var status: String,        // "pending" | "in_progress" | "done"
+    var turnStart: Int? = null,
+    var turnEnd: Int? = null,
+    var planStep: Int? = null,
+)
+
+@Serializable
+data class PlanEntry(
+    val turn: Int,
+    val by: String,             // "advisor"
+    val summary: String,
+    val snapshot: String,       // relative path
+    val reason: String? = null, // "stuck-signal" | "T0 fresh" | ...
+)
+
+@Serializable
+data class ReviewEntry(
+    val turn: Int,
+    val removed: List<String>,
+    val flagged: List<String>,
+)

--- a/knes-agent/src/main/kotlin/knes/agent/v2/runtime/Phase.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/runtime/Phase.kt
@@ -1,0 +1,30 @@
+package knes.agent.v2.runtime
+
+enum class Phase {
+    Boot, Overworld, Indoors, Battle, MenuStuck,
+    Dialog, BattleMessage, Cutscene, CartographerExplore;
+
+    companion object {
+        /**
+         * Classify from RAM. Reuses v1 phase markers; CartographerExplore is
+         * set explicitly by Cartographer agent — never inferred here.
+         */
+        fun fromRam(ram: Map<String, Int>): Phase {
+            val mapId = ram["currentMapId"] ?: -1
+            val mapflags = ram["mapflags"] ?: 0
+            val battleInProgress = (ram["battleState"] ?: 0) != 0
+            val menuState = ram["menuState"] ?: 0
+            val party = (ram["char1_hpLow"] ?: 0) != 0 || (ram["worldX"] ?: 0) != 0
+            return when {
+                !party -> Boot
+                battleInProgress -> Battle
+                menuState != 0 -> MenuStuck
+                mapId == 0 && (mapflags and 1) == 0 -> Overworld
+                else -> Indoors
+            }
+        }
+    }
+}
+
+/** RAM fields stable across phase whitelist (used by Watchdog for "static is OK"). */
+val PHASE_STATIC_WHITELIST: Set<Phase> = setOf(Phase.Dialog, Phase.BattleMessage, Phase.Cutscene)

--- a/knes-agent/src/main/kotlin/knes/agent/v2/runtime/Plan.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/runtime/Plan.kt
@@ -1,0 +1,19 @@
+package knes.agent.v2.runtime
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Plan(
+    val createdAtTurn: Int,
+    val milestone: String,
+    val steps: List<PlanStep>,
+    var cursor: Int = 0,        // index of current step
+)
+
+@Serializable
+data class PlanStep(
+    val index: Int,
+    val description: String,
+    val intentTool: String? = null,   // optional hint, e.g. "walkTo"
+    val intentArgs: Map<String, String>? = null,
+)

--- a/knes-agent/src/main/kotlin/knes/agent/v2/runtime/Resumer.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/runtime/Resumer.kt
@@ -1,0 +1,34 @@
+package knes.agent.v2.runtime
+
+import knes.api.EmulatorSession
+import java.nio.file.Files
+
+class Resumer(
+    private val session: EmulatorSession,
+    private val run: V2RunDirectory,
+    private val memory: V2Memory,
+) {
+    fun resume() {
+        val lastTurn = memory.campaign.lastTurn
+        if (lastTurn == 0) {
+            System.err.println("[v2.resume] lastTurn=0 — nothing to resume; running fresh")
+            return
+        }
+        val checkpointTurn = (lastTurn / 100) * 100
+        val checkpoint = run.savestate(checkpointTurn)
+        if (!checkpoint.toFile().exists()) {
+            System.err.println("[v2.resume] WARN: no checkpoint at T$checkpointTurn — starting from emulator boot. " +
+                "Decision replay from T1 not implemented; advisor will plan from observed RAM.")
+            return
+        }
+        // PPU pre-warm (per v1 Main.kt:81-83)
+        session.advanceFrames(120)
+        val ok = session.loadState(Files.readAllBytes(checkpoint))
+        require(ok) { "loadState failed for $checkpoint" }
+        session.advanceFrames(120)
+        System.err.println("[v2.resume] restored T$checkpointTurn (last_turn=$lastTurn). " +
+            "Replay from T$checkpointTurn to T$lastTurn not implemented yet — emulator at checkpoint, " +
+            "memory at last_turn — Advisor will reconcile via campaign.json digest.")
+        // TODO(D2-followup): replay button events from decisions/turn-(checkpointTurn+1).json..turn-lastTurn.json
+    }
+}

--- a/knes-agent/src/main/kotlin/knes/agent/v2/runtime/SnapshotDumper.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/runtime/SnapshotDumper.kt
@@ -1,0 +1,19 @@
+package knes.agent.v2.runtime
+
+import knes.agent.tools.EmulatorToolset
+import java.nio.file.Files
+import java.util.Base64
+
+class SnapshotDumper(
+    private val toolset: EmulatorToolset,
+    private val run: V2RunDirectory,
+) {
+    /** Dump per-iter screenshot. Idempotent — overwrites if same turn called twice. */
+    fun dump(turn: Int): String {
+        val b64 = toolset.getScreen().base64
+        val bytes = Base64.getDecoder().decode(b64)
+        val out = run.turnSnapshot(turn)
+        Files.write(out, bytes)
+        return run.root.relativize(out).toString()
+    }
+}

--- a/knes-agent/src/main/kotlin/knes/agent/v2/runtime/TurnLog.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/runtime/TurnLog.kt
@@ -1,0 +1,31 @@
+package knes.agent.v2.runtime
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TurnLog(
+    val turn: Int,
+    val frame: Long,
+    val phase: String,
+    val ram: Map<String, Int>,
+    val snapshot: String,
+    val executor: ExecutorTrace,
+    val watchdog: WatchdogTrace,
+)
+
+@Serializable
+data class ExecutorTrace(
+    val model: String,
+    val tool: String,
+    val args: Map<String, String>,
+    val reasoningSummary: String,
+    val outcome: String,        // "ok" | "fail" | "reject"
+    val message: String? = null,
+    val ms: Long,
+)
+
+@Serializable
+data class WatchdogTrace(
+    val stuckCounter: Int,
+    val threshold: Int,
+)

--- a/knes-agent/src/main/kotlin/knes/agent/v2/runtime/V2Memory.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/runtime/V2Memory.kt
@@ -1,0 +1,66 @@
+package knes.agent.v2.runtime
+
+import kotlinx.serialization.json.Json
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.time.OffsetDateTime
+import kotlin.io.path.exists
+import kotlin.io.path.readText
+
+class V2Memory(val run: V2RunDirectory) {
+    private val json = Json { prettyPrint = true; ignoreUnknownKeys = true; encodeDefaults = true }
+
+    var campaign: Campaign = loadOrInitCampaign()
+        private set
+
+    var currentPlan: Plan? = loadPlanIfExists()
+        private set
+
+    fun saveCampaign() {
+        atomicWrite(run.campaignJson, json.encodeToString(Campaign.serializer(), campaign))
+    }
+
+    fun setPlan(plan: Plan) {
+        currentPlan = plan
+        atomicWrite(run.currentPlanJson, json.encodeToString(Plan.serializer(), plan))
+    }
+
+    fun appendTurn(log: TurnLog) {
+        val out = json.encodeToString(TurnLog.serializer(), log)
+        atomicWrite(run.turnDecisionFile(log.turn), out)
+        campaign.lastTurn = log.turn
+        saveCampaign()
+    }
+
+    fun appendReviewLine(line: String) {
+        Files.writeString(
+            run.reviewJsonl, line + "\n",
+            java.nio.file.StandardOpenOption.CREATE,
+            java.nio.file.StandardOpenOption.APPEND,
+        )
+    }
+
+    private fun loadOrInitCampaign(): Campaign =
+        if (run.campaignJson.exists()) {
+            json.decodeFromString(Campaign.serializer(), run.campaignJson.readText())
+        } else {
+            Campaign(
+                startedAt = OffsetDateTime.now().toString(),
+                scope = "coneria_buy_equip_grind",
+            ).also { c ->
+                atomicWrite(run.campaignJson, json.encodeToString(Campaign.serializer(), c))
+            }
+        }
+
+    private fun loadPlanIfExists(): Plan? =
+        if (run.currentPlanJson.exists()) json.decodeFromString(
+            Plan.serializer(), run.currentPlanJson.readText()
+        ) else null
+
+    private fun atomicWrite(path: Path, content: String) {
+        val tmp = path.resolveSibling(path.fileName.toString() + ".tmp")
+        Files.writeString(tmp, content)
+        Files.move(tmp, path, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
+    }
+}

--- a/knes-agent/src/main/kotlin/knes/agent/v2/runtime/V2RunDirectory.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/runtime/V2RunDirectory.kt
@@ -1,0 +1,72 @@
+package knes.agent.v2.runtime
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.createDirectories
+import kotlin.io.path.deleteIfExists
+import kotlin.io.path.exists
+
+class V2RunDirectory(val root: Path) {
+    val campaignJson: Path = root.resolve("campaign.json")
+    val currentPlanJson: Path = root.resolve("current_plan.json")
+    val landmarksJson: Path = root.resolve("landmarks.json")
+    val warpsJson: Path = root.resolve("warps.json")
+    val blockagesJson: Path = root.resolve("blockages.json")
+    val overworldMapJson: Path = root.resolve("overworld-map.json")
+    val cartographerFlagsJson: Path = root.resolve("cartographer-flags.json")
+    val reviewJsonl: Path = root.resolve("review.jsonl")
+    val decisionsDir: Path = root.resolve("decisions")
+    val snapshotsDir: Path = root.resolve("snapshots")
+    val interiorMapsDir: Path = root.resolve("interior-maps")
+    val savestateDir: Path = root.resolve("savestate-checkpoints")
+
+    fun ensure() {
+        root.createDirectories()
+        decisionsDir.createDirectories()
+        snapshotsDir.createDirectories()
+        interiorMapsDir.createDirectories()
+        savestateDir.createDirectories()
+    }
+
+    fun turnDecisionFile(turn: Int): Path =
+        decisionsDir.resolve("turn-%05d.json".format(turn))
+
+    fun turnSnapshot(turn: Int): Path =
+        snapshotsDir.resolve("turn-%05d.png".format(turn))
+
+    fun savestate(turn: Int): Path =
+        savestateDir.resolve("T%d.nss".format(turn))
+
+    companion object {
+        private val TS_FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd-HHmm")
+        private fun runsRoot(): Path =
+            Path.of(System.getProperty("user.home"), ".knes", "runs")
+
+        fun freshRun(): V2RunDirectory {
+            val ts = LocalDateTime.now().format(TS_FMT)
+            val dir = runsRoot().resolve("$ts-v2")
+            val rd = V2RunDirectory(dir).also { it.ensure() }
+            updateLatestSymlink(dir)
+            return rd
+        }
+
+        fun resume(path: Path): V2RunDirectory {
+            require(path.exists()) { "resume dir does not exist: $path" }
+            return V2RunDirectory(path)
+        }
+
+        private fun updateLatestSymlink(target: Path) {
+            val link = runsRoot().resolve("latest-v2")
+            try {
+                link.deleteIfExists()
+                Files.createSymbolicLink(link, target)
+            } catch (e: Throwable) {
+                System.err.println("[v2.run-dir] WARN: symlink update failed: ${e.message}")
+            }
+        }
+    }
+}

--- a/knes-agent/src/main/kotlin/knes/agent/v2/runtime/Watchdog.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/runtime/Watchdog.kt
@@ -5,7 +5,7 @@ class Watchdog(
     private val staticWhitelist: Set<Phase> = PHASE_STATIC_WHITELIST,
 ) {
     private var stuck = 0
-    private var lastRamHash: Int = 0
+    private var lastRamHash: Int? = null
 
     /**
      * @param phase  current Phase classification
@@ -14,8 +14,12 @@ class Watchdog(
      */
     fun observe(phase: Phase, ramHash: Int, skillProgress: Boolean) {
         if (phase in staticWhitelist) return
-        stuck = if (ramHash == lastRamHash && !skillProgress) stuck + 1 else 0
+        val prev = lastRamHash
         lastRamHash = ramHash
+        if (skillProgress) { stuck = 0; return }
+        // First observation OR same-as-previous → count as static-no-progress.
+        // Change in RAM → reset to 0 (fresh start; next observation may be static again).
+        stuck = if (prev == null || ramHash == prev) stuck + 1 else 0
     }
 
     fun stuckSignal(phase: Phase): Boolean =
@@ -23,7 +27,7 @@ class Watchdog(
 
     fun threshold(phase: Phase): Int = thresholds[phase] ?: 5
     fun counter(): Int = stuck
-    fun reset() { stuck = 0 }
+    fun reset() { stuck = 0; lastRamHash = null }
 
     fun diagnose(phase: Phase, recentOutcomes: List<String>): String =
         "phase=$phase stuck=$stuck/${threshold(phase)} recentOutcomes=${recentOutcomes.takeLast(3)}"

--- a/knes-agent/src/main/kotlin/knes/agent/v2/runtime/Watchdog.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/runtime/Watchdog.kt
@@ -1,0 +1,38 @@
+package knes.agent.v2.runtime
+
+class Watchdog(
+    private val thresholds: Map<Phase, Int> = DEFAULT_THRESHOLDS,
+    private val staticWhitelist: Set<Phase> = PHASE_STATIC_WHITELIST,
+) {
+    private var stuck = 0
+    private var lastRamHash: Int = 0
+
+    /**
+     * @param phase  current Phase classification
+     * @param ramHash hash of watched RAM fields (worldX, worldY, currentMapId, hp..., gold, menuState)
+     * @param skillProgress true if last executor outcome was Ok
+     */
+    fun observe(phase: Phase, ramHash: Int, skillProgress: Boolean) {
+        if (phase in staticWhitelist) return
+        stuck = if (ramHash == lastRamHash && !skillProgress) stuck + 1 else 0
+        lastRamHash = ramHash
+    }
+
+    fun stuckSignal(phase: Phase): Boolean =
+        stuck >= (thresholds[phase] ?: 5)
+
+    fun threshold(phase: Phase): Int = thresholds[phase] ?: 5
+    fun counter(): Int = stuck
+    fun reset() { stuck = 0 }
+
+    fun diagnose(phase: Phase, recentOutcomes: List<String>): String =
+        "phase=$phase stuck=$stuck/${threshold(phase)} recentOutcomes=${recentOutcomes.takeLast(3)}"
+
+    companion object {
+        val DEFAULT_THRESHOLDS: Map<Phase, Int> = mapOf(
+            Phase.Battle to 3, Phase.MenuStuck to 3,
+            Phase.Overworld to 5, Phase.Indoors to 5,
+            Phase.CartographerExplore to 10,
+        )
+    }
+}

--- a/knes-agent/src/main/kotlin/knes/agent/v2/tools/MenuWalker.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/tools/MenuWalker.kt
@@ -1,0 +1,81 @@
+package knes.agent.v2.tools
+
+/**
+ * Parses menu path strings like "main/equip/char1/weapon/0" into a sequence
+ * of NES button taps for the FF1 field menu.
+ *
+ * Path grammar:
+ *   <root> "/" <segment> ("/" <segment>)*
+ *   root := main | shop
+ *   main segments := item|magic|equip|status|exit|char1..char4|weapon|armor|<slot-index>
+ *   shop segments := buy|sell|exit|<item-index>|char1..char4
+ *
+ * The walker emits an ordered list of MenuTap actions; an executor calls
+ * `toolset.tap(button, ...)` for each. MenuWalker itself is pure (no I/O),
+ * tested below.
+ */
+data class MenuTap(val button: String, val count: Int = 1)
+
+class MenuWalker {
+    fun parse(path: String): List<MenuTap> {
+        val segments = path.trim('/').split("/")
+        require(segments.isNotEmpty()) { "empty menu path" }
+        return when (segments[0]) {
+            "main" -> parseMain(segments.drop(1))
+            "shop" -> parseShop(segments.drop(1))
+            else -> throw IllegalArgumentException("unknown menu root: ${segments[0]}")
+        }
+    }
+
+    private fun parseMain(rest: List<String>): List<MenuTap> {
+        val out = mutableListOf<MenuTap>()
+        out += MenuTap("B")    // open field menu
+        if (rest.isEmpty()) return out
+        val top = mapOf("item" to 0, "magic" to 1, "equip" to 2, "status" to 3, "exit" to 4)
+        val idx = top[rest[0]] ?: throw IllegalArgumentException("unknown main item: ${rest[0]}")
+        if (idx > 0) out += MenuTap("DOWN", idx)
+        out += MenuTap("A")
+        // char selector
+        if (rest.size >= 2 && rest[1].startsWith("char")) {
+            val n = rest[1].removePrefix("char").toInt()
+            require(n in 1..4) { "char must be 1..4" }
+            if (n > 1) out += MenuTap("DOWN", n - 1)
+            out += MenuTap("A")
+        }
+        // weapon|armor sub-tab (equip only)
+        if (rest.size >= 3 && (rest[2] == "weapon" || rest[2] == "armor")) {
+            if (rest[2] == "armor") out += MenuTap("RIGHT")
+            // slot
+            if (rest.size >= 4) {
+                val slot = rest[3].toInt()
+                require(slot in 0..3) { "slot must be 0..3" }
+                if (slot > 0) out += MenuTap("DOWN", slot)
+                out += MenuTap("A")
+            }
+        }
+        return out
+    }
+
+    private fun parseShop(rest: List<String>): List<MenuTap> {
+        // BUY/SELL/EXIT menu reached via dialog A-tap by caller
+        val out = mutableListOf<MenuTap>()
+        if (rest.isEmpty()) return out
+        val top = mapOf("buy" to 0, "sell" to 1, "exit" to 2)
+        val idx = top[rest[0]] ?: throw IllegalArgumentException("unknown shop item: ${rest[0]}")
+        if (idx > 0) out += MenuTap("DOWN", idx)
+        out += MenuTap("A")
+        if (rest.size >= 2) {
+            val item = rest[1].toInt()
+            require(item in 0..7) { "shop item must be 0..7" }
+            if (item > 0) out += MenuTap("DOWN", item)
+            out += MenuTap("A")
+        }
+        if (rest.size >= 3 && rest[2].startsWith("char")) {
+            val n = rest[2].removePrefix("char").toInt()
+            require(n in 1..4) { "char must be 1..4" }
+            if (n > 1) out += MenuTap("DOWN", n - 1)
+            out += MenuTap("A")
+        }
+        return out
+    }
+}

--- a/knes-agent/src/main/kotlin/knes/agent/v2/tools/ToolSurface.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/tools/ToolSurface.kt
@@ -28,9 +28,11 @@ interface ToolSurface {
 class DefaultToolSurface(
     private val toolset: EmulatorToolset,
     private val phaseProvider: () -> Phase,
-    // injected v1 skill instances (constructed in Main wiring)
     private val walkOverworld: WalkOverworldTo,
     private val exitInterior: ExitInterior,
+    private val buyAtShopSkill: BuyAtShop,
+    private val equipWeaponSkill: EquipWeapon,
+    private val restAtInnSkill: RestAtInn,
     private val menuWalker: MenuWalker = MenuWalker(),
 ) : ToolSurface {
 
@@ -55,19 +57,30 @@ class DefaultToolSurface(
     }
 
     override suspend fun buyAtShop(items: List<Int>, charSlots: List<Int>): ToolOutcome {
-        // Delegate to v1 BuyAtShop V5.45 via invokeWithAdvisor entry point.
-        // Concrete signature wiring done in Main; here we use a thin lambda.
-        return ToolOutcome.Reject("buyAtShop wiring TBD until Main wires v1 BuyAtShop instance")
-            .also { System.err.println("[v2.tool] buyAtShop placeholder hit — wire in Phase C.") }
+        require(items.size == charSlots.size) { "items.size must equal charSlots.size" }
+        // v1 BuyAtShop V5.45 takes a single (itemSlot, forCharSlot) pair via invoke,
+        // OR a batch via invokeWithAdvisor. Iterate the simple way; macros own their
+        // own per-iter PNG dump and shop-dialog state.
+        val results = mutableListOf<String>()
+        for ((i, c) in items.zip(charSlots)) {
+            val r = buyAtShopSkill.invoke(mapOf(
+                "itemSlot" to "$i", "forCharSlot" to "$c", "expectedKeeperKind" to "weapon",
+            ))
+            results += "i=$i c=$c → ${r.message}"
+            if (!r.ok) return ToolOutcome.Fail("buyAtShop aborted at i=$i c=$c: ${r.message}")
+        }
+        return ToolOutcome.Ok(results.joinToString("; "))
     }
 
     override suspend fun equipWeapon(charSlot: Int, weaponSlot: Int): ToolOutcome {
-        // v1 EquipWeapon known-buggy (MenuStuck). Reuse anyway per spec section 13.
-        return ToolOutcome.Reject("equipWeapon wiring TBD until Main wires v1 instance")
+        val r = equipWeaponSkill.invoke(mapOf("charSlot" to "$charSlot", "weaponSlot" to "$weaponSlot"))
+        return if (r.ok) ToolOutcome.Ok(r.message) else ToolOutcome.Fail(r.message)
     }
 
-    override suspend fun restAtInn(innMapId: String): ToolOutcome =
-        ToolOutcome.Reject("restAtInn wiring TBD")
+    override suspend fun restAtInn(innMapId: String): ToolOutcome {
+        val r = restAtInnSkill.invoke(mapOf("innInteriorMapId" to innMapId))
+        return if (r.ok) ToolOutcome.Ok(r.message) else ToolOutcome.Fail(r.message)
+    }
 
     override suspend fun battleFightAll(): ToolOutcome {
         val r = toolset.executeAction(profileId = "ff1", actionId = "battle_fight_all")

--- a/knes-agent/src/main/kotlin/knes/agent/v2/tools/ToolSurface.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/tools/ToolSurface.kt
@@ -1,0 +1,80 @@
+package knes.agent.v2.tools
+
+import knes.agent.skills.BuyAtShop
+import knes.agent.skills.EquipWeapon
+import knes.agent.skills.RestAtInn
+import knes.agent.skills.SkillResult
+import knes.agent.skills.WalkOverworldTo
+import knes.agent.skills.ExitInterior
+import knes.agent.tools.EmulatorToolset
+import knes.agent.v2.runtime.Phase
+
+sealed class ToolOutcome {
+    data class Ok(val message: String = "", val data: Map<String, String> = emptyMap()) : ToolOutcome()
+    data class Fail(val message: String) : ToolOutcome()
+    data class Reject(val reason: String) : ToolOutcome()
+}
+
+interface ToolSurface {
+    suspend fun walkTo(x: Int, y: Int): ToolOutcome
+    suspend fun interactAt(x: Int, y: Int): ToolOutcome
+    suspend fun useMenu(path: String): ToolOutcome
+    suspend fun buyAtShop(items: List<Int>, charSlots: List<Int>): ToolOutcome
+    suspend fun equipWeapon(charSlot: Int, weaponSlot: Int): ToolOutcome
+    suspend fun restAtInn(innMapId: String): ToolOutcome
+    suspend fun battleFightAll(): ToolOutcome
+}
+
+class DefaultToolSurface(
+    private val toolset: EmulatorToolset,
+    private val phaseProvider: () -> Phase,
+    // injected v1 skill instances (constructed in Main wiring)
+    private val walkOverworld: WalkOverworldTo,
+    private val exitInterior: ExitInterior,
+    private val menuWalker: MenuWalker = MenuWalker(),
+) : ToolSurface {
+
+    override suspend fun walkTo(x: Int, y: Int): ToolOutcome = when (phaseProvider()) {
+        Phase.Overworld -> wrap(walkOverworld.invoke(mapOf("targetX" to "$x", "targetY" to "$y", "maxSteps" to "32")))
+        Phase.Indoors   -> wrap(exitInterior.invoke(mapOf("maxSteps" to "64")))
+        else -> ToolOutcome.Reject("walkTo not applicable in phase ${phaseProvider()}")
+    }
+
+    override suspend fun interactAt(x: Int, y: Int): ToolOutcome {
+        val walk = walkTo(x, y)
+        if (walk !is ToolOutcome.Ok) return walk
+        toolset.tap(button = "A", count = 1, pressFrames = 5, gapFrames = 15)
+        return ToolOutcome.Ok("interactAt done")
+    }
+
+    override suspend fun useMenu(path: String): ToolOutcome {
+        val taps = try { menuWalker.parse(path) }
+                   catch (e: IllegalArgumentException) { return ToolOutcome.Reject(e.message ?: "bad path") }
+        for (t in taps) toolset.tap(button = t.button, count = t.count, pressFrames = 5, gapFrames = 12)
+        return ToolOutcome.Ok("menu walked: $path")
+    }
+
+    override suspend fun buyAtShop(items: List<Int>, charSlots: List<Int>): ToolOutcome {
+        // Delegate to v1 BuyAtShop V5.45 via invokeWithAdvisor entry point.
+        // Concrete signature wiring done in Main; here we use a thin lambda.
+        return ToolOutcome.Reject("buyAtShop wiring TBD until Main wires v1 BuyAtShop instance")
+            .also { System.err.println("[v2.tool] buyAtShop placeholder hit — wire in Phase C.") }
+    }
+
+    override suspend fun equipWeapon(charSlot: Int, weaponSlot: Int): ToolOutcome {
+        // v1 EquipWeapon known-buggy (MenuStuck). Reuse anyway per spec section 13.
+        return ToolOutcome.Reject("equipWeapon wiring TBD until Main wires v1 instance")
+    }
+
+    override suspend fun restAtInn(innMapId: String): ToolOutcome =
+        ToolOutcome.Reject("restAtInn wiring TBD")
+
+    override suspend fun battleFightAll(): ToolOutcome {
+        val r = toolset.executeAction(profileId = "ff1", actionId = "battle_fight_all")
+        return if (r.ok) ToolOutcome.Ok(r.message, r.data) else ToolOutcome.Fail(r.message)
+    }
+
+    private fun wrap(s: SkillResult): ToolOutcome =
+        if (s.ok) ToolOutcome.Ok(s.message, s.ramAfter.mapValues { it.value.toString() })
+        else ToolOutcome.Fail(s.message)
+}

--- a/knes-agent/src/test/kotlin/knes/agent/v2/runtime/V2MemoryTest.kt
+++ b/knes-agent/src/test/kotlin/knes/agent/v2/runtime/V2MemoryTest.kt
@@ -1,0 +1,41 @@
+package knes.agent.v2.runtime
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.collections.shouldContainExactly
+import java.nio.file.Files
+
+class V2MemoryTest : StringSpec({
+    "campaign + plan + turn-log survive write + reopen" {
+        val tmpRoot = Files.createTempDirectory("v2-mem-test")
+        val run = V2RunDirectory(tmpRoot).also { it.ensure() }
+
+        val m1 = V2Memory(run)
+        m1.campaign.milestones += Milestone(id = "boot", status = "done", turnStart = 1, turnEnd = 47)
+        m1.campaign.plans += PlanEntry(turn = 48, by = "advisor", summary = "head to (15,22)", snapshot = "snapshots/turn-00048.png")
+        m1.saveCampaign()
+
+        val plan = Plan(
+            createdAtTurn = 48,
+            milestone = "buy_weapons",
+            steps = listOf(PlanStep(0, "walk to weapon shop", "walkTo", mapOf("x" to "15", "y" to "22"))),
+        )
+        m1.setPlan(plan)
+
+        val turnLog = TurnLog(
+            turn = 49, frame = 1234L, phase = "Overworld",
+            ram = mapOf("worldX" to 14, "worldY" to 21),
+            snapshot = "snapshots/turn-00049.png",
+            executor = ExecutorTrace("claude-sonnet-4-6", "walkTo", mapOf("x" to "15", "y" to "22"), "step 0", "ok", null, 200),
+            watchdog = WatchdogTrace(0, 5),
+        )
+        m1.appendTurn(turnLog)
+
+        // Reopen
+        val m2 = V2Memory(V2RunDirectory(tmpRoot))
+        m2.campaign.milestones.map { it.id } shouldContainExactly listOf("boot")
+        m2.campaign.lastTurn shouldBe 49
+        m2.currentPlan?.steps?.size shouldBe 1
+        m2.currentPlan?.steps?.first()?.intentArgs?.get("x") shouldBe "15"
+    }
+})

--- a/knes-agent/src/test/kotlin/knes/agent/v2/runtime/WatchdogTest.kt
+++ b/knes-agent/src/test/kotlin/knes/agent/v2/runtime/WatchdogTest.kt
@@ -1,0 +1,39 @@
+package knes.agent.v2.runtime
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class WatchdogTest : StringSpec({
+    "Overworld threshold is 5, MenuStuck is 3" {
+        val w = Watchdog()
+        // Five identical RAM hashes + zero skill progress in Overworld → signal
+        repeat(5) { w.observe(Phase.Overworld, ramHash = 42, skillProgress = false) }
+        w.stuckSignal(Phase.Overworld) shouldBe true
+        w.reset()
+        // Three is enough for MenuStuck
+        repeat(3) { w.observe(Phase.MenuStuck, ramHash = 42, skillProgress = false) }
+        w.stuckSignal(Phase.MenuStuck) shouldBe true
+    }
+
+    "skill progress resets counter" {
+        val w = Watchdog()
+        repeat(4) { w.observe(Phase.Overworld, ramHash = 42, skillProgress = false) }
+        w.observe(Phase.Overworld, ramHash = 42, skillProgress = true)
+        w.stuckSignal(Phase.Overworld) shouldBe false
+        w.counter() shouldBe 0
+    }
+
+    "Dialog whitelist does not tick counter even with static RAM" {
+        val w = Watchdog()
+        repeat(20) { w.observe(Phase.Dialog, ramHash = 42, skillProgress = false) }
+        w.stuckSignal(Phase.Dialog) shouldBe false
+        w.counter() shouldBe 0
+    }
+
+    "RAM change resets counter" {
+        val w = Watchdog()
+        repeat(4) { w.observe(Phase.Overworld, ramHash = 42, skillProgress = false) }
+        w.observe(Phase.Overworld, ramHash = 99, skillProgress = false)
+        w.counter() shouldBe 0
+    }
+})

--- a/knes-agent/src/test/kotlin/knes/agent/v2/tools/MenuWalkerTest.kt
+++ b/knes-agent/src/test/kotlin/knes/agent/v2/tools/MenuWalkerTest.kt
@@ -1,0 +1,42 @@
+package knes.agent.v2.tools
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.collections.shouldContainExactly
+
+class MenuWalkerTest : StringSpec({
+    val w = MenuWalker()
+
+    "main/equip/char1/weapon/0 emits expected sequence" {
+        w.parse("main/equip/char1/weapon/0") shouldContainExactly listOf(
+            MenuTap("B"),
+            MenuTap("DOWN", 2),   // equip is 3rd item (idx 2)
+            MenuTap("A"),
+            MenuTap("A"),          // char1 — no DOWN needed
+            MenuTap("A"),          // weapon — first slot, no DOWN
+        )
+    }
+
+    "main/equip/char3/weapon/1 navigates to char3 and slot 1" {
+        val seq = w.parse("main/equip/char3/weapon/1")
+        seq[3] shouldBe MenuTap("DOWN", 2)    // char3 → DOWN×2 then A
+        seq[4] shouldBe MenuTap("A")
+        seq[5] shouldBe MenuTap("DOWN", 1)    // slot 1 → DOWN×1 then A
+    }
+
+    "shop/buy/0/char1 emits buy+item0+char1" {
+        w.parse("shop/buy/0/char1") shouldContainExactly listOf(
+            MenuTap("A"),          // buy (idx 0)
+            MenuTap("A"),          // item 0
+            MenuTap("A"),          // char1
+        )
+    }
+
+    "invalid root throws" {
+        runCatching { w.parse("nonsense/x") }.isFailure shouldBe true
+    }
+
+    "char out of range throws" {
+        runCatching { w.parse("main/equip/char9/weapon/0") }.isFailure shouldBe true
+    }
+})


### PR DESCRIPTION
Parallel FF1 agent (knes.agent.v2.*) implementing the architecture from docs/Gemini Plays Final Fantasy.pdf — Cartographer + Advisor + Executor + Reviewer + phase-aware stuck-signal watchdog + hierarchical decision-log save format. v1 stays untouched. Entry points: :knes-agent:run (v1), :knes-agent:runV2 (v2).

**Design:** docs/superpowers/specs/2026-05-12-knes-agent-v2-design.md
**Plan:** docs/superpowers/plans/2026-05-12-knes-agent-v2.md

## What landed

Phase A–D: 25 implementation commits + 5 smoke-discovered hot fixes.

3 minimal tests all green (V2Memory round-trip, Watchdog phase thresholds, MenuWalker parser).

## Smoke 0 status: partial

6 iterations, 5 fixes (Gemini model id, HTTP timeout, press-start bootstrap, switch to Gemini 2.5 Pro, JSON markdown fence strip). End-to-end Cartographer → Advisor wiring proven; bug #6 open.

**Bug #6:** Gemini emits `intentArgs.items: ["Rapier"]` (list) for buyAtShop; StepWire schema expects Map<String, String>. Fix: change to Map<String, JsonElement> + normalize in Executor dispatch.

## Test plan

- [ ] Bug #6 fix
- [ ] Smoke 0–3 + A/B vs v1
