### PR TITLE
knes-agent v2 Smoke 1 progress — Town navigation, vision-driven Executor, first battle won

### DIFF
--- a/docs/superpowers/notes/2026-05-12-v2-smoke-1-handoff.md
+++ b/docs/superpowers/notes/2026-05-12-v2-smoke-1-handoff.md
@@ -1,0 +1,126 @@
+# knes-agent v2 — Smoke 1 handoff (post-Town-fix)
+
+**Date:** 2026-05-12
+**Branch:** `ff1-buy-and-equip-coneria` HEAD `deb4694`
+**Spec:** `docs/superpowers/specs/2026-05-12-knes-agent-v2-design.md`
+**Plan:** `docs/superpowers/plans/2026-05-12-knes-agent-v2.md`
+**Prior handoff:** `docs/superpowers/notes/2026-05-12-v2-smoke-0-handoff.md`
+
+## What landed
+
+Two of three Smoke-0 unblock items (per user scope decision: "just the 3 handoff items + smaller fix at T2/T3"):
+
+1. `deb4694` — `fix(v2)`: Town vs Indoors phase split + landmarks digest in Advisor
+   - `Phase.Town` for `mapId=0 + mapflags.bit0=1` (was: misclassified as `Indoors`).
+   - `ToolSurface.walkTo`: `Phase.Town` → `Reject` (in-town pathfinder deferred). Eliminates the prior bounce-out where `Indoors→exitInterior` dispatch dumped party back to overworld.
+   - `Watchdog`: `Town` threshold = 5.
+   - `AdvisorAgent`: optional `LandmarkMemory` injection; renders `LandmarkContext` plus usage rules (overworld vs town-overlay vs interior) into the prompt.
+   - `Main.kt`: passes preseeded `~/.knes/ff1-landmarks.json` (Coneria TOWN_ENTRY + weapon-shopkeeper) into Advisor.
+   - `PhaseTest`: 4 cases (Town / Overworld / Indoors / Boot).
+
+Deferred: (1) `DiscoverShop`/`DiscoverInn` wiring into Cartographer — preseeded landmarks cover Smoke 1 needs; (2) keeper-approach port from `AgentSession.runOutfitBootPhase` into `ToolSurface.buyAtShop`.
+
+## Smoke 0 result (post-fix)
+
+`runV2 --fresh --max-turns=10 --cart-seconds=20 --cart-vision-calls=2` — run dir `2026-05-12-1410-v2`.
+
+| T  | Phase     | mapflags | wXY       | Tool        | Outcome | Note                                                       |
+|----|-----------|----------|-----------|-------------|---------|------------------------------------------------------------|
+| 1  | Boot      | 0        | (0,0)     | boot        | **ok**  | overworld after 28 taps                                    |
+| 2  | Overworld | 0        | (146,158) | walkTo      | **ok**  | reached (147,155) in 3 steps (Coneria entry)               |
+| 3  | Overworld | **2**    | (147,155) | buyAtShop   | fail    | mapflags.bit0=0 — transition transient (bit1=1, see below) |
+| 4  | Overworld | 2        | (147,155) | buyAtShop   | fail    | same                                                       |
+| 5–8 | Overworld | 2       | (147,155) | equipWeapon | fail    | WeaponNotInSlot (nothing bought yet)                       |
+
+Pre-fix Smoke 0 (commit `589ad44`) had T3 dispatching `exitInterior` and bouncing party to overworld. Post-fix T2 reaches Coneria entry cleanly. **walkTo Reject path verified at Smoke 1 (T17 below).**
+
+## Smoke 1 result
+
+`runV2 --fresh --max-turns=1500` — run dir `2026-05-12-1415-v2` (completed in ~3 min).
+
+Phase distribution:
+```
+Boot:      1 turn
+Overworld: 13 turns
+Town:      1486 turns  ← party stayed in Coneria town overlay (vs Smoke 0 baseline = always bounced out)
+```
+
+Tool/outcome tally:
+```
+battleFightAll   ok   1484
+useMenu          ok       3
+walkTo           ok       2
+walkTo           reject   2  ← Town overlay walkTo correctly rejected
+boot             ok       1
+buyAtShop        fail     4
+equipWeapon      fail     4
+```
+
+Outcome: **0/4 weapons bought, 0/4 equipped.** Spec §12 success criteria (≥3/4 buy + ≥3/4 equip + party back overworld) not met.
+
+Key turns:
+- T11-12: buyAtShop fails on overworld at Coneria entry while mapflags=2 (transition transient — bit1=1 = "screen transition / dialog active" per `ExitTownEmpirical.kt:104`).
+- T13: `battleFightAll` returns ok in 0 rounds (no-op success — see Gap #1 below).
+- T14: useMenu equip succeeds at opening field menu while on overworld.
+- T15: party transitions to Town (mapflags=1, smPlayer=(16,23)).
+- T17: walkTo(147,156) → Reject with new message "walkTo not implemented for Town overlay — use interactAt at landmark local coords". Phase fix verified at scale.
+- T50, T500, T1500: stuck in `battleFightAll` no-op loop. Watchdog never trips because every call returns ok=true (resets counter via `skillProgress` branch).
+
+## Gaps revealed (in priority order for next session)
+
+### Gap #1 — `battleFightAll` stealth no-op (critical regression risk)
+`toolset.executeAction(profileId="ff1", actionId="battle_fight_all")` returns `ok=true` in 0 rounds when there is no battle in progress. The skill must reject when `battleState=0` so the watchdog can fire stuck-signal. **This single bug killed the entire Smoke 1 campaign at T13.**
+
+Fix sketch: in `DefaultToolSurface.battleFightAll`, gate on `Phase != Phase.Battle` → Reject.
+
+### Gap #2 — mapflags=2 transition transient
+After walking onto a TOWN_ENTRY tile, mapflags transiently equals 2 (bit0=0, bit1=1 = "dialog/menu active") before settling to mapflags=1 (in-town). v1's `ExitTownEmpirical` already handles this with a settle loop (`while ((mapflags & 0x02) != 0) wait; break`). The Advisor planned `buyAtShop` immediately after walkTo without a settle step.
+
+Fix sketch: add a one-tick "settle" wait after walkTo in `ToolSurface.walkTo`, OR have Phase classifier treat mapflags=2 as a `Transition` phase that the Advisor's prompt instructs to be patient with.
+
+### Gap #3 — Keeper-approach (deferred from Smoke 0 handoff, still open)
+`BuyAtShop.invoke` assumes party already faces the shopkeeper. v1's `AgentSession.runOutfitBootPhase:1162-1244` runs a post-enter vision scan + walks party to (sx, sy+1) facing N before buying. v2's `ToolSurface.buyAtShop` does not. Smoke 1 confirms: even when party is in Town (T15+), buyAtShop would fail at "tap A on keeper" because party is at sm=(16,23) ≠ adjacent to keeper at local=(11,10) per preseeded landmark.
+
+Fix sketch: option (X) from prior handoff — port the keeper-approach into `enterAndApproachShop` helper invoked by `ToolSurface.buyAtShop` when phase=Town.
+
+### Gap #4 — Executor latching onto no-op tools
+Sonnet picked `battleFightAll` 1484× because it was the only tool returning ok=true in Town. Fixing Gap #1 forces Executor to surface real failure; combined with Gap #3 the Executor will then actually drive the buy flow.
+
+## Files committed this session
+
+```
+knes-agent/src/main/kotlin/knes/agent/v2/Main.kt                 (+1 -1)
+knes-agent/src/main/kotlin/knes/agent/v2/agents/AdvisorAgent.kt  (+27 0)
+knes-agent/src/main/kotlin/knes/agent/v2/runtime/Phase.kt        (+12 -1)
+knes-agent/src/main/kotlin/knes/agent/v2/runtime/Watchdog.kt     (+1 -1)
+knes-agent/src/main/kotlin/knes/agent/v2/tools/ToolSurface.kt    (+10 0)
+knes-agent/src/test/kotlin/knes/agent/v2/runtime/PhaseTest.kt    (+30 new)
+```
+
+Total: 6 files, +80 / -3 lines, 1 commit.
+
+## Resume instructions
+
+```bash
+# Confirm wiring still intact:
+./gradlew :knes-agent:test --tests 'knes.agent.v2.*'
+
+# Re-run Smoke 0 (cheap, ~$0.05):
+./gradlew :knes-agent:runV2 -PappArgs="--fresh --max-turns=10 --cart-seconds=20 --cart-vision-calls=2"
+
+# Inspect Smoke 1 archive:
+ls /Users/askowronski/.knes/runs/2026-05-12-1415-v2/decisions/ | wc -l   # → 1500
+```
+
+Required env: `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`. Optional: `GEMINI_MODEL` override.
+
+## Open follow-ups (carried from Smoke 0 handoff + new)
+
+- **NEW:** `battleFightAll` must reject when not in battle (Gap #1) — single highest-leverage fix.
+- **NEW:** mapflags=2 transition settle (Gap #2) — small, deterministic, no LLM cost.
+- Keeper-approach in `ToolSurface.buyAtShop` (Gap #3) — half-day port from AgentSession.
+- `EquipWeapon` MenuStuck — known v1-inherited bug.
+- `Resumer` decision replay (D2 has a TODO).
+- `ReviewerAgent.invokeHaiku` placeholder returning `{"actions":[]}`.
+- `ExecutorAgent.askLlm` plan-tail fallback (no real Sonnet tool-calling yet).
+- Cartographer `DiscoverShop`/`DiscoverInn` wiring (spec §6 paragraph 4) — only needed when preseeded landmarks aren't enough (other towns).

--- a/knes-agent/src/main/kotlin/knes/agent/v2/Main.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/Main.kt
@@ -21,6 +21,7 @@ import knes.agent.v2.agents.AdvisorAgent
 import knes.agent.v2.agents.CartographerAgent
 import knes.agent.v2.agents.ExecutorAgent
 import knes.agent.v2.agents.ReviewerAgent
+import knes.agent.v2.llm.AnthropicHttp
 import knes.agent.v2.llm.GeminiPro31Client
 import knes.agent.v2.llm.HaikuClient
 import knes.agent.v2.llm.SonnetClient
@@ -53,6 +54,7 @@ fun main(args: Array<String>) {
 
     runBlocking {
         AnthropicSession(anthropicKey).use { anthropic ->
+            AnthropicHttp(anthropicKey).use { anthropicHttp ->
             GeminiPro31Client(geminiKey).use { gemini ->
                 val session = EmulatorSession()
                 val toolset = EmulatorToolset(session)
@@ -108,9 +110,11 @@ fun main(args: Array<String>) {
                 )
 
                 // Agents
+                val sonnet = SonnetClient(anthropicHttp)
+                val haiku = HaikuClient(anthropicHttp)
                 val advisor = AdvisorAgent(gemini, memory, run, landmarks)
-                val executor = ExecutorAgent(anthropic, SonnetClient(anthropic), tools, memory)
-                val reviewer = ReviewerAgent(HaikuClient(anthropic), memory)
+                val executor = ExecutorAgent(anthropic, sonnet, haiku, tools, memory)
+                val reviewer = ReviewerAgent(haiku, memory)
                 val cartographer = CartographerAgent(
                     gemini, toolset, memory, snapshotDumper, overworldMap, fog, landmarks,
                     cfg.cartographerBudgetSeconds, cfg.cartographerMaxVisionCalls,
@@ -132,7 +136,7 @@ fun main(args: Array<String>) {
 
                 // Phase 1: campaign loop
                 val recentExecutorOutcomes = ArrayDeque<String>(4)
-                val sonnetModelId = SonnetClient(anthropic).modelId
+                val sonnetModelId = sonnet.modelId
                 var turn = firstTurn
                 while (turn <= cfg.maxTurns && !memory.campaign.done) {
                     val snap = toolset.getScreen().base64
@@ -195,6 +199,7 @@ fun main(args: Array<String>) {
                 }
 
                 System.err.println("[v2.main] done. last_turn=${memory.campaign.lastTurn}")
+            }
             }
         }
     }

--- a/knes-agent/src/main/kotlin/knes/agent/v2/Main.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/Main.kt
@@ -174,6 +174,8 @@ fun main(args: Array<String>) {
                         )
                     )
 
+                    advanceMilestones(memory, phase, state.ram, decision, turn)
+
                     if (watchdog.stuckSignal(phase)) {
                         val diag = watchdog.diagnose(phase, recentExecutorOutcomes.toList())
                         System.err.println("[v2.main] stuck-signal — $diag")
@@ -196,4 +198,57 @@ fun main(args: Array<String>) {
             }
         }
     }
+}
+
+/**
+ * Advance campaign milestones based on observed phase + RAM signals. Idempotent:
+ * each milestone flips from "in_progress" to "done" exactly once, and the next
+ * pending milestone becomes "in_progress". Without this, `currentMilestone()`
+ * falls through to "boot" forever and the Advisor keeps emitting "Restart with
+ * default party" (Smoke 1 v2 evidence: 20 replans in 109 turns all saying that).
+ *
+ * Signals (deliberately coarse — refinement deferred until a milestone earns it):
+ *  - boot          → done when phase != Boot (party + worldX present)
+ *  - enter_coneria → done when phase == Town (mapflags.bit0=1, mapId=0)
+ *  - buy_weapons   → done when any char has a non-zero weapon byte in any slot
+ *  - equip_weapons → done when ≥1 char has an equipped weapon (bit7 set)
+ *  - exit_coneria  → done when phase == Overworld AFTER enter_coneria fired
+ *  - grind         → done when any char's xpLow > 0 (post-battle XP gained)
+ */
+private fun advanceMilestones(
+    memory: knes.agent.v2.runtime.V2Memory,
+    phase: knes.agent.v2.runtime.Phase,
+    ram: Map<String, Int>,
+    @Suppress("UNUSED_PARAMETER") decision: knes.agent.v2.agents.ExecutorDecision,
+    turn: Int,
+) {
+    val ms = memory.campaign.milestones
+    fun mark(id: String, predicate: () -> Boolean) {
+        val m = ms.firstOrNull { it.id == id } ?: return
+        if (m.status == "in_progress" && predicate()) {
+            m.status = "done"; m.turnEnd = turn
+            val next = ms.firstOrNull { it.status == "pending" }
+            if (next != null) { next.status = "in_progress"; next.turnStart = turn }
+            System.err.println("[v2.main] milestone $id done at T$turn; next=${next?.id ?: "(none)"}")
+        }
+    }
+    val anyWeaponHeld = (1..4).any { c -> (0..3).any { s ->
+        (ram["char${c}_weapon${s}"] ?: 0) != 0
+    } }
+    val anyWeaponEquipped = (1..4).any { c -> (0..3).any { s ->
+        ((ram["char${c}_weapon${s}"] ?: 0) and 0x80) != 0
+    } }
+    val anyXp = (1..4).any { c -> (ram["char${c}_xpLow"] ?: 0) > 0 || (ram["char${c}_xpHigh"] ?: 0) > 0 }
+
+    mark("boot")          { phase != knes.agent.v2.runtime.Phase.Boot }
+    mark("enter_coneria") { phase == knes.agent.v2.runtime.Phase.Town }
+    mark("buy_weapons")   { anyWeaponHeld }
+    mark("equip_weapons") { anyWeaponEquipped }
+    mark("exit_coneria")  {
+        val enterDone = ms.firstOrNull { it.id == "enter_coneria" }?.status == "done"
+        enterDone && phase == knes.agent.v2.runtime.Phase.Overworld
+    }
+    mark("grind")         { anyXp }
+
+    memory.saveCampaign()
 }

--- a/knes-agent/src/main/kotlin/knes/agent/v2/Main.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/Main.kt
@@ -98,6 +98,8 @@ fun main(args: Array<String>) {
                 val restAtInn = RestAtInn(toolset)
                 val pressStart = PressStartUntilOverworld(toolset)
 
+                val sonnet = SonnetClient(anthropicHttp)
+                val haiku = HaikuClient(anthropicHttp)
                 val tools = DefaultToolSurface(
                     toolset = toolset,
                     phaseProvider = { Phase.fromRam(toolset.getState().ram) },
@@ -107,11 +109,10 @@ fun main(args: Array<String>) {
                     buyAtShopSkill = buyAtShop,
                     equipWeaponSkill = equipWeapon,
                     restAtInnSkill = restAtInn,
+                    haiku = haiku,
                 )
 
                 // Agents
-                val sonnet = SonnetClient(anthropicHttp)
-                val haiku = HaikuClient(anthropicHttp)
                 val advisor = AdvisorAgent(gemini, memory, run, landmarks)
                 val executor = ExecutorAgent(anthropic, sonnet, haiku, tools, memory)
                 val reviewer = ReviewerAgent(haiku, memory)

--- a/knes-agent/src/main/kotlin/knes/agent/v2/Main.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/Main.kt
@@ -108,7 +108,7 @@ fun main(args: Array<String>) {
                 )
 
                 // Agents
-                val advisor = AdvisorAgent(gemini, memory, run)
+                val advisor = AdvisorAgent(gemini, memory, run, landmarks)
                 val executor = ExecutorAgent(anthropic, SonnetClient(anthropic), tools, memory)
                 val reviewer = ReviewerAgent(HaikuClient(anthropic), memory)
                 val cartographer = CartographerAgent(

--- a/knes-agent/src/main/kotlin/knes/agent/v2/agents/AdvisorAgent.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/agents/AdvisorAgent.kt
@@ -1,5 +1,7 @@
 package knes.agent.v2.agents
 
+import knes.agent.perception.LandmarkMemory
+import knes.agent.runtime.LandmarkContext
 import knes.agent.v2.llm.GeminiPro31Client
 import knes.agent.v2.runtime.Plan
 import knes.agent.v2.runtime.PlanEntry
@@ -16,6 +18,7 @@ class AdvisorAgent(
     private val gemini: GeminiPro31Client,
     private val memory: V2Memory,
     private val run: V2RunDirectory,
+    private val landmarks: LandmarkMemory? = null,
 ) {
     suspend fun plan(reason: String, screenshotB64: String, turn: Int) {
         val prompt = buildPrompt(reason)
@@ -32,6 +35,27 @@ class AdvisorAgent(
         System.err.println("[v2.advisor] turn=$turn reason=$reason steps=${plan.steps.size}")
     }
 
+    private fun landmarksDigest(): String {
+        val lm = landmarks ?: return ""
+        val rendered = LandmarkContext.render(lm) ?: return ""
+        // Append concrete guidance so the planner stops emitting raw walkTo(x,y)
+        // toward in-town NPCs (Smoke 0 T2-T7 trace): interior-coord landmarks
+        // (mapId>=0 with localX/localY) are only reachable via interactAt at
+        // those local coords once the party is in the matching map/town.
+        return """
+            $rendered
+
+            Landmark usage:
+            - Overworld landmarks (worldX,worldY) — valid targets for walkTo / interactAt while phase=Overworld.
+            - Town-overlay landmarks (mapId=0, has localX/localY) — the party must first cross a TOWN_ENTRY
+              tile via walkTo on the overworld; once mapflags.bit0=1, the party is in town overlay. Town
+              walkTo is currently unimplemented (returns Reject); the next planned tool call once inside
+              town should be buyAtShop (which probes the shopkeeper directly) or interactAt at the local
+              coords if the party already happens to be adjacent.
+            - True interior landmarks (mapId>0) — interactAt with local coords once inside that mapId.
+        """.trimIndent()
+    }
+
     private fun currentMilestone(): String =
         memory.campaign.milestones.firstOrNull { it.status == "in_progress" }?.id
             ?: memory.campaign.milestones.firstOrNull { it.status == "pending" }?.id
@@ -45,6 +69,8 @@ class AdvisorAgent(
         Trigger reason: $reason
         Campaign so far: ${memory.campaign.milestones.joinToString { "${it.id}=${it.status}" }}
         Recent plans: ${memory.campaign.plans.takeLast(3).joinToString("\n") { "T${it.turn}: ${it.summary}" }}
+
+        ${landmarksDigest()}
 
         Output schema (STRICT — every step uses one of the seven tools below; intentArgs values are STRINGS):
         {"steps":[

--- a/knes-agent/src/main/kotlin/knes/agent/v2/agents/AdvisorAgent.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/agents/AdvisorAgent.kt
@@ -47,11 +47,12 @@ class AdvisorAgent(
 
             Landmark usage:
             - Overworld landmarks (worldX,worldY) — valid targets for walkTo / interactAt while phase=Overworld.
-            - Town-overlay landmarks (mapId=0, has localX/localY) — the party must first cross a TOWN_ENTRY
-              tile via walkTo on the overworld; once mapflags.bit0=1, the party is in town overlay. Town
-              walkTo is currently unimplemented (returns Reject); the next planned tool call once inside
-              town should be buyAtShop (which probes the shopkeeper directly) or interactAt at the local
-              coords if the party already happens to be adjacent.
+              walkTo args are overworld world coords (worldX,worldY space).
+            - Town-overlay landmarks (mapId=0, has localX/localY) — the party first crosses a TOWN_ENTRY
+              tile via walkTo on the overworld; once mapflags.bit0=1 (phase=Town), walkTo args become
+              TOWN-LOCAL coords (smPlayerX/smPlayerY space). E.g. walkTo(11,10) in Town walks the party
+              to local tile (11,10) using Haiku vision per step. Ends in Ok when party is adjacent.
+              After walking adjacent, call buyAtShop.
             - True interior landmarks (mapId>0) — interactAt with local coords once inside that mapId.
         """.trimIndent()
     }

--- a/knes-agent/src/main/kotlin/knes/agent/v2/agents/ExecutorAgent.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/agents/ExecutorAgent.kt
@@ -123,7 +123,9 @@ class ExecutorAgent(
             {"tool":"<one of: boot|walkTo|interactAt|useMenu|buyAtShop|equipWeapon|restAtInn|battleFightAll>","args":{"<key>":"<value>"},"reasoning":"<≤80 chars why>"}
 
             Hard rules:
-            - For walkTo / interactAt: args = {"x":"<int>","y":"<int>"} (overworld coords)
+            - For walkTo / interactAt: args = {"x":"<int>","y":"<int>"}.
+              Coordinate space depends on phase: Overworld → world coords (worldX,worldY).
+              Town → town-local coords (smPlayerX,smPlayerY space — e.g. 11,10 for weapon shopkeeper).
             - useMenu: args = {"path":"<menu-path>"} — path grammar: main/<item|equip|magic|status|exit>[/charN][/weapon|armor][/0-3] or shop/<buy|sell|exit>[/N][/charN]
             - buyAtShop: args = {"items":"3,2,1,0","charSlots":"0,1,2,3"} (comma lists same length)
             - equipWeapon: args = {"charSlot":"<0-3>","weaponSlot":"<0-3>"}

--- a/knes-agent/src/main/kotlin/knes/agent/v2/agents/ExecutorAgent.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/agents/ExecutorAgent.kt
@@ -132,8 +132,14 @@ class ExecutorAgent(
             - restAtInn: args = {"innMapId":"<int>"}
             - boot / battleFightAll: args = {}
             - Pick battleFightAll ONLY if scene overlay = battle.
-            - If the scene shows party-near-shopkeeper (vp distance ≤ 1), pick buyAtShop.
-            - If shopkeeper visible but party far, pick walkTo / interactAt at world coords from RAM (worldX,worldY).
+            - Pick buyAtShop ONLY when ALL of:
+                (a) phase=Town (mapflags.bit0=1, mapId=0 from RAM digest),
+                (b) scene shows party-adjacent (viewport distance ≤ 1) to a shopkeeper sprite.
+              If (a) holds but (b) doesn't: pick walkTo with TOWN-LOCAL coords from the known
+              landmark (e.g. weapon shopkeeper local(11,10) in Coneria — see landmarks digest
+              in plan context).
+            - If phase=Overworld and party is at a town entry tile: pick walkTo(entry-world-coords)
+              to step INTO town first; do NOT call buyAtShop from overworld (it will Reject).
             - DO NOT explain. JSON only.
         """.trimIndent()
     }

--- a/knes-agent/src/main/kotlin/knes/agent/v2/agents/ExecutorAgent.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/agents/ExecutorAgent.kt
@@ -1,6 +1,7 @@
 package knes.agent.v2.agents
 
 import knes.agent.llm.AnthropicSession
+import knes.agent.v2.llm.HaikuClient
 import knes.agent.v2.llm.SonnetClient
 import knes.agent.v2.runtime.Plan
 import knes.agent.v2.runtime.PlanStep
@@ -17,18 +18,15 @@ data class ExecutorDecision(
 )
 
 /**
- * Per-turn tool picker. Given current plan + observation (screenshot + RAM
- * digest), Sonnet 4.6 picks the next tool and arguments. ToolSurface invokes
- * it; we return the outcome for memory.appendTurn.
- *
- * Implementation: for the first cut, prefer the plan's intentTool/intentArgs
- * verbatim (trust Advisor). If plan cursor exhausted OR intentTool null OR
- * last 2 outcomes were not Ok, ask Sonnet via a structured prompt (placeholder
- * fallback for now).
+ * Per-turn tool picker. Plan-hint dispatch is the default fast path; when the
+ * plan exhausts or recent steps keep failing, Sonnet decides what to do next —
+ * informed by a Haiku scene description (Option A: vision pre-processed by
+ * Haiku, Sonnet reads the text digest).
  */
 class ExecutorAgent(
     private val anthropic: AnthropicSession,
     private val sonnet: SonnetClient,
+    private val haiku: HaikuClient,
     private val tools: ToolSurface,
     private val memory: V2Memory,
 ) {
@@ -38,12 +36,6 @@ class ExecutorAgent(
     suspend fun act(screenshotB64: String, ramDigest: String): ExecutorDecision {
         val started = System.currentTimeMillis()
         val plan = memory.currentPlan
-        // Reset recent-outcomes history when the Advisor writes a new plan.
-        // Without this, stale Reject/Fail entries from the previous plan keep
-        // shouldUsePlanHint=false for the new plan's first steps, so even a
-        // fresh sensible plan never executes. Smoke 1 v4 evidence: 39
-        // consecutive Rejects across 8 replans because recentOutcomes carried
-        // forward.
         val planCreatedAt = plan?.createdAtTurn ?: -1
         if (planCreatedAt != lastPlanCreatedAt) {
             recentOutcomes.clear()
@@ -51,10 +43,6 @@ class ExecutorAgent(
         }
         val step = plan?.steps?.getOrNull(plan.cursor)
 
-        // Plan exhausted (cursor past last step) — signal Reject directly so the
-        // watchdog ticks and the Advisor replans. The previous "fallback to
-        // plan tail" repeated the last step forever, masking progress: Smoke 1
-        // v3 spent 266/300 turns hammering useMenu(shop/exit) via this path.
         if (plan != null && step == null) {
             val outcome = ToolOutcome.Reject("plan exhausted at cursor=${plan.cursor}/${plan.steps.size} — awaiting advisor replan")
             recentOutcomes.addLast(outcome.javaClass.simpleName)
@@ -89,17 +77,71 @@ class ExecutorAgent(
         return recentFails < 2
     }
 
+    /**
+     * Vision-informed tool decision when plan-hint isn't usable (cursor past
+     * step, intentTool missing, or 2+ recent fails). Haiku describes the
+     * screen → Sonnet picks one tool. On parse / network failure, falls back
+     * to plan tail so the emulator keeps running frames.
+     */
     private suspend fun askLlm(plan: Plan?, screenshotB64: String, ramDigest: String): Triple<String, Map<String, String>, String> {
-        // TODO(C3-followup): plug a Koog tool registry so Sonnet can call tools natively.
-        // Until then: fall back to the plan's tail step so the emulator keeps
-        // running frames (a pure Reject path skips emulator interaction → the
-        // mapflags=2 transition transient never settles, Smoke 1 v4 evidence).
-        // Fix B (useMenu RAM-diff gate) and Gap #1 (battleFightAll phase gate)
-        // already catch the stealth-no-op variants of plan-tail; anything else
-        // genuinely runs frames and either advances state or Fails honestly.
-        val tail = plan?.steps?.lastOrNull()
-        if (tail?.intentTool != null) return Triple(tail.intentTool, tail.intentArgs ?: emptyMap(), "fallback to plan tail")
-        return Triple("useMenu", mapOf("path" to "main/exit"), "no plan + no LLM wired yet — best-effort menu exit")
+        return try {
+            val scene = haiku.describeScene(screenshotB64)
+            val raw = sonnet.decideTool(EXECUTOR_SYSTEM_PROMPT, buildSonnetUserText(plan, scene, ramDigest))
+            parseToolDecision(raw)
+        } catch (e: Exception) {
+            System.err.println("[v2.executor] askLlm error: ${e.message?.take(160)} — falling back to plan tail")
+            val tail = plan?.steps?.lastOrNull()
+            if (tail?.intentTool != null) Triple(tail.intentTool, tail.intentArgs ?: emptyMap(), "fallback to plan tail (askLlm exception)")
+            else Triple("useMenu", mapOf("path" to "main/exit"), "fallback no-op (no plan, askLlm exception)")
+        }
+    }
+
+    private fun buildSonnetUserText(plan: Plan?, scene: String, ramDigest: String): String {
+        val planSummary = if (plan == null) "(no plan)" else {
+            val cur = plan.steps.getOrNull(plan.cursor)
+            val tail = plan.steps.lastOrNull()
+            buildString {
+                append("milestone=${plan.milestone} cursor=${plan.cursor}/${plan.steps.size}\n")
+                if (cur != null) append("current step [${cur.index}]: ${cur.intentTool}(${cur.intentArgs ?: emptyMap()}) — ${cur.description}\n")
+                if (tail != null && tail.index != cur?.index) append("final step [${tail.index}]: ${tail.intentTool}(${tail.intentArgs ?: emptyMap()}) — ${tail.description}\n")
+            }
+        }
+        val recent = if (recentOutcomes.isEmpty()) "(none)" else recentOutcomes.joinToString(",")
+        return """
+            Scene (from Haiku vision):
+            $scene
+
+            RAM digest:
+            $ramDigest
+
+            Current plan context:
+            $planSummary
+
+            Recent executor outcomes (last 4): $recent
+
+            Pick ONE tool to execute next turn. Output ONLY JSON:
+            {"tool":"<one of: boot|walkTo|interactAt|useMenu|buyAtShop|equipWeapon|restAtInn|battleFightAll>","args":{"<key>":"<value>"},"reasoning":"<≤80 chars why>"}
+
+            Hard rules:
+            - For walkTo / interactAt: args = {"x":"<int>","y":"<int>"} (overworld coords)
+            - useMenu: args = {"path":"<menu-path>"} — path grammar: main/<item|equip|magic|status|exit>[/charN][/weapon|armor][/0-3] or shop/<buy|sell|exit>[/N][/charN]
+            - buyAtShop: args = {"items":"3,2,1,0","charSlots":"0,1,2,3"} (comma lists same length)
+            - equipWeapon: args = {"charSlot":"<0-3>","weaponSlot":"<0-3>"}
+            - restAtInn: args = {"innMapId":"<int>"}
+            - boot / battleFightAll: args = {}
+            - Pick battleFightAll ONLY if scene overlay = battle.
+            - If the scene shows party-near-shopkeeper (vp distance ≤ 1), pick buyAtShop.
+            - If shopkeeper visible but party far, pick walkTo / interactAt at world coords from RAM (worldX,worldY).
+            - DO NOT explain. JSON only.
+        """.trimIndent()
+    }
+
+    private fun parseToolDecision(raw: String): Triple<String, Map<String, String>, String> {
+        val start = raw.indexOf('{'); val end = raw.lastIndexOf('}')
+        require(start in 0 until end) { "no JSON object in sonnet response: ${raw.take(200)}" }
+        val parsed = kotlinx.serialization.json.Json { ignoreUnknownKeys = true }
+            .decodeFromString(ToolWire.serializer(), raw.substring(start, end + 1))
+        return Triple(parsed.tool, parsed.args ?: emptyMap(), "sonnet+haiku: ${parsed.reasoning?.take(80) ?: ""}")
     }
 
     private suspend fun dispatch(tool: String, args: Map<String, String>): ToolOutcome = when (tool) {
@@ -120,5 +162,23 @@ class ExecutorAgent(
     private fun advancePlan(plan: Plan) {
         val advanced = plan.copy(cursor = (plan.cursor + 1).coerceAtMost(plan.steps.size))
         memory.setPlan(advanced)
+    }
+
+    @kotlinx.serialization.Serializable
+    private data class ToolWire(
+        val tool: String,
+        val args: Map<String, String>? = null,
+        val reasoning: String? = null,
+    )
+
+    companion object {
+        private val EXECUTOR_SYSTEM_PROMPT = """
+            You are the per-turn tool picker for an FF1 NES playing agent. Read the
+            Haiku scene description, RAM digest, current plan, and recent outcomes,
+            then pick exactly ONE tool to execute next turn. Respond with JSON only.
+            The plan was authored by a strategic Advisor (Gemini 2.5 Pro) — prefer
+            following it unless the scene clearly contradicts (e.g. plan says "buy"
+            but scene shows battle overlay → fight first).
+        """.trimIndent()
     }
 }

--- a/knes-agent/src/main/kotlin/knes/agent/v2/agents/ExecutorAgent.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/agents/ExecutorAgent.kt
@@ -33,10 +33,22 @@ class ExecutorAgent(
     private val memory: V2Memory,
 ) {
     private val recentOutcomes = ArrayDeque<String>(4)
+    private var lastPlanCreatedAt: Int = -1
 
     suspend fun act(screenshotB64: String, ramDigest: String): ExecutorDecision {
         val started = System.currentTimeMillis()
         val plan = memory.currentPlan
+        // Reset recent-outcomes history when the Advisor writes a new plan.
+        // Without this, stale Reject/Fail entries from the previous plan keep
+        // shouldUsePlanHint=false for the new plan's first steps, so even a
+        // fresh sensible plan never executes. Smoke 1 v4 evidence: 39
+        // consecutive Rejects across 8 replans because recentOutcomes carried
+        // forward.
+        val planCreatedAt = plan?.createdAtTurn ?: -1
+        if (planCreatedAt != lastPlanCreatedAt) {
+            recentOutcomes.clear()
+            lastPlanCreatedAt = planCreatedAt
+        }
         val step = plan?.steps?.getOrNull(plan.cursor)
 
         // Plan exhausted (cursor past last step) — signal Reject directly so the
@@ -79,10 +91,15 @@ class ExecutorAgent(
 
     private suspend fun askLlm(plan: Plan?, screenshotB64: String, ramDigest: String): Triple<String, Map<String, String>, String> {
         // TODO(C3-followup): plug a Koog tool registry so Sonnet can call tools natively.
-        // Until then: return the "(none)" sentinel so dispatch Rejects. The prior
-        // "fallback to plan tail" caused Sonnet to repeat the plan's last step
-        // forever once the recent-failure threshold was hit (Smoke 1 v3 evidence).
-        return Triple("(none)", emptyMap(), "askLlm not yet wired — Reject to trigger advisor replan")
+        // Until then: fall back to the plan's tail step so the emulator keeps
+        // running frames (a pure Reject path skips emulator interaction → the
+        // mapflags=2 transition transient never settles, Smoke 1 v4 evidence).
+        // Fix B (useMenu RAM-diff gate) and Gap #1 (battleFightAll phase gate)
+        // already catch the stealth-no-op variants of plan-tail; anything else
+        // genuinely runs frames and either advances state or Fails honestly.
+        val tail = plan?.steps?.lastOrNull()
+        if (tail?.intentTool != null) return Triple(tail.intentTool, tail.intentArgs ?: emptyMap(), "fallback to plan tail")
+        return Triple("useMenu", mapOf("path" to "main/exit"), "no plan + no LLM wired yet — best-effort menu exit")
     }
 
     private suspend fun dispatch(tool: String, args: Map<String, String>): ToolOutcome = when (tool) {

--- a/knes-agent/src/main/kotlin/knes/agent/v2/agents/ExecutorAgent.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/agents/ExecutorAgent.kt
@@ -39,6 +39,22 @@ class ExecutorAgent(
         val plan = memory.currentPlan
         val step = plan?.steps?.getOrNull(plan.cursor)
 
+        // Plan exhausted (cursor past last step) — signal Reject directly so the
+        // watchdog ticks and the Advisor replans. The previous "fallback to
+        // plan tail" repeated the last step forever, masking progress: Smoke 1
+        // v3 spent 266/300 turns hammering useMenu(shop/exit) via this path.
+        if (plan != null && step == null) {
+            val outcome = ToolOutcome.Reject("plan exhausted at cursor=${plan.cursor}/${plan.steps.size} — awaiting advisor replan")
+            recentOutcomes.addLast(outcome.javaClass.simpleName)
+            if (recentOutcomes.size > 4) recentOutcomes.removeFirst()
+            return ExecutorDecision(
+                tool = "(none)", args = emptyMap(),
+                reasoning = "plan exhausted — Reject to trigger replan",
+                outcome = outcome,
+                ms = System.currentTimeMillis() - started,
+            )
+        }
+
         val (tool, args, reasoning) =
             if (shouldUsePlanHint(step)) {
                 Triple(step!!.intentTool!!, step.intentArgs ?: emptyMap(),
@@ -63,10 +79,10 @@ class ExecutorAgent(
 
     private suspend fun askLlm(plan: Plan?, screenshotB64: String, ramDigest: String): Triple<String, Map<String, String>, String> {
         // TODO(C3-followup): plug a Koog tool registry so Sonnet can call tools natively.
-        // For first cut, fall back to plan tail or safe no-op so the loop doesn't crash.
-        val tail = plan?.steps?.lastOrNull()
-        if (tail?.intentTool != null) return Triple(tail.intentTool, tail.intentArgs ?: emptyMap(), "fallback to plan tail")
-        return Triple("useMenu", mapOf("path" to "main/exit"), "no plan + no LLM wired yet — safe no-op")
+        // Until then: return the "(none)" sentinel so dispatch Rejects. The prior
+        // "fallback to plan tail" caused Sonnet to repeat the plan's last step
+        // forever once the recent-failure threshold was hit (Smoke 1 v3 evidence).
+        return Triple("(none)", emptyMap(), "askLlm not yet wired — Reject to trigger advisor replan")
     }
 
     private suspend fun dispatch(tool: String, args: Map<String, String>): ToolOutcome = when (tool) {

--- a/knes-agent/src/main/kotlin/knes/agent/v2/llm/AnthropicHttp.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/llm/AnthropicHttp.kt
@@ -1,0 +1,100 @@
+package knes.agent.v2.llm
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
+
+/**
+ * Minimal vision-capable Anthropic Messages API wrapper for v2 agents.
+ *
+ * Mirrors GeminiPro31Client's HTTP style. Reused by HaikuClient (scene
+ * description from screenshot) and SonnetClient (tool decision, text-only).
+ */
+class AnthropicHttp(private val apiKey: String) : AutoCloseable {
+    private val http = HttpClient(CIO) {
+        install(HttpTimeout) {
+            requestTimeoutMillis = 120_000
+            socketTimeoutMillis = 120_000
+        }
+    }
+    private val json = Json { ignoreUnknownKeys = true }
+
+    suspend fun generate(
+        model: String,
+        systemPrompt: String,
+        userText: String,
+        imageB64: String? = null,
+        maxTokens: Int = 800,
+    ): String {
+        val body = buildJsonObject {
+            put("model", model)
+            put("max_tokens", maxTokens)
+            put("system", systemPrompt)
+            putJsonArray("messages") {
+                addJsonObject {
+                    put("role", "user")
+                    putJsonArray("content") {
+                        if (imageB64 != null) {
+                            addJsonObject {
+                                put("type", "image")
+                                putJsonObject("source") {
+                                    put("type", "base64")
+                                    put("media_type", "image/png")
+                                    put("data", imageB64)
+                                }
+                            }
+                        }
+                        addJsonObject {
+                            put("type", "text")
+                            put("text", userText)
+                        }
+                    }
+                }
+            }
+        }.toString()
+
+        val resp = http.post(API_URL) {
+            header("x-api-key", apiKey)
+            header("anthropic-version", "2023-06-01")
+            contentType(ContentType.Application.Json)
+            setBody(body)
+        }
+        if (!resp.status.isSuccess()) {
+            throw RuntimeException("Anthropic http ${resp.status.value}: ${resp.bodyAsText().take(400)}")
+        }
+        val text = resp.bodyAsText()
+        val content = json.parseToJsonElement(text).jsonObject["content"]?.jsonArray
+            ?: throw RuntimeException("Anthropic response missing content: ${text.take(400)}")
+        return content.firstOrNull { it.jsonObject["type"]?.jsonPrimitive?.content == "text" }
+            ?.jsonObject?.get("text")?.jsonPrimitive?.content
+            ?: throw RuntimeException("Anthropic response no text block: ${text.take(400)}")
+    }
+
+    override fun close() { http.close() }
+
+    companion object {
+        const val API_URL = "https://api.anthropic.com/v1/messages"
+    }
+}
+
+private inline fun kotlinx.serialization.json.JsonArrayBuilder.addJsonObject(
+    block: kotlinx.serialization.json.JsonObjectBuilder.() -> Unit,
+) { add(buildJsonObject(block)) }

--- a/knes-agent/src/main/kotlin/knes/agent/v2/llm/HaikuClient.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/llm/HaikuClient.kt
@@ -1,9 +1,43 @@
 package knes.agent.v2.llm
 
-import knes.agent.llm.AnthropicSession
-
-class HaikuClient(private val anthropic: AnthropicSession) {
+class HaikuClient(private val http: AnthropicHttp) {
     val modelId = "claude-haiku-4-5-20251001"
-    // ReviewerAgent uses a placeholder LLM invocation for first cut; this
-    // holder pins the model id for the future wire-up.
+
+    /**
+     * Scene description for the Executor. Returns a compact text breakdown of
+     * what's visible in the viewport: party position, visible NPC sprites with
+     * kind+viewport coords, and any interactive overlays (dialog/menu/shop UI).
+     *
+     * Per spec §3: vision pre-processing belongs in Haiku, not the Executor's
+     * Sonnet call directly. Sonnet reads this text + RAM digest + plan and
+     * picks the next tool.
+     */
+    suspend fun describeScene(screenshotB64: String): String {
+        val systemPrompt = """
+            You are a vision pre-processor for an FF1 NES playing agent.
+            Read the screenshot and emit a TERSE scene digest in this exact format
+            (one line per fact, no prose):
+
+            party: vp(<x>,<y>) facing <N|S|E|W|?>
+            overlay: <none|field-menu|dialog|shop-menu|battle|post-battle|title|encounter-flash>
+            sprite: <kind> vp(<x>,<y>) [<short note>]
+            sprite: ...
+            exits-visible: <south|north|east|west|south,east|...|none>
+
+            Rules:
+            - Viewport tiles are 0..15 horizontally, 0..14 vertically. Party sprite is usually at vp(8,7) but verify.
+            - Sprite kinds: shopkeeper, innkeeper, king, generic-npc, chest, sign, exit-tile.
+            - For shopkeeper: include note with merchandise type if visible (weapon/armor/item/magic).
+            - If overlay is shop-menu/dialog/battle, omit sprite lines (they're covered by the UI).
+            - Be honest: if you can't tell, write "?" instead of guessing.
+            - Max 8 lines total. NO markdown, NO extra prose.
+        """.trimIndent()
+        return http.generate(
+            model = modelId,
+            systemPrompt = systemPrompt,
+            userText = "Describe what is on the screen now.",
+            imageB64 = screenshotB64,
+            maxTokens = 400,
+        ).trim()
+    }
 }

--- a/knes-agent/src/main/kotlin/knes/agent/v2/llm/HaikuClient.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/llm/HaikuClient.kt
@@ -40,4 +40,33 @@ class HaikuClient(private val http: AnthropicHttp) {
             maxTokens = 400,
         ).trim()
     }
+
+    /**
+     * One-shot cardinal direction picker for vision-driven walking. Used by
+     * the Town walkTo loop: ask Haiku which cardinal moves the party toward
+     * a described target visible (or believed to be near) on screen. Returns
+     * exactly one of: N, S, E, W, DONE, UNCLEAR.
+     */
+    suspend fun directionTo(screenshotB64: String, targetText: String): String {
+        val systemPrompt = """
+            You navigate an FF1 NES party. The party sprite is usually at viewport
+            tile (8,7). Given a screenshot and a target description, decide which
+            cardinal direction (N/S/E/W) the party should step next to get closer
+            to the target.
+
+            Rules:
+            - Output EXACTLY one token: N, S, E, W, DONE, or UNCLEAR. No prose.
+            - DONE if the party is already adjacent to (or on) the target.
+            - UNCLEAR if you cannot see the target on screen.
+            - Follow locate-party → locate-target → derive-direction. NO prior-knowledge
+              of FF1 geography.
+        """.trimIndent()
+        return http.generate(
+            model = modelId,
+            systemPrompt = systemPrompt,
+            userText = "Target: $targetText. Cardinal direction?",
+            imageB64 = screenshotB64,
+            maxTokens = 8,
+        ).trim().uppercase().take(8)
+    }
 }

--- a/knes-agent/src/main/kotlin/knes/agent/v2/llm/SonnetClient.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/llm/SonnetClient.kt
@@ -1,10 +1,21 @@
 package knes.agent.v2.llm
 
-import knes.agent.llm.AnthropicSession
-
-class SonnetClient(private val anthropic: AnthropicSession) {
+class SonnetClient(private val http: AnthropicHttp) {
     val modelId = "claude-sonnet-4-6"
-    // Real Koog tool-calling integration arrives in a follow-up task. For first
-    // cut ExecutorAgent uses plan-hint dispatch only; this holder reserves the
-    // model id so TurnLog records correctly attribute decisions.
+
+    /**
+     * Per-turn tool decision. Sonnet receives a scene digest (from Haiku), the
+     * RAM digest, the current plan summary, and recent outcomes — then picks
+     * exactly one tool to execute. Returns the raw response text (JSON object
+     * with tool/args/reasoning); ExecutorAgent parses it.
+     */
+    suspend fun decideTool(systemPrompt: String, userText: String): String {
+        return http.generate(
+            model = modelId,
+            systemPrompt = systemPrompt,
+            userText = userText,
+            imageB64 = null,
+            maxTokens = 400,
+        ).trim()
+    }
 }

--- a/knes-agent/src/main/kotlin/knes/agent/v2/runtime/Phase.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/runtime/Phase.kt
@@ -21,7 +21,17 @@ enum class Phase {
         fun fromRam(ram: Map<String, Int>): Phase {
             val mapId = ram["currentMapId"] ?: -1
             val mapflags = ram["mapflags"] ?: 0
-            val battleInProgress = (ram["battleState"] ?: 0) != 0
+            // Battle detection: the ff1 RAM profile doesn't expose a
+            // canonical "battleState" byte. The reliable signals are
+            // screenState=0x68 (battle screen drawn) and battleTurn>0.
+            // Smoke 1 v6 evidence: 12 turns sat in battle (screenState=104,
+            // battleTurn=2, enemyCount=5) but Phase reported Overworld
+            // because the `battleState` lookup missed — blocking Gap #1's
+            // battleFightAll gate on a legitimate battle.
+            val screenState = ram["screenState"] ?: 0
+            val battleInProgress = screenState == 0x68 ||
+                (ram["battleTurn"] ?: 0) > 0 ||
+                (ram["enemyCount"] ?: 0) > 0
             val menuState = ram["menuState"] ?: 0
             val party = (ram["char1_hpLow"] ?: 0) != 0 || (ram["worldX"] ?: 0) != 0
             return when {

--- a/knes-agent/src/main/kotlin/knes/agent/v2/runtime/Phase.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/runtime/Phase.kt
@@ -21,17 +21,15 @@ enum class Phase {
         fun fromRam(ram: Map<String, Int>): Phase {
             val mapId = ram["currentMapId"] ?: -1
             val mapflags = ram["mapflags"] ?: 0
-            // Battle detection: the ff1 RAM profile doesn't expose a
-            // canonical "battleState" byte. The reliable signals are
-            // screenState=0x68 (battle screen drawn) and battleTurn>0.
-            // Smoke 1 v6 evidence: 12 turns sat in battle (screenState=104,
-            // battleTurn=2, enemyCount=5) but Phase reported Overworld
-            // because the `battleState` lookup missed — blocking Gap #1's
-            // battleFightAll gate on a legitimate battle.
+            // Battle detection: screenState == 0x68 is the only signal that
+            // unambiguously means "battle screen is being drawn right now".
+            // battleTurn and enemyCount retain their last-battle values
+            // after victory (Smoke 1 v7 evidence: T86 had screenState=0x60
+            // post-battle but battleTurn=2 enemyCount=5 stale → my prior
+            // "OR battleTurn>0 OR enemyCount>0" check kept Phase=Battle
+            // sticky and blocked the agent from continuing post-victory).
             val screenState = ram["screenState"] ?: 0
-            val battleInProgress = screenState == 0x68 ||
-                (ram["battleTurn"] ?: 0) > 0 ||
-                (ram["enemyCount"] ?: 0) > 0
+            val battleInProgress = screenState == 0x68
             val menuState = ram["menuState"] ?: 0
             val party = (ram["char1_hpLow"] ?: 0) != 0 || (ram["worldX"] ?: 0) != 0
             return when {

--- a/knes-agent/src/main/kotlin/knes/agent/v2/runtime/Phase.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/runtime/Phase.kt
@@ -1,13 +1,22 @@
 package knes.agent.v2.runtime
 
 enum class Phase {
-    Boot, Overworld, Indoors, Battle, MenuStuck,
+    Boot, Overworld, Town, Indoors, Battle, MenuStuck,
     Dialog, BattleMessage, Cutscene, CartographerExplore;
 
     companion object {
         /**
          * Classify from RAM. Reuses v1 phase markers; CartographerExplore is
          * set explicitly by Cartographer agent — never inferred here.
+         *
+         * Town vs Indoors: per `reference_ff1_shop_architecture.md`, FF1 NES
+         * town overlays (Coneria, Pravoka, …) live at mapId=0 with mapflags
+         * bit0=1 — they share the overworld map id but render town tiles.
+         * True building interiors (sub-shops, castles, dungeons) have mapId>0.
+         * Distinguishing matters for walkTo dispatch: Indoors → exitInterior
+         * (bounce out), but Town must NOT bounce — the agent needs to reach
+         * an NPC inside before any buy/inn skill can succeed (see Smoke 0
+         * trace T2-T5 in `2026-05-12-v2-smoke-0-handoff.md`).
          */
         fun fromRam(ram: Map<String, Int>): Phase {
             val mapId = ram["currentMapId"] ?: -1
@@ -20,6 +29,7 @@ enum class Phase {
                 battleInProgress -> Battle
                 menuState != 0 -> MenuStuck
                 mapId == 0 && (mapflags and 1) == 0 -> Overworld
+                mapId == 0 && (mapflags and 1) == 1 -> Town
                 else -> Indoors
             }
         }

--- a/knes-agent/src/main/kotlin/knes/agent/v2/runtime/V2Memory.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/runtime/V2Memory.kt
@@ -48,6 +48,14 @@ class V2Memory(val run: V2RunDirectory) {
             Campaign(
                 startedAt = OffsetDateTime.now().toString(),
                 scope = "coneria_buy_equip_grind",
+                milestones = mutableListOf(
+                    Milestone(id = "boot",          status = "in_progress"),
+                    Milestone(id = "enter_coneria", status = "pending"),
+                    Milestone(id = "buy_weapons",   status = "pending"),
+                    Milestone(id = "equip_weapons", status = "pending"),
+                    Milestone(id = "exit_coneria", status = "pending"),
+                    Milestone(id = "grind",         status = "pending"),
+                ),
             ).also { c ->
                 atomicWrite(run.campaignJson, json.encodeToString(Campaign.serializer(), c))
             }

--- a/knes-agent/src/main/kotlin/knes/agent/v2/runtime/Watchdog.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/runtime/Watchdog.kt
@@ -36,7 +36,7 @@ class Watchdog(
     companion object {
         val DEFAULT_THRESHOLDS: Map<Phase, Int> = mapOf(
             Phase.Battle to 3, Phase.MenuStuck to 3,
-            Phase.Overworld to 5, Phase.Indoors to 5,
+            Phase.Overworld to 5, Phase.Town to 5, Phase.Indoors to 5,
             Phase.CartographerExplore to 10,
         )
     }

--- a/knes-agent/src/main/kotlin/knes/agent/v2/tools/ToolSurface.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/tools/ToolSurface.kt
@@ -247,6 +247,19 @@ class DefaultToolSurface(
 
     override suspend fun buyAtShop(items: List<Int>, charSlots: List<Int>): ToolOutcome {
         require(items.size == charSlots.size) { "items.size must equal charSlots.size" }
+        // Phase pre-flight. BuyAtShop.invoke assumes party is facing the keeper
+        // inside a town overlay; firing it from Overworld returns
+        // "NotInShop: mapflags.bit0=0, mapId=0" (Smoke 1 v12 evidence: 17 such
+        // calls in one run from Sonnet+haiku planning buy without walking in
+        // first). Reject early with a clear hint so the next plan picks walkTo
+        // to the shopkeeper's local coords before re-trying buyAtShop.
+        val phase = phaseProvider()
+        if (phase != Phase.Town) {
+            return ToolOutcome.Reject(
+                "buyAtShop only valid in Phase.Town (current: $phase). " +
+                "Walk into town first via walkTo(<town-entry world coords>), then walkTo(<keeper local coords>), then buyAtShop."
+            )
+        }
         val results = mutableListOf<String>()
         for ((i, c) in items.zip(charSlots)) {
             val r = buyAtShopSkill.invoke(mapOf(

--- a/knes-agent/src/main/kotlin/knes/agent/v2/tools/ToolSurface.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/tools/ToolSurface.kt
@@ -120,7 +120,7 @@ class DefaultToolSurface(
         )
         var steps = 0
         var consecutiveStuck = 0
-        var lastSm = -1 to -1
+        val stuckLimit = 8
         while (steps < maxSteps) {
             val r = toolset.getState().ram
             val sx = r["smPlayerX"] ?: 0
@@ -138,35 +138,75 @@ class DefaultToolSurface(
             } catch (e: Exception) {
                 return ToolOutcome.Fail("townWalk: Haiku error after $steps steps: ${e.message?.take(80)}")
             }
-            val btn = mapCardinal(dir) ?: run {
-                // Haiku unsure — fallback to dominant-axis cardinal toward target
-                when {
-                    kotlin.math.abs(dx) >= kotlin.math.abs(dy) && dx != 0 -> if (dx > 0) "Right" else "Left"
-                    dy != 0 -> if (dy > 0) "Down" else "Up"
-                    else -> null
-                }
-            }
-            if (btn == null)
-                return ToolOutcome.Fail("townWalk: no direction (Haiku=$dir, dx=$dx dy=$dy) after $steps steps")
+            val primary = mapCardinal(dir) ?: dominantAxisCardinal(dx, dy)
+                ?: return ToolOutcome.Fail("townWalk: no direction (Haiku=$dir, dx=$dx dy=$dy) after $steps steps")
 
-            toolset.tap(button = btn, count = 1, pressFrames = 5, gapFrames = 12)
-            steps++
-
+            // Try primary; if blocked, try both perpendicular cardinals before
+            // counting as stuck. Coneria evidence (Smoke 1 v10): party reached
+            // sm=(15,18), Haiku kept picking blocked cardinal — single-direction
+            // retry hit the 4-stuck guard and gave up. Perpendicular fallback
+            // lets us route around walls/NPCs without a full BFS pathfinder.
+            val tried = tryCardinals(primary, dx, dy, sx, sy)
+            steps += tried.tapsUsed
             val r2 = toolset.getState().ram
             val sx2 = r2["smPlayerX"] ?: 0
             val sy2 = r2["smPlayerY"] ?: 0
             val moved = (sx2 != sx || sy2 != sy)
-            if (!moved && (sx2 to sy2) == lastSm) {
+            if (!moved) {
                 consecutiveStuck++
-                if (consecutiveStuck >= 4)
-                    return ToolOutcome.Fail("townWalk: stuck at sm=($sx,$sy) for 4 taps toward ($tx,$ty)")
+                if (consecutiveStuck >= stuckLimit)
+                    return ToolOutcome.Fail("townWalk: stuck at sm=($sx,$sy) for $stuckLimit rounds toward ($tx,$ty); tried=${tried.tried.joinToString(",")}")
             } else {
                 consecutiveStuck = 0
             }
-            lastSm = sx to sy
         }
         val r = toolset.getState().ram
         return ToolOutcome.Fail("townWalk: maxSteps=$maxSteps reached, sm=(${r["smPlayerX"]},${r["smPlayerY"]}) target=($tx,$ty)")
+    }
+
+    private data class CardinalTryResult(val tried: List<String>, val tapsUsed: Int)
+
+    /** Try primary, then perpendiculars, then opposite — first one that moves the party wins. */
+    private suspend fun tryCardinals(
+        primary: String, dx: Int, dy: Int, sx: Int, sy: Int,
+    ): CardinalTryResult {
+        // Build try order: primary first, then two perpendiculars (target-biased),
+        // then the opposite (last resort).
+        val perps = perpendicularsOf(primary, dx, dy)
+        val opp = oppositeOf(primary)
+        val order = listOfNotNull(primary, perps.first, perps.second, opp).distinct()
+        val tried = mutableListOf<String>()
+        var tapsUsed = 0
+        for (btn in order) {
+            toolset.tap(button = btn, count = 1, pressFrames = 5, gapFrames = 12)
+            tapsUsed++
+            tried += btn
+            val r = toolset.getState().ram
+            val nx = r["smPlayerX"] ?: 0
+            val ny = r["smPlayerY"] ?: 0
+            if (nx != sx || ny != sy) break
+        }
+        return CardinalTryResult(tried, tapsUsed)
+    }
+
+    private fun dominantAxisCardinal(dx: Int, dy: Int): String? = when {
+        kotlin.math.abs(dx) >= kotlin.math.abs(dy) && dx != 0 -> if (dx > 0) "Right" else "Left"
+        dy != 0 -> if (dy > 0) "Down" else "Up"
+        else -> null
+    }
+
+    private fun perpendicularsOf(primary: String, dx: Int, dy: Int): Pair<String, String> {
+        // For a vertical primary (Up/Down), perpendiculars are Left/Right — biased
+        // toward dx sign. Vice-versa for horizontal.
+        return when (primary) {
+            "Up", "Down" -> if (dx >= 0) "Right" to "Left" else "Left" to "Right"
+            "Left", "Right" -> if (dy >= 0) "Down" to "Up" else "Up" to "Down"
+            else -> "Up" to "Down"
+        }
+    }
+
+    private fun oppositeOf(primary: String): String = when (primary) {
+        "Up" -> "Down"; "Down" -> "Up"; "Left" -> "Right"; "Right" -> "Left"; else -> "Down"
     }
 
     private fun mapCardinal(dir: String): String? = when (dir.trim().uppercase().take(4)) {

--- a/knes-agent/src/main/kotlin/knes/agent/v2/tools/ToolSurface.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/tools/ToolSurface.kt
@@ -44,6 +44,16 @@ class DefaultToolSurface(
     override suspend fun walkTo(x: Int, y: Int): ToolOutcome = when (phaseProvider()) {
         Phase.Overworld -> wrap(walkOverworld.invoke(mapOf("targetX" to "$x", "targetY" to "$y", "maxSteps" to "32")))
         Phase.Indoors   -> wrap(exitInterior.invoke(mapOf("maxSteps" to "64")))
+        // Town overlay (mapId=0, mapflags.bit0=1): no in-town pathfinder yet.
+        // Returning Reject avoids the prior bug where Indoors-dispatch routed
+        // here, calling exitInterior and bouncing the agent back to overworld
+        // before it could ever reach the shopkeeper (Smoke 0 T2-T5 trace).
+        // Caller must use interactAt at the landmark's local coords, or
+        // (once available) a townWalkTo skill.
+        Phase.Town      -> ToolOutcome.Reject(
+            "walkTo not implemented for Town overlay — use interactAt at landmark local coords " +
+            "(see prompt for known landmarks)"
+        )
         else -> ToolOutcome.Reject("walkTo not applicable in phase ${phaseProvider()}")
     }
 

--- a/knes-agent/src/main/kotlin/knes/agent/v2/tools/ToolSurface.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/tools/ToolSurface.kt
@@ -118,11 +118,29 @@ class DefaultToolSurface(
         val haiku = this.haiku ?: return ToolOutcome.Reject(
             "townWalkVision: Haiku not wired (DefaultToolSurface haiku=null)"
         )
+        // Snapshot the map identity at start. If either changes mid-loop we've
+        // left the town overlay (typically by stepping onto a door tile that
+        // triggered a castle/inn/shop transition). Abort cleanly so Sonnet
+        // can replan instead of cardinal-tapping deeper into the unintended
+        // interior. Smoke 1 v11 evidence: townWalk pushed party north out
+        // Coneria's top exit into Coneria CASTLE (mapId=8) → throne room
+        // (mapId=24).
+        val startMapId = toolset.getState().ram["currentMapId"] ?: 0
+        val startMapflagsBit0 = (toolset.getState().ram["mapflags"] ?: 0) and 0x01
         var steps = 0
         var consecutiveStuck = 0
         val stuckLimit = 8
         while (steps < maxSteps) {
             val r = toolset.getState().ram
+            val curMapId = r["currentMapId"] ?: 0
+            val curMapflagsBit0 = (r["mapflags"] ?: 0) and 0x01
+            if (curMapId != startMapId || curMapflagsBit0 != startMapflagsBit0) {
+                return ToolOutcome.Reject(
+                    "townWalk: left town overlay mid-loop (startMid=$startMapId/mfBit0=$startMapflagsBit0 " +
+                    "→ now mid=$curMapId/mfBit0=$curMapflagsBit0); door tile triggered transition. " +
+                    "Caller should walk back to overworld and reapproach."
+                )
+            }
             val sx = r["smPlayerX"] ?: 0
             val sy = r["smPlayerY"] ?: 0
             val dx = tx - sx

--- a/knes-agent/src/main/kotlin/knes/agent/v2/tools/ToolSurface.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/tools/ToolSurface.kt
@@ -43,7 +43,9 @@ class DefaultToolSurface(
 
     override suspend fun walkTo(x: Int, y: Int): ToolOutcome = when (phaseProvider()) {
         Phase.Overworld -> wrap(walkOverworld.invoke(mapOf("targetX" to "$x", "targetY" to "$y", "maxSteps" to "32")))
+            .also { if (it is ToolOutcome.Ok) settleMapflagsTransient() }
         Phase.Indoors   -> wrap(exitInterior.invoke(mapOf("maxSteps" to "64")))
+            .also { if (it is ToolOutcome.Ok) settleMapflagsTransient() }
         // Town overlay (mapId=0, mapflags.bit0=1): no in-town pathfinder yet.
         // Returning Reject avoids the prior bug where Indoors-dispatch routed
         // here, calling exitInterior and bouncing the agent back to overworld
@@ -81,6 +83,25 @@ class DefaultToolSurface(
             return ToolOutcome.Reject("useMenu had no effect — menu/screen state unchanged (pre=post=$pre); path '$path' likely doesn't match current screen")
         }
         return ToolOutcome.Ok("menu walked: $path")
+    }
+
+    /**
+     * Wait for the mapflags bit1 transition transient to clear after a successful
+     * walk. Pattern from ExitTownEmpirical.kt:104: mapflags bit1 = "dialog/menu
+     * active in transition"; resolves within ~300 frames once the engine commits
+     * to the new map/overlay. Without this, Smoke 1 v3/v4/v5 fired buyAtShop
+     * immediately after walkTo while mapflags=2 (bit0=0, bit1=1) and BuyAtShop's
+     * standard-map check failed with "NotInShop: mapflags.bit0=0, mapId=0".
+     *
+     * Polls in 60-frame chunks up to ~5 seconds wallclock. Idempotent if bit1
+     * is already clear.
+     */
+    private suspend fun settleMapflagsTransient() {
+        repeat(5) {
+            val mf = toolset.getState().ram["mapflags"] ?: 0
+            if ((mf and 0x02) == 0) return
+            toolset.step(buttons = emptyList(), frames = 60)
+        }
     }
 
     private suspend fun snapshotMenuRam(): List<Int> {

--- a/knes-agent/src/main/kotlin/knes/agent/v2/tools/ToolSurface.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/tools/ToolSurface.kt
@@ -95,6 +95,18 @@ class DefaultToolSurface(
     }
 
     override suspend fun battleFightAll(): ToolOutcome {
+        // Gate on Phase.Battle. The ff1.battle_fight_all profile action
+        // returns ok=true with "Battle complete in 0 rounds" when no battle
+        // is in progress (it just confirms the post-battle screen check
+        // passed trivially). Smoke 1 evidence: Sonnet picked this 1484×
+        // in a row in Town because it was the only tool returning ok, and
+        // the watchdog never tripped (skillProgress=true reset the counter).
+        // Rejecting here forces real failure to surface so the Advisor can
+        // replan toward the actual buy/walk flow.
+        val phase = phaseProvider()
+        if (phase != Phase.Battle) {
+            return ToolOutcome.Reject("battleFightAll only valid in Phase.Battle (current: $phase)")
+        }
         val r = toolset.executeAction(profileId = "ff1", actionId = "battle_fight_all")
         return if (r.ok) ToolOutcome.Ok(r.message, r.data) else ToolOutcome.Fail(r.message)
     }

--- a/knes-agent/src/main/kotlin/knes/agent/v2/tools/ToolSurface.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/tools/ToolSurface.kt
@@ -67,8 +67,30 @@ class DefaultToolSurface(
     override suspend fun useMenu(path: String): ToolOutcome {
         val taps = try { menuWalker.parse(path) }
                    catch (e: IllegalArgumentException) { return ToolOutcome.Reject(e.message ?: "bad path") }
+        // RAM-diff gate: capture menu/screen state before and after taps. If
+        // nothing changes, the path didn't match what was actually on screen
+        // (e.g. shop/exit when no shop dialog open) — return Reject so the
+        // watchdog can tick. Without this, MenuWalker happily emits button
+        // taps for any well-formed path; Smoke 1 v3 evidence: 266/300 turns
+        // looping useMenu(shop/exit) with screenState=menuCursor=menuHandX
+        // =menuHandY=0 throughout, every call returning ok.
+        val pre = snapshotMenuRam()
         for (t in taps) toolset.tap(button = t.button, count = t.count, pressFrames = 5, gapFrames = 12)
+        val post = snapshotMenuRam()
+        if (pre == post) {
+            return ToolOutcome.Reject("useMenu had no effect — menu/screen state unchanged (pre=post=$pre); path '$path' likely doesn't match current screen")
+        }
         return ToolOutcome.Ok("menu walked: $path")
+    }
+
+    private suspend fun snapshotMenuRam(): List<Int> {
+        val r = toolset.getState().ram
+        return listOf(
+            r["screenState"] ?: 0,
+            r["menuCursor"] ?: 0,
+            r["menuHandX"] ?: 0,
+            r["menuHandY"] ?: 0,
+        )
     }
 
     override suspend fun buyAtShop(items: List<Int>, charSlots: List<Int>): ToolOutcome {

--- a/knes-agent/src/main/kotlin/knes/agent/v2/tools/ToolSurface.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/tools/ToolSurface.kt
@@ -8,6 +8,7 @@ import knes.agent.skills.RestAtInn
 import knes.agent.skills.SkillResult
 import knes.agent.skills.WalkOverworldTo
 import knes.agent.tools.EmulatorToolset
+import knes.agent.v2.llm.HaikuClient
 import knes.agent.v2.runtime.Phase
 
 sealed class ToolOutcome {
@@ -36,6 +37,7 @@ class DefaultToolSurface(
     private val buyAtShopSkill: BuyAtShop,
     private val equipWeaponSkill: EquipWeapon,
     private val restAtInnSkill: RestAtInn,
+    private val haiku: HaikuClient? = null,
     private val menuWalker: MenuWalker = MenuWalker(),
 ) : ToolSurface {
 
@@ -46,16 +48,10 @@ class DefaultToolSurface(
             .also { if (it is ToolOutcome.Ok) settleMapflagsTransient() }
         Phase.Indoors   -> wrap(exitInterior.invoke(mapOf("maxSteps" to "64")))
             .also { if (it is ToolOutcome.Ok) settleMapflagsTransient() }
-        // Town overlay (mapId=0, mapflags.bit0=1): no in-town pathfinder yet.
-        // Returning Reject avoids the prior bug where Indoors-dispatch routed
-        // here, calling exitInterior and bouncing the agent back to overworld
-        // before it could ever reach the shopkeeper (Smoke 0 T2-T5 trace).
-        // Caller must use interactAt at the landmark's local coords, or
-        // (once available) a townWalkTo skill.
-        Phase.Town      -> ToolOutcome.Reject(
-            "walkTo not implemented for Town overlay — use interactAt at landmark local coords " +
-            "(see prompt for known landmarks)"
-        )
+        // Town overlay (mapId=0, mapflags.bit0=1): in-town movement via
+        // Haiku-vision per step + RAM verification. Caller passes target
+        // *local* coords (smPlayerX/smPlayerY space), not overworld.
+        Phase.Town      -> townWalkVision(x, y, maxSteps = 30)
         else -> ToolOutcome.Reject("walkTo not applicable in phase ${phaseProvider()}")
     }
 
@@ -102,6 +98,83 @@ class DefaultToolSurface(
             if ((mf and 0x02) == 0) return
             toolset.step(buttons = emptyList(), frames = 60)
         }
+    }
+
+    /**
+     * Vision-driven in-town walk. Target (tx, ty) is interpreted as
+     * smPlayerX/smPlayerY (town-local) coordinates. Each step:
+     *  1. Read smPlayer. If already at or adjacent to target → Ok.
+     *  2. Ask Haiku for the next cardinal toward the target, with the
+     *     screenshot as context (Haiku locates party + target → derives
+     *     direction per `feedback_locate_party_first.md`).
+     *  3. Tap that cardinal; verify smPlayer changed via RAM.
+     *  4. If no movement (NPC block / wall), try the perpendicular axis
+     *     toward the target. After K consecutive non-moves, give up.
+     *
+     * Returns Ok if adjacent to target, Fail otherwise. Reject if Haiku
+     * isn't wired (test harness path).
+     */
+    private suspend fun townWalkVision(tx: Int, ty: Int, maxSteps: Int): ToolOutcome {
+        val haiku = this.haiku ?: return ToolOutcome.Reject(
+            "townWalkVision: Haiku not wired (DefaultToolSurface haiku=null)"
+        )
+        var steps = 0
+        var consecutiveStuck = 0
+        var lastSm = -1 to -1
+        while (steps < maxSteps) {
+            val r = toolset.getState().ram
+            val sx = r["smPlayerX"] ?: 0
+            val sy = r["smPlayerY"] ?: 0
+            val dx = tx - sx
+            val dy = ty - sy
+            if (sx == tx && sy == ty)
+                return ToolOutcome.Ok("townWalk: reached ($tx,$ty) in $steps steps")
+            if (kotlin.math.abs(dx) + kotlin.math.abs(dy) == 1)
+                return ToolOutcome.Ok("townWalk: adjacent to ($tx,$ty) at sm=($sx,$sy) in $steps steps")
+
+            val b64 = toolset.getScreen().base64
+            val dir = try {
+                haiku.directionTo(b64, "town tile local($tx,$ty) — distance dx=$dx dy=$dy from party at local($sx,$sy)")
+            } catch (e: Exception) {
+                return ToolOutcome.Fail("townWalk: Haiku error after $steps steps: ${e.message?.take(80)}")
+            }
+            val btn = mapCardinal(dir) ?: run {
+                // Haiku unsure — fallback to dominant-axis cardinal toward target
+                when {
+                    kotlin.math.abs(dx) >= kotlin.math.abs(dy) && dx != 0 -> if (dx > 0) "Right" else "Left"
+                    dy != 0 -> if (dy > 0) "Down" else "Up"
+                    else -> null
+                }
+            }
+            if (btn == null)
+                return ToolOutcome.Fail("townWalk: no direction (Haiku=$dir, dx=$dx dy=$dy) after $steps steps")
+
+            toolset.tap(button = btn, count = 1, pressFrames = 5, gapFrames = 12)
+            steps++
+
+            val r2 = toolset.getState().ram
+            val sx2 = r2["smPlayerX"] ?: 0
+            val sy2 = r2["smPlayerY"] ?: 0
+            val moved = (sx2 != sx || sy2 != sy)
+            if (!moved && (sx2 to sy2) == lastSm) {
+                consecutiveStuck++
+                if (consecutiveStuck >= 4)
+                    return ToolOutcome.Fail("townWalk: stuck at sm=($sx,$sy) for 4 taps toward ($tx,$ty)")
+            } else {
+                consecutiveStuck = 0
+            }
+            lastSm = sx to sy
+        }
+        val r = toolset.getState().ram
+        return ToolOutcome.Fail("townWalk: maxSteps=$maxSteps reached, sm=(${r["smPlayerX"]},${r["smPlayerY"]}) target=($tx,$ty)")
+    }
+
+    private fun mapCardinal(dir: String): String? = when (dir.trim().uppercase().take(4)) {
+        "N", "UP" -> "Up"
+        "S", "DOWN" -> "Down"
+        "E", "RIGHT" -> "Right"
+        "W", "LEFT" -> "Left"
+        else -> null
     }
 
     private suspend fun snapshotMenuRam(): List<Int> {

--- a/knes-agent/src/test/kotlin/knes/agent/v2/runtime/PhaseTest.kt
+++ b/knes-agent/src/test/kotlin/knes/agent/v2/runtime/PhaseTest.kt
@@ -37,11 +37,16 @@ class PhaseTest : StringSpec({
         )) shouldBe Phase.Battle
     }
 
-    "Battle: battleTurn>0 alone classifies as Battle" {
+    "Post-battle: stale battleTurn/enemyCount without screenState=0x68 → not Battle" {
+        // After victory, screenState transitions away from 0x68 but
+        // battleTurn/enemyCount retain their last values. Phase must
+        // recover to Overworld (or whatever map+mapflags says) so the
+        // agent can continue the campaign loop — see Smoke 1 v7 sticky
+        // bug in 2026-05-12-v2-smoke handoff.
         Phase.fromRam(mapOf(
             "currentMapId" to 0, "mapflags" to 0,
             "char1_hpLow" to 35, "worldX" to 149,
-            "battleTurn" to 1,
-        )) shouldBe Phase.Battle
+            "screenState" to 0x60, "battleTurn" to 2, "enemyCount" to 5,
+        )) shouldBe Phase.Overworld
     }
 })

--- a/knes-agent/src/test/kotlin/knes/agent/v2/runtime/PhaseTest.kt
+++ b/knes-agent/src/test/kotlin/knes/agent/v2/runtime/PhaseTest.kt
@@ -28,4 +28,20 @@ class PhaseTest : StringSpec({
     "Boot: no party state → Boot" {
         Phase.fromRam(mapOf("currentMapId" to 0, "mapflags" to 0)) shouldBe Phase.Boot
     }
+
+    "Battle: screenState=0x68 → Battle (even with mapflags=0)" {
+        Phase.fromRam(mapOf(
+            "currentMapId" to 0, "mapflags" to 0,
+            "char1_hpLow" to 35, "worldX" to 149,
+            "screenState" to 0x68, "battleTurn" to 2, "enemyCount" to 5,
+        )) shouldBe Phase.Battle
+    }
+
+    "Battle: battleTurn>0 alone classifies as Battle" {
+        Phase.fromRam(mapOf(
+            "currentMapId" to 0, "mapflags" to 0,
+            "char1_hpLow" to 35, "worldX" to 149,
+            "battleTurn" to 1,
+        )) shouldBe Phase.Battle
+    }
 })

--- a/knes-agent/src/test/kotlin/knes/agent/v2/runtime/PhaseTest.kt
+++ b/knes-agent/src/test/kotlin/knes/agent/v2/runtime/PhaseTest.kt
@@ -1,0 +1,31 @@
+package knes.agent.v2.runtime
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class PhaseTest : StringSpec({
+    "Town overlay: mapId=0, mapflags.bit0=1 → Town (not Indoors)" {
+        Phase.fromRam(mapOf(
+            "currentMapId" to 0, "mapflags" to 1,
+            "char1_hpLow" to 30, "worldX" to 147,
+        )) shouldBe Phase.Town
+    }
+
+    "Overworld: mapId=0, mapflags=0 → Overworld" {
+        Phase.fromRam(mapOf(
+            "currentMapId" to 0, "mapflags" to 0,
+            "char1_hpLow" to 30, "worldX" to 147,
+        )) shouldBe Phase.Overworld
+    }
+
+    "Interior building: mapId>0 → Indoors" {
+        Phase.fromRam(mapOf(
+            "currentMapId" to 8, "mapflags" to 1,
+            "char1_hpLow" to 30, "worldX" to 147,
+        )) shouldBe Phase.Indoors
+    }
+
+    "Boot: no party state → Boot" {
+        Phase.fromRam(mapOf("currentMapId" to 0, "mapflags" to 0)) shouldBe Phase.Boot
+    }
+})

--- a/knes-agent/src/test/kotlin/knes/agent/v2/runtime/V2MemoryTest.kt
+++ b/knes-agent/src/test/kotlin/knes/agent/v2/runtime/V2MemoryTest.kt
@@ -11,6 +11,9 @@ class V2MemoryTest : StringSpec({
         val run = V2RunDirectory(tmpRoot).also { it.ensure() }
 
         val m1 = V2Memory(run)
+        // First-open auto-seeds the coneria_buy_equip_grind milestones; clear them so
+        // this test exercises a clean append + reopen round-trip.
+        m1.campaign.milestones.clear()
         m1.campaign.milestones += Milestone(id = "boot", status = "done", turnStart = 1, turnEnd = 47)
         m1.campaign.plans += PlanEntry(turn = 48, by = "advisor", summary = "head to (15,22)", snapshot = "snapshots/turn-00048.png")
         m1.saveCampaign()


### PR DESCRIPTION
Continuation of #126 (squash-merged). Empirical trajectory of v2 from "always bounced out of Coneria" through "first battle won" to "navigates inside town, no castle traps." Across 14 commits and 13 Smoke 1 runs.

## What landed (14 commits)

### Phase classifier
- `3cdf425` Phase.Town split (mapId=0 + mapflags.bit0=1) — was misclassified as Indoors, walkTo dispatched exitInterior bouncing party out.
- `fab0d1c` Phase battle detection via `screenState=0x68 || battleTurn>0 || enemyCount>0`.
- `b13536f` Narrow battle to `screenState=0x68` only — battleTurn / enemyCount retain stale values post-victory, were causing sticky-Battle phase.

### Tool surface — stealth-no-op gates + town navigation
- `8727de6` `battleFightAll` Phase gate — was returning ok=true with 0 rounds when not in battle, Sonnet looped 1484× on it in Smoke 1 v3.
- `1e4cefb` `useMenu` RAM-diff gate + ExecutorAgent plan-exhausted Reject + askLlm fallback fix.
- `481fac0` Reset `recentOutcomes` on plan change so Advisor replans actually execute step 0.
- `609f9bb` mapflags=2 transition transient settle wait after walkTo Ok.
- `e7cc941` Vision-driven Town walkTo (Haiku per step + RAM verify) — replaces the prior "Reject" stub so party can actually move inside town overlay.
- `e1da9b1` townWalk perpendicular-cardinal fallback + stuck threshold 4→8 — escape corners Haiku can't unblock with one direction.
- `9c65f00` townWalk transition guard — abort if mapId or mapflags.bit0 changes mid-loop, prevents accidental castle entry via north exit door.
- `371b45c` buyAtShop Phase pre-flight Reject when not in Town + tighter Sonnet prompt for buyAtShop ONLY when party adjacent to keeper.

### Campaign infrastructure
- `f74c29a` Seed campaign milestones + advance them in main loop — `currentMilestone()` was falling through to "boot" forever, Advisor kept replanning "Restart with default party."

### Executor — vision via Haiku scene + Sonnet decide (Option A)
- `5124716` `AnthropicHttp` minimal Messages API wrapper + `HaikuClient.describeScene(b64)` returning a TERSE scene digest (party/overlay/sprites/exits) + `SonnetClient.decideTool(...)` returning JSON tool decision. ExecutorAgent.askLlm now uses both instead of the placeholder plan-tail fallback.

### Docs
- `a4bb354` Smoke 1 handoff with 3 gaps identified (post-Smoke-1-v1).

## Empirical progression (Smoke 1 runs)

| run | turns | Phase=Town | Phase=Battle | Castle trap | battleFightAll ok | Weapons bought |
|---|---|---|---|---|---|---|
| v3 (handoff) | 1500 | 1486 | 0 (misclassified) | no | 0 (1484 false-ok) | 0 |
| v4 | 43 (killed) | 0 frozen | 0 | no | 0 | 0 |
| v5 | 86 (killed) | 7 | 0 | no | 0 | 0 |
| v6 | 91 (killed) | 11 | 12 (sticky) | no | 0 | 0 |
| v7 | 89 (killed) | 1 brief | 11+ correct | no | **1** | 0 |
| v8 | 300 | 16 | 0 (no encounter) | no | 0 | 0 |
| v9 | 64 (killed) | 29 | 0 | no | 0 | 0 |
| v10 | 52 (killed) | 44 | 0 | no | 0 | 0 (stuck at sm=(15,18)) |
| v11 | 22 (killed) | 3 | 0 | **15 turns** | 0 | 0 |
| v12 | 300 | 19 | 0 | **0 (guard fired 5×)** | 0 | 0 |

**Headline:** v7 won FF1's first random encounter (+30 gold). v12 confirms transition guard keeps party out of castle. Token-flow architecture validated end-to-end: Haiku scene digest → Sonnet tool JSON → ToolSurface dispatch → RAM/vision verify.

## What's NOT in this PR (carried forward)

- **0/4 weapons bought** — Gap #3 (keeper-approach inside town) still open. townWalkVision gets party near shopkeeper but Haiku has trouble routing the final approach to keeper-adjacent (vp distance ≤ 1).
- Reviewer audit (spec §7) still placeholder.
- Resumer decision replay (spec D2).
- Sonnet native tool-calling (spec C3 — currently uses JSON-via-text).

## Test plan
- [x] \`./gradlew :knes-agent:test --tests 'knes.agent.v2.*'\` green (PhaseTest 6/6, WatchdogTest 4/4, V2MemoryTest 1/1, MenuWalkerTest 5/5)
- [ ] Smoke 1 v13 with #126-merged master baseline
- [ ] Land Gap #3 (keeper-approach) follow-up — see body of newest handoff doc

## Handoffs
- \`docs/superpowers/notes/2026-05-12-v2-smoke-0-handoff.md\` (in #126)
- \`docs/superpowers/notes/2026-05-12-v2-smoke-1-handoff.md\` (this PR — \`a4bb354\`)