### PR TITLE
chore(knes-agent): logical separation — agent no longer depends on emulator directly

### DIFF
--- a/knes-agent-tools/src/main/kotlin/knes/agent/tools/EmulatorToolset.kt
+++ b/knes-agent-tools/src/main/kotlin/knes/agent/tools/EmulatorToolset.kt
@@ -26,6 +26,15 @@ open class EmulatorToolset(
     val session: EmulatorSession,
     private val controller: ApiController = session.controller,
 ) : ToolSet {
+
+    companion object {
+        fun local(): EmulatorToolset = EmulatorToolset(EmulatorSession())
+    }
+
+    fun saveSavestate(): ByteArray = session.saveState()
+    fun loadSavestate(bytes: ByteArray): Boolean = session.loadState(bytes)
+    fun advanceFrames(count: Int) = session.advanceFrames(count)
+
     @Tool
     @LLMDescription("Load a NES ROM from the given file path. Requires the Compose UI with embedded API server running on port 6502.")
     open fun loadRom(path: String): StatusResult {

--- a/knes-agent-tools/src/main/kotlin/knes/agent/tools/RemoteEmulatorToolset.kt
+++ b/knes-agent-tools/src/main/kotlin/knes/agent/tools/RemoteEmulatorToolset.kt
@@ -51,6 +51,11 @@ class RemoteEmulatorToolset(
     sessionStub: EmulatorSession = EmulatorSession(),
 ) : EmulatorToolset(sessionStub) {
 
+    companion object {
+        fun remote(url: String): RemoteEmulatorToolset = RemoteEmulatorToolset(url)
+    }
+
+
     private val http: HttpClient = HttpClient.newBuilder()
         .connectTimeout(Duration.ofSeconds(5))
         .build()

--- a/knes-agent/build.gradle
+++ b/knes-agent/build.gradle
@@ -25,11 +25,7 @@ tasks.register('runV2', JavaExec) {
 }
 
 dependencies {
-    implementation project(':knes-emulator')
-    implementation project(':knes-controllers')
-    implementation project(':knes-debug')
     implementation project(':knes-agent-tools')
-    implementation project(':knes-emulator-session')
 
     // Koog — pin to a specific release at first compile; update if breaking.
     implementation 'ai.koog:agents-core:0.6.1'
@@ -43,6 +39,10 @@ dependencies {
     implementation 'ch.qos.logback:logback-classic:1.5.6'
     implementation 'io.ktor:ktor-client-cio:3.3.0'
 
+    testImplementation project(':knes-emulator')
+    testImplementation project(':knes-controllers')
+    testImplementation project(':knes-debug')
+    testImplementation project(':knes-emulator-session')
     testImplementation 'io.kotest:kotest-runner-junit5:6.1.4'
     testImplementation 'io.kotest:kotest-assertions-core:6.1.4'
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1'

--- a/knes-agent/src/main/kotlin/knes/agent/v2/Main.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/Main.kt
@@ -16,6 +16,7 @@ import knes.agent.skills.PressStartUntilOverworld
 import knes.agent.skills.RestAtInn
 import knes.agent.skills.WalkOverworldTo
 import knes.agent.tools.EmulatorToolset
+import knes.agent.tools.RemoteEmulatorToolset
 import knes.agent.v2.agents.AdvisorAgent
 import knes.agent.v2.agents.CartographerAgent
 import knes.agent.v2.agents.ExecutorAgent
@@ -36,7 +37,6 @@ import knes.agent.v2.runtime.TurnLog
 import knes.agent.v2.runtime.WatchdogTrace
 import knes.agent.v2.tools.DefaultToolSurface
 import knes.agent.v2.tools.ToolOutcome
-import knes.api.EmulatorSession
 import kotlinx.coroutines.runBlocking
 import java.io.File
 import java.nio.file.Files
@@ -72,12 +72,11 @@ fun main(args: Array<String>) {
                 // `--remote=<url>` is set. The remote variant skips loadRom
                 // (the UI loads the ROM) and savestate checkpoints (no
                 // /save endpoint yet).
-                val session = EmulatorSession()
                 val toolset: EmulatorToolset = if (cfg.remoteUrl != null) {
                     Log.event("REMOTE mode — RemoteEmulatorToolset → ${cfg.remoteUrl} (ROM must be loaded in UI; /save checkpoints skipped)")
-                    knes.agent.tools.RemoteEmulatorToolset(cfg.remoteUrl, session)
+                    RemoteEmulatorToolset.remote(cfg.remoteUrl)
                 } else {
-                    EmulatorToolset(session)
+                    EmulatorToolset.local()
                 }
                 if (cfg.remoteUrl == null) {
                     require(toolset.loadRom(cfg.rom).ok) { "Failed to load ROM: ${cfg.rom}" }
@@ -98,7 +97,7 @@ fun main(args: Array<String>) {
                     require(cfg.remoteUrl == null) {
                         "--resume is not supported with --remote (no save/load over REST yet)"
                     }
-                    Resumer(session, run, memory).resume()
+                    Resumer(toolset, run, memory).resume()
                 }
                 val snapshotDumper = SnapshotDumper(toolset, run)
                 val watchdog = Watchdog()
@@ -415,7 +414,7 @@ fun main(args: Array<String>) {
                         // `session` isn't driving the emulator, so its
                         // saveState() snapshot would be garbage (an empty
                         // NES at boot state, not the Compose UI's frame).
-                        val saveBytes = session.saveState()
+                        val saveBytes = toolset.saveSavestate()
                         Files.write(run.savestate(turn), saveBytes)
                         Log.ok("checkpoint saved (${saveBytes.size} bytes)", turn)
                     }

--- a/knes-agent/src/main/kotlin/knes/agent/v2/runtime/Resumer.kt
+++ b/knes-agent/src/main/kotlin/knes/agent/v2/runtime/Resumer.kt
@@ -1,10 +1,10 @@
 package knes.agent.v2.runtime
 
-import knes.api.EmulatorSession
+import knes.agent.tools.EmulatorToolset
 import java.nio.file.Files
 
 class Resumer(
-    private val session: EmulatorSession,
+    private val toolset: EmulatorToolset,
     private val run: V2RunDirectory,
     private val memory: V2Memory,
 ) {
@@ -21,10 +21,10 @@ class Resumer(
             return
         }
         // PPU pre-warm (per v1 Main pattern)
-        session.advanceFrames(120)
-        val ok = session.loadState(Files.readAllBytes(checkpoint))
+        toolset.advanceFrames(120)
+        val ok = toolset.loadSavestate(Files.readAllBytes(checkpoint))
         require(ok) { "loadState failed for $checkpoint" }
-        session.advanceFrames(120)
+        toolset.advanceFrames(120)
         Log.ok("resume: restored T$checkpointTurn (last_turn=$lastTurn). Replay T$checkpointTurn→T$lastTurn not implemented — Advisor will reconcile via campaign.json.")
         // TODO(D2-followup): replay button events from decisions/turn-(checkpointTurn+1).json..turn-lastTurn.json
     }


### PR DESCRIPTION
## Summary

Krok 1 separacji logicznej agenta od emulatora. Kod produkcyjny `knes-agent` zależy teraz wyłącznie od `knes-agent-tools` — żadnych bezpośrednich importów z `knes-emulator`, `knes-api`, `knes-debug`.

**Zmiany w `knes-agent-tools`:**
- `EmulatorToolset.local()` — fabryka zamiast `EmulatorSession()` w Main
- `RemoteEmulatorToolset.remote(url)` — fabryka dla trybu zdalnego
- `saveSavestate()`, `loadSavestate()`, `advanceFrames()` — nowe metody toolsetu dla Resumera

**Zmiany w `knes-agent`:**
- `Main.kt`: używa fabryk, brak `import knes.api.EmulatorSession`
- `Resumer`: bierze `EmulatorToolset` zamiast `EmulatorSession`
- `build.gradle`: `knes-emulator/controllers/debug/emulator-session` przeniesione do `testImplementation` (potrzebne przez testy diagnostyczne używające `session.readMemory()`)

## Test plan
- [ ] `./gradlew :knes-agent:test` zielony
- [ ] `./gradlew :knes-agent:compileKotlin` — brak importów `knes.api.*` w src/main